### PR TITLE
Don't exit Work/Series/Publisher etc after Saving an update (#127)

### DIFF
--- a/thoth-app/src/component/contributor.rs
+++ b/thoth-app/src/component/contributor.rs
@@ -135,9 +135,6 @@ impl Component for ContributorComponent {
                                 format!("Saved {}", c.full_name),
                                 NotificationStatus::Success,
                             )));
-                            self.link.send_message(Msg::ChangeRoute(AppRoute::Admin(
-                                AdminRoute::Contributors,
-                            )));
                             true
                         }
                         None => {

--- a/thoth-app/src/component/funder.rs
+++ b/thoth-app/src/component/funder.rs
@@ -132,9 +132,6 @@ impl Component for FunderComponent {
                                 format!("Saved {}", f.funder_name),
                                 NotificationStatus::Success,
                             )));
-                            self.link.send_message(Msg::ChangeRoute(AppRoute::Admin(
-                                AdminRoute::Funders,
-                            )));
                             true
                         }
                         None => {

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -168,9 +168,6 @@ impl Component for ImprintComponent {
                                 format!("Saved {}", i.imprint_name),
                                 NotificationStatus::Success,
                             )));
-                            self.link.send_message(Msg::ChangeRoute(AppRoute::Admin(
-                                AdminRoute::Imprints,
-                            )));
                             true
                         }
                         None => {

--- a/thoth-app/src/component/publisher.rs
+++ b/thoth-app/src/component/publisher.rs
@@ -133,9 +133,6 @@ impl Component for PublisherComponent {
                                 format!("Saved {}", p.publisher_name),
                                 NotificationStatus::Success,
                             )));
-                            self.link.send_message(Msg::ChangeRoute(AppRoute::Admin(
-                                AdminRoute::Publishers,
-                            )));
                             true
                         }
                         None => {

--- a/thoth-app/src/component/series.rs
+++ b/thoth-app/src/component/series.rs
@@ -202,9 +202,6 @@ impl Component for SeriesComponent {
                                 format!("Saved {}", s.series_name),
                                 NotificationStatus::Success,
                             )));
-                            self.link.send_message(Msg::ChangeRoute(AppRoute::Admin(
-                                AdminRoute::Serieses,
-                            )));
                             true
                         }
                         None => {

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -211,8 +211,6 @@ impl Component for WorkComponent {
                                 format!("Saved {}", w.title),
                                 NotificationStatus::Success,
                             )));
-                            self.link
-                                .send_message(Msg::ChangeRoute(AppRoute::Admin(AdminRoute::Works)));
                             true
                         }
                         None => {


### PR DESCRIPTION
Fixes #127.

Saving a change to a Work, Series, Publisher, Imprint, Funder or Contributor no longer returns the user to the full list of such items, but keeps them in the changed item. The initial issue suggested also adding a separate "Save and Exit" button, which has not been implemented here. Another option would be to make the left sidebar "sticky" so that users could easily exit to the full list after saving.