### PR TITLE
Provide ONIX XML as downloadable attachment rather than webpage (#151)

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -66,6 +66,7 @@ async fn onix(req: HttpRequest, path: web::Path<(Uuid,)>) -> HttpResponse {
     if let Ok(work) = get_work(work_id, thoth_url).await {
         if let Ok(body) = generate_onix_3(work) {
             HttpResponse::Ok()
+                .header("Content-Disposition", "attachment")
                 .content_type("text/xml; charset=utf-8")
                 .body(String::from_utf8(body).unwrap())
         } else {


### PR DESCRIPTION
Fixes #151.

Browser now prompts user to save ONIX XML to file. Previously, it opened it as a webpage, leading to information such as special characters potentially being lost in pretty-printing (#145).

File name defaults to the work's UUID as no alternative information is available. Note user may still choose to open the file as a webpage.

![image](https://user-images.githubusercontent.com/73792779/103558506-aedd1d00-4eac-11eb-9a8f-45eeb79a448b.png)