### PR TITLE
Add new created_at and updated_at dates to API structures

### DIFF
--- a/thoth-api/Cargo.toml
+++ b/thoth-api/Cargo.toml
@@ -19,7 +19,7 @@ backend = ["diesel", "diesel-derive-enum", "diesel_migrations", "actix-web", "fu
 actix-web = { version = "3.0.0", optional = true }
 argon2rs = "0.2.5"
 chrono = { version = "0.4", features = ["serde"] }
-diesel = { version = "1.4.0", features = ["postgres", "uuidv07", "chrono", "r2d2"], optional = true }
+diesel = { version = "1.4.0", features = ["postgres", "uuidv07", "chrono", "r2d2", "64-column-tables"], optional = true }
 diesel-derive-enum = { version = "1.1.0", features = ["postgres"], optional = true }
 diesel_migrations = { version = "1.4.0", features = ["postgres"], optional = true }
 dotenv = "0.9.0"

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -17,7 +17,8 @@ pub struct Account {
     pub is_admin: bool,
     pub is_bot: bool,
     pub is_active: bool,
-    pub registered: NaiveDateTime,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
     pub token: Option<String>,
 }
 

--- a/thoth-api/src/contribution/model.rs
+++ b/thoth-api/src/contribution/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -37,6 +38,8 @@ pub struct Contribution {
     pub main_contribution: bool,
     pub biography: Option<String>,
     pub institution: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/contributor/model.rs
+++ b/thoth-api/src/contributor/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use uuid::Uuid;
 
 #[cfg(feature = "backend")]
@@ -11,6 +12,8 @@ pub struct Contributor {
     pub full_name: String,
     pub orcid: Option<String>,
     pub website: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/funder/model.rs
+++ b/thoth-api/src/funder/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use uuid::Uuid;
 
 #[cfg(feature = "backend")]
@@ -8,6 +9,8 @@ pub struct Funder {
     pub funder_id: Uuid,
     pub funder_name: String,
     pub funder_doi: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/funding/model.rs
+++ b/thoth-api/src/funding/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use uuid::Uuid;
 
 #[cfg(feature = "backend")]
@@ -13,6 +14,8 @@ pub struct Funding {
     pub project_shortname: Option<String>,
     pub grant_number: Option<String>,
     pub jurisdiction: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1,4 +1,5 @@
 use chrono::naive::NaiveDate;
+use chrono::naive::NaiveDateTime;
 use diesel::prelude::*;
 use juniper::FieldError;
 use juniper::FieldResult;
@@ -1413,6 +1414,14 @@ impl Work {
         self.cover_caption.as_ref()
     }
 
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
     pub fn imprint(&self, context: &Context) -> Imprint {
         use crate::schema::imprint::dsl::*;
         let connection = context.db.get().unwrap();
@@ -1566,6 +1575,14 @@ impl Publication {
         self.publication_url.as_ref()
     }
 
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
     pub fn prices(&self, context: &Context) -> Vec<Price> {
         use crate::schema::price::dsl::*;
         let connection = context.db.get().unwrap();
@@ -1602,6 +1619,14 @@ impl Publisher {
         self.publisher_url.as_ref()
     }
 
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
     pub fn imprints(&self, context: &Context) -> Vec<Imprint> {
         use crate::schema::imprint::dsl::*;
         let connection = context.db.get().unwrap();
@@ -1624,6 +1649,14 @@ impl Imprint {
 
     pub fn imprint_url(&self) -> Option<&String> {
         self.imprint_url.as_ref()
+    }
+
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
     }
 
     pub fn publisher(&self, context: &Context) -> Publisher {
@@ -1670,6 +1703,14 @@ impl Contributor {
         self.website.as_ref()
     }
 
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
     pub fn contributions(&self, context: &Context) -> Vec<Contribution> {
         use crate::schema::contribution::dsl::*;
         let connection = context.db.get().unwrap();
@@ -1704,6 +1745,14 @@ impl Contribution {
 
     pub fn institution(&self) -> Option<&String> {
         self.institution.as_ref()
+    }
+
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
     }
 
     pub fn work(&self, context: &Context) -> Work {
@@ -1750,6 +1799,14 @@ impl Series {
         self.series_url.as_ref()
     }
 
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
     pub fn imprint(&self, context: &Context) -> Imprint {
         use crate::schema::imprint::dsl::*;
         let connection = context.db.get().unwrap();
@@ -1781,6 +1838,14 @@ impl Issue {
 
     pub fn issue_ordinal(&self) -> &i32 {
         &self.issue_ordinal
+    }
+
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
     }
 
     pub fn series(&self, context: &Context) -> Series {
@@ -1823,6 +1888,14 @@ impl Language {
         self.main_language
     }
 
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
     pub fn work(&self, context: &Context) -> Work {
         use crate::schema::work::dsl::*;
         let connection = context.db.get().unwrap();
@@ -1848,6 +1921,14 @@ impl Price {
 
     pub fn unit_price(&self) -> f64 {
         self.unit_price
+    }
+
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
     }
 
     pub fn publication(&self, context: &Context) -> Publication {
@@ -1882,6 +1963,14 @@ impl Subject {
         &self.subject_ordinal
     }
 
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
+    }
+
     pub fn work(&self, context: &Context) -> Work {
         use crate::schema::work::dsl::*;
         let connection = context.db.get().unwrap();
@@ -1903,6 +1992,14 @@ impl Funder {
 
     pub fn funder_doi(&self) -> Option<&String> {
         self.funder_doi.as_ref()
+    }
+
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
     }
 
     pub fn fundings(&self, context: &Context) -> Vec<Funding> {
@@ -1947,6 +2044,14 @@ impl Funding {
 
     pub fn jurisdiction(&self) -> Option<&String> {
         self.jurisdiction.as_ref()
+    }
+
+    pub fn created_at(&self) -> NaiveDateTime {
+        self.created_at
+    }
+
+    pub fn updated_at(&self) -> NaiveDateTime {
+        self.updated_at
     }
 
     pub fn work(&self, context: &Context) -> Work {

--- a/thoth-api/src/imprint/model.rs
+++ b/thoth-api/src/imprint/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use uuid::Uuid;
 
 #[cfg(feature = "backend")]
@@ -9,6 +10,8 @@ pub struct Imprint {
     pub publisher_id: Uuid,
     pub imprint_name: String,
     pub imprint_url: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/issue/model.rs
+++ b/thoth-api/src/issue/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use uuid::Uuid;
 
 #[cfg(feature = "backend")]
@@ -8,6 +9,8 @@ pub struct Issue {
     pub series_id: Uuid,
     pub work_id: Uuid,
     pub issue_ordinal: i32,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/language/model.rs
+++ b/thoth-api/src/language/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -26,6 +27,8 @@ pub struct Language {
     pub language_code: LanguageCode,
     pub language_relation: LanguageRelation,
     pub main_language: bool,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/price/model.rs
+++ b/thoth-api/src/price/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -13,6 +14,8 @@ pub struct Price {
     pub publication_id: Uuid,
     pub currency_code: CurrencyCode,
     pub unit_price: f64,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/publication/model.rs
+++ b/thoth-api/src/publication/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -38,6 +39,8 @@ pub struct Publication {
     pub work_id: Uuid,
     pub isbn: Option<String>,
     pub publication_url: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/publisher/model.rs
+++ b/thoth-api/src/publisher/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use uuid::Uuid;
 
 #[cfg(feature = "backend")]
@@ -9,6 +10,8 @@ pub struct Publisher {
     pub publisher_name: String,
     pub publisher_shortname: Option<String>,
     pub publisher_url: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/schema.rs
+++ b/thoth-api/src/schema.rs
@@ -11,7 +11,8 @@ table! {
         is_admin -> Bool,
         is_bot -> Bool,
         is_active -> Bool,
-        registered -> Timestamp,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
         token -> Nullable<Text>,
     }
 }
@@ -27,6 +28,8 @@ table! {
         main_contribution -> Bool,
         biography -> Nullable<Text>,
         institution -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -40,6 +43,8 @@ table! {
         full_name -> Text,
         orcid -> Nullable<Text>,
         website -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -50,6 +55,8 @@ table! {
         funder_id -> Uuid,
         funder_name -> Text,
         funder_doi -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -65,6 +72,8 @@ table! {
         project_shortname -> Nullable<Text>,
         grant_number -> Nullable<Text>,
         jurisdiction -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -76,6 +85,8 @@ table! {
         publisher_id -> Uuid,
         imprint_name -> Text,
         imprint_url -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -86,6 +97,8 @@ table! {
         series_id -> Uuid,
         work_id -> Uuid,
         issue_ordinal -> Int4,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -100,6 +113,8 @@ table! {
         language_code -> Language_code,
         language_relation -> Language_relation,
         main_language -> Bool,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -112,6 +127,8 @@ table! {
         publication_id -> Uuid,
         currency_code -> Currency_code,
         unit_price -> Float8,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -125,6 +142,8 @@ table! {
         work_id -> Uuid,
         isbn -> Nullable<Text>,
         publication_url -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -136,6 +155,8 @@ table! {
         publisher_name -> Text,
         publisher_shortname -> Nullable<Text>,
         publisher_url -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -151,6 +172,8 @@ table! {
         issn_digital -> Text,
         series_url -> Nullable<Text>,
         imprint_id -> Uuid,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -164,6 +187,8 @@ table! {
         subject_type -> Subject_type,
         subject_code -> Text,
         subject_ordinal -> Int4,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 
@@ -204,6 +229,8 @@ table! {
         toc -> Nullable<Text>,
         cover_url -> Nullable<Text>,
         cover_caption -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 

--- a/thoth-api/src/series/model.rs
+++ b/thoth-api/src/series/model.rs
@@ -1,3 +1,4 @@
+use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -26,6 +27,8 @@ pub struct Series {
     pub issn_digital: String,
     pub series_url: Option<String>,
     pub imprint_id: Uuid,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/subject/model.rs
+++ b/thoth-api/src/subject/model.rs
@@ -1,5 +1,6 @@
 use phf::phf_map;
 use phf::Map;
+use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -30,6 +31,8 @@ pub struct Subject {
     pub subject_type: SubjectType,
     pub subject_code: String,
     pub subject_ordinal: i32,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(

--- a/thoth-api/src/subject/model.rs
+++ b/thoth-api/src/subject/model.rs
@@ -1,6 +1,6 @@
+use chrono::naive::NaiveDateTime;
 use phf::phf_map;
 use phf::Map;
-use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;

--- a/thoth-api/src/work/model.rs
+++ b/thoth-api/src/work/model.rs
@@ -1,4 +1,5 @@
 use chrono::naive::NaiveDate;
+use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -83,6 +84,8 @@ pub struct Work {
     pub toc: Option<String>,
     pub cover_url: Option<String>,
     pub cover_caption: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
 }
 
 #[cfg_attr(


### PR DESCRIPTION
Continuation of #121, following changes under #153.

#153 added `created_at` and `updated_at` attributes to all tables in database. This change adds these attributes to the API schema file, structures and GraphQL schema. Updating any object via the web interface now correctly sets the `updated_at` database value to the date/time of the update.

Note this value is only set when fields on a record are updated directly, not when a record's relations are changed. For example, changing the Title of a Work sets the Work's `updated_at` value, but adding a Contributor does not.