### PR TITLE
Fix boilerplate to ensure app is only started once

### DIFF
--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -28,18 +28,11 @@ impl Component for DashboardComponent {
     type Properties = ();
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+        link.send_message(Msg::GetStats);
+
         DashboardComponent {
             get_stats: Default::default(),
             link,
-        }
-    }
-
-    fn rendered(&mut self, first_render: bool) {
-        if first_render {
-            self.link
-                .send_future(self.get_stats.fetch(Msg::SetStatsFetchState));
-            self.link
-                .send_message(Msg::SetStatsFetchState(FetchAction::Fetching));
         }
     }
 

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -164,15 +164,6 @@ impl Component for WorkComponent {
         }
     }
 
-    fn rendered(&mut self, first_render: bool) {
-        if first_render {
-            self.link
-                .send_future(self.fetch_work.fetch(Msg::SetWorkFetchState));
-            self.link
-                .send_message(Msg::SetWorkFetchState(FetchAction::Fetching));
-        }
-    }
-
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::SetWorkFetchState(fetch_state) => {

--- a/thoth-app/src/lib.rs
+++ b/thoth-app/src/lib.rs
@@ -16,7 +16,7 @@ use crate::component::root::RootComponent;
 pub const THOTH_API: &str = env!("THOTH_API");
 const SESSION_COOKIE: &str = "sessionToken";
 
-#[wasm_bindgen(start)]
+#[wasm_bindgen]
 pub fn run_app() -> Result<(), JsValue> {
     wasm_logger::init(wasm_logger::Config::default());
 


### PR DESCRIPTION
Fixes an issue where two "copies" of the app were being created on startup. This was causing duplicate GraphQL requests to be sent on every load of page data (visible in devtools Network tab), and triggering the error message `attempted to set a logger after the logging system was already initialized` (displayed in devtools Console).

Also fixes an issue in Work component where additional duplicate GraphQL requests were being sent by the `rendered` function.

Also amends Dashboard component to make its request workflow consistent with other components (this is mainly a stylistic change as the previous workflow was not causing any duplicate requests).