### PR TITLE
Feature/159 account permissions

### DIFF
--- a/src/bin/thoth.rs
+++ b/src/bin/thoth.rs
@@ -154,7 +154,13 @@ fn main() -> Result<()> {
                 dotenv().ok();
                 let pool = establish_connection();
                 match register(
-                    &name, &surname, &email, &password, &is_superuser, &is_bot, &pool,
+                    &name,
+                    &surname,
+                    &email,
+                    &password,
+                    &is_superuser,
+                    &is_bot,
+                    &pool,
                 ) {
                     Ok(_) => Ok(()),
                     Err(e) => Err(e.into()),

--- a/src/bin/thoth.rs
+++ b/src/bin/thoth.rs
@@ -100,10 +100,10 @@ fn main() -> Result<()> {
                                 .required(true),
                         )
                         .arg(
-                            Arg::with_name("is-admin")
-                                .long("is-admin")
+                            Arg::with_name("is-superuser")
+                                .long("is-superuser")
                                 .multiple(false)
-                                .help("Is the user an admin"),
+                                .help("Is the user a super user"),
                         )
                         .arg(
                             Arg::with_name("is-bot")
@@ -148,13 +148,13 @@ fn main() -> Result<()> {
                 let surname = register_matches.value_of("surname").unwrap();
                 let email = register_matches.value_of("email").unwrap();
                 let password = register_matches.value_of("password").unwrap();
-                let is_admin = register_matches.is_present("is-admin");
+                let is_superuser = register_matches.is_present("is-superuser");
                 let is_bot = register_matches.is_present("is-bot");
 
                 dotenv().ok();
                 let pool = establish_connection();
                 match register(
-                    &name, &surname, &email, &password, &is_admin, &is_bot, &pool,
+                    &name, &surname, &email, &password, &is_superuser, &is_bot, &pool,
                 ) {
                     Ok(_) => Ok(()),
                     Err(e) => Err(e.into()),

--- a/thoth-api/migrations/0.2.14/down.sql
+++ b/thoth-api/migrations/0.2.14/down.sql
@@ -1,3 +1,4 @@
+DROP TRIGGER set_updated_at ON publisher_account;
 DROP TABLE publisher_account;
 
 ALTER TABLE account RENAME COLUMN is_superuser TO is_admin;

--- a/thoth-api/migrations/0.2.14/down.sql
+++ b/thoth-api/migrations/0.2.14/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE publisher_account;
+
+ALTER TABLE account RENAME COLUMN is_superuser TO is_admin;

--- a/thoth-api/migrations/0.2.14/up.sql
+++ b/thoth-api/migrations/0.2.14/up.sql
@@ -2,7 +2,10 @@ CREATE TABLE publisher_account (
     account_id          UUID NOT NULL REFERENCES account(account_id) ON DELETE CASCADE,
     publisher_id        UUID NOT NULL REFERENCES publisher(publisher_id) ON DELETE CASCADE,
     is_admin            BOOLEAN NOT NULL DEFAULT False,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (account_id, publisher_id)
 );
+SELECT diesel_manage_updated_at('publisher_account');
 
 ALTER TABLE account RENAME COLUMN is_admin TO is_superuser;

--- a/thoth-api/migrations/0.2.14/up.sql
+++ b/thoth-api/migrations/0.2.14/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE publisher_account (
+    account_id          UUID NOT NULL REFERENCES account(account_id) ON DELETE CASCADE,
+    publisher_id        UUID NOT NULL REFERENCES publisher(publisher_id) ON DELETE CASCADE,
+    is_admin            BOOLEAN NOT NULL DEFAULT False,
+    PRIMARY KEY (account_id, publisher_id)
+);
+
+ALTER TABLE account RENAME COLUMN is_admin TO is_superuser;

--- a/thoth-api/src/account/handler.rs
+++ b/thoth-api/src/account/handler.rs
@@ -56,7 +56,7 @@ impl From<AccountData> for NewAccount {
             surname,
             email,
             password,
-            is_admin,
+            is_superuser,
             is_bot,
             ..
         } = account_data;
@@ -69,7 +69,7 @@ impl From<AccountData> for NewAccount {
             email,
             hash,
             salt,
-            is_admin,
+            is_superuser,
             is_bot,
         }
     }

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -4,6 +4,8 @@ use uuid::Uuid;
 
 #[cfg(feature = "backend")]
 use crate::schema::account;
+#[cfg(feature = "backend")]
+use crate::schema::publisher_account;
 
 #[cfg_attr(feature = "backend", derive(Queryable))]
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -14,7 +16,7 @@ pub struct Account {
     pub email: String,
     pub hash: Vec<u8>,
     pub salt: String,
-    pub is_admin: bool,
+    pub is_superuser: bool,
     pub is_bot: bool,
     pub is_active: bool,
     pub created_at: NaiveDateTime,
@@ -30,7 +32,7 @@ pub struct NewAccount {
     pub email: String,
     pub hash: Vec<u8>,
     pub salt: String,
-    pub is_admin: bool,
+    pub is_superuser: bool,
     pub is_bot: bool,
 }
 
@@ -40,8 +42,25 @@ pub struct AccountData {
     pub surname: String,
     pub email: String,
     pub password: String,
-    pub is_admin: bool,
+    pub is_superuser: bool,
     pub is_bot: bool,
+}
+
+#[cfg_attr(feature = "backend", derive(Queryable))]
+pub struct PublisherAccount {
+    pub account_id: Uuid,
+    pub publisher_id: Uuid,
+    pub is_admin: bool,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[cfg_attr(feature = "backend", derive(Insertable))]
+#[cfg_attr(feature = "backend", table_name = "publisher_account")]
+pub struct NewPublisherAccount {
+    pub account_id: Uuid,
+    pub publisher_id: Uuid,
+    pub is_admin: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/thoth-api/src/account/service.rs
+++ b/thoth-api/src/account/service.rs
@@ -40,7 +40,7 @@ pub fn register(
     surname: &str,
     email: &str,
     password: &str,
-    is_admin: &bool,
+    is_superuser: &bool,
     is_bot: &bool,
     pool: &PgPool,
 ) -> Result<Account, ThothError> {
@@ -50,7 +50,7 @@ pub fn register(
         surname: surname.to_owned(),
         email: email.to_owned(),
         password: password.to_owned(),
-        is_admin: is_admin.to_owned(),
+        is_superuser: is_superuser.to_owned(),
         is_bot: is_bot.to_owned(),
     };
 

--- a/thoth-api/src/schema.rs
+++ b/thoth-api/src/schema.rs
@@ -8,7 +8,7 @@ table! {
         email -> Text,
         hash -> Bytea,
         salt -> Text,
-        is_admin -> Bool,
+        is_superuser -> Bool,
         is_bot -> Bool,
         is_active -> Bool,
         created_at -> Timestamp,
@@ -162,6 +162,18 @@ table! {
 
 table! {
     use diesel::sql_types::*;
+
+    publisher_account (account_id, publisher_id) {
+        account_id -> Uuid,
+        publisher_id -> Uuid,
+        is_admin -> Bool,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
     use crate::series::model::Series_type;
 
     series (series_id) {
@@ -244,11 +256,14 @@ joinable!(issue -> work (work_id));
 joinable!(language -> work (work_id));
 joinable!(price -> publication (publication_id));
 joinable!(publication -> work (work_id));
+joinable!(publisher_account -> account (account_id));
+joinable!(publisher_account -> publisher (publisher_id));
 joinable!(series -> imprint (imprint_id));
 joinable!(subject -> work (work_id));
 joinable!(work -> imprint (imprint_id));
 
 allow_tables_to_appear_in_same_query!(
+    account,
     contribution,
     contributor,
     funder,
@@ -258,6 +273,7 @@ allow_tables_to_appear_in_same_query!(
     language,
     price,
     publication,
+    publisher_account,
     publisher,
     series,
     subject,


### PR DESCRIPTION
Added `publisher_account` table to give permissions to accounts over specific publisher derived objects. Account's attribute `is_admin` has been moved over to `publisher_account`, and renamed in the account table to `is_superuser` to distinguish between an admin account in a publisher environment to a global Thoth admin (superuser)