### PR TITLE
Feature/160 implement permissions

### DIFF
--- a/thoth-api/src/account/handler.rs
+++ b/thoth-api/src/account/handler.rs
@@ -20,7 +20,7 @@ use crate::db::PgPool;
 use crate::errors::ThothError;
 
 impl Account {
-    pub fn get_permissions(&self, pool: &PgPool) -> Result<Option<Vec<AccountAccess>>, ThothError> {
+    pub fn get_permissions(&self, pool: &PgPool) -> Result<Vec<AccountAccess>, ThothError> {
         use crate::schema::publisher_account::dsl::*;
         let conn = pool.get().unwrap();
 
@@ -29,14 +29,14 @@ impl Account {
             .load::<PublisherAccount>(&conn)
             .expect("Error loading publisher accounts");
         let permissions: Vec<AccountAccess> = linked_publishers.into_iter().map(|p| p.into()).collect();
-        Ok(Some(permissions))
+        Ok(permissions)
     }
 
     pub fn issue_token(&self, pool: &PgPool) -> Result<String, ThothError> {
         const DEFAULT_TOKEN_VALIDITY: i64 = 24 * 60 * 60;
         let connection = pool.get().unwrap();
         dotenv().ok();
-        let namespace = self.get_permissions(&pool).unwrap_or(None);
+        let namespace = self.get_permissions(&pool).unwrap_or_default();
         let secret_str = env::var("SECRET_KEY").expect("SECRET_KEY must be set");
         let secret: &[u8] = secret_str.as_bytes();
         let now = SystemTime::now()

--- a/thoth-api/src/account/handler.rs
+++ b/thoth-api/src/account/handler.rs
@@ -53,7 +53,7 @@ impl Account {
             exp: now.as_secs() as i64 + DEFAULT_TOKEN_VALIDITY,
             iat: now.as_secs() as i64,
             jti: Uuid::new_v4().to_string(),
-            namespace: namespace,
+            namespace,
         };
         let token = encode(
             &Header::default(),

--- a/thoth-api/src/account/handler.rs
+++ b/thoth-api/src/account/handler.rs
@@ -29,7 +29,8 @@ impl Account {
             .filter(account_id.eq(self.account_id))
             .load::<PublisherAccount>(&conn)
             .expect("Error loading publisher accounts");
-        let permissions: Vec<LinkedPublisher> = linked_publishers.into_iter().map(|p| p.into()).collect();
+        let permissions: Vec<LinkedPublisher> =
+            linked_publishers.into_iter().map(|p| p.into()).collect();
         Ok(permissions)
     }
 
@@ -37,7 +38,8 @@ impl Account {
         const DEFAULT_TOKEN_VALIDITY: i64 = 24 * 60 * 60;
         let connection = pool.get().unwrap();
         dotenv().ok();
-        let linked_publishers: Vec<LinkedPublisher> = self.get_permissions(&pool).unwrap_or_default();
+        let linked_publishers: Vec<LinkedPublisher> =
+            self.get_permissions(&pool).unwrap_or_default();
         let namespace = AccountAccess {
             is_superuser: self.is_superuser,
             is_bot: self.is_bot,

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -64,7 +64,16 @@ pub struct NewPublisherAccount {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AccountAccess {
+    pub is_superuser: bool,
+    pub is_bot: bool,
+    pub linked_publishers: Vec<LinkedPublisher>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkedPublisher {
     pub publisher_id: Uuid,
     pub is_admin: bool,
 }
@@ -76,7 +85,7 @@ pub struct Token {
     pub iat: i64,
     pub jti: String,
     #[serde(rename = "https://thoth.pub/resource_access")]
-    pub namespace: Vec<AccountAccess>,
+    pub namespace: AccountAccess,
 }
 
 #[derive(Clone)]

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -76,7 +76,7 @@ pub struct Token {
     pub iat: i64,
     pub jti: String,
     #[serde(rename = "https://thoth.pub/resource_access")]
-    pub namespace: Option<Vec<AccountAccess>>,
+    pub namespace: Vec<AccountAccess>,
 }
 
 #[derive(Clone)]

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -64,11 +64,19 @@ pub struct NewPublisherAccount {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AccountAccess {
+    pub publisher_id: Uuid,
+    pub is_admin: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Token {
     pub sub: String,
     pub exp: i64,
     pub iat: i64,
     pub jti: String,
+    #[serde(rename = "https://thoth.pub/resource_access")]
+    pub namespace: Option<Vec<AccountAccess>>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Included publisher account permissions in JWT. Closes #160 . A token now looks like:

```
{
  "sub": "javi@openbookpublishers.com",
  "exp": 1612626786,
  "iat": 1612540386,
  "jti": "dd8cf5db-2e03-475f-b64b-c58a70e05e4b",
  "https://thoth.pub/resource_access": {
    "isSuperuser": false,
    "isBot": false,
    "linkedPublishers": [
      {
        "publisherId": "9a24a5e4-f5f6-406f-b58b-39ee884c6476",
        "isAdmin": true
      }
    ]
  }
}
```