### PR TITLE
Add names to contribution table in database and API structures

### DIFF
--- a/thoth-api/migrations/0.2.14/down.sql
+++ b/thoth-api/migrations/0.2.14/down.sql
@@ -2,3 +2,8 @@ DROP TRIGGER set_updated_at ON publisher_account;
 DROP TABLE publisher_account;
 
 ALTER TABLE account RENAME COLUMN is_superuser TO is_admin;
+
+ALTER TABLE contribution
+    DROP COLUMN first_name,
+    DROP COLUMN last_name,
+    DROP COLUMN full_name;

--- a/thoth-api/migrations/0.2.14/up.sql
+++ b/thoth-api/migrations/0.2.14/up.sql
@@ -25,9 +25,6 @@ UPDATE contribution
 ALTER TABLE contribution
     ALTER COLUMN last_name SET NOT NULL,
     ALTER COLUMN full_name SET NOT NULL,
-    ADD CONSTRAINT name_length_check
-    CHECK (
-        (octet_length(first_name) >= 1)
-        AND (octet_length(last_name) >= 1)
-        AND (octet_length(full_name) >= 1)
-    );
+    ADD CONSTRAINT contribution_first_name_check CHECK (octet_length(first_name) >= 1),
+    ADD CONSTRAINT contribution_last_name_check CHECK (octet_length(last_name) >= 1),
+    ADD CONSTRAINT contribution_full_name_check CHECK (octet_length(full_name) >= 1);

--- a/thoth-api/migrations/0.2.14/up.sql
+++ b/thoth-api/migrations/0.2.14/up.sql
@@ -9,3 +9,25 @@ CREATE TABLE publisher_account (
 SELECT diesel_manage_updated_at('publisher_account');
 
 ALTER TABLE account RENAME COLUMN is_admin TO is_superuser;
+
+ALTER TABLE contribution
+    ADD COLUMN first_name TEXT,
+    ADD COLUMN last_name TEXT,
+    ADD COLUMN full_name TEXT;
+
+UPDATE contribution
+    SET first_name = contributor.first_name,
+        last_name = contributor.last_name,
+        full_name = contributor.full_name
+    FROM contributor
+    WHERE contribution.contributor_id = contributor.contributor_id;
+
+ALTER TABLE contribution
+    ALTER COLUMN last_name SET NOT NULL,
+    ALTER COLUMN full_name SET NOT NULL,
+    ADD CONSTRAINT name_length_check
+    CHECK (
+        (octet_length(first_name) >= 1)
+        AND (octet_length(last_name) >= 1)
+        AND (octet_length(full_name) >= 1)
+    );

--- a/thoth-api/src/contribution/model.rs
+++ b/thoth-api/src/contribution/model.rs
@@ -44,6 +44,9 @@ pub enum ContributionField {
     Institution,
     CreatedAt,
     UpdatedAt,
+    FirstName,
+    LastName,
+    FullName,
 }
 
 #[cfg_attr(feature = "backend", derive(Queryable))]
@@ -56,6 +59,9 @@ pub struct Contribution {
     pub institution: Option<String>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+    pub first_name: Option<String>,
+    pub last_name: String,
+    pub full_name: String,
 }
 
 #[cfg_attr(
@@ -70,6 +76,9 @@ pub struct NewContribution {
     pub main_contribution: bool,
     pub biography: Option<String>,
     pub institution: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: String,
+    pub full_name: String,
 }
 
 #[cfg_attr(
@@ -85,6 +94,9 @@ pub struct PatchContribution {
     pub main_contribution: bool,
     pub biography: Option<String>,
     pub institution: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: String,
+    pub full_name: String,
 }
 
 impl Default for ContributionType {

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -829,6 +829,18 @@ impl QueryRoot {
                 Direction::ASC => query = query.order(updated_at.asc()),
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
+            ContributionField::FirstName => match order.direction {
+                Direction::ASC => query = query.order(first_name.asc()),
+                Direction::DESC => query = query.order(first_name.desc()),
+            },
+            ContributionField::LastName => match order.direction {
+                Direction::ASC => query = query.order(last_name.asc()),
+                Direction::DESC => query = query.order(last_name.desc()),
+            },
+            ContributionField::FullName => match order.direction {
+                Direction::ASC => query = query.order(full_name.asc()),
+                Direction::DESC => query = query.order(full_name.desc()),
+            },
         }
         query
             .limit(limit.into())
@@ -2493,6 +2505,18 @@ impl Contribution {
 
     pub fn updated_at(&self) -> NaiveDateTime {
         self.updated_at
+    }
+
+    pub fn first_name(&self) -> Option<&String> {
+        self.first_name.as_ref()
+    }
+
+    pub fn last_name(&self) -> &String {
+        &self.last_name
+    }
+
+    pub fn full_name(&self) -> &String {
+        &self.full_name
     }
 
     pub fn work(&self, context: &Context) -> Work {

--- a/thoth-api/src/schema.rs
+++ b/thoth-api/src/schema.rs
@@ -30,6 +30,9 @@ table! {
         institution -> Nullable<Text>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+        first_name -> Nullable<Text>,
+        last_name -> Text,
+        full_name -> Text,
     }
 }
 


### PR DESCRIPTION
Fixes #164 and #166. Adds `first_name`, `last_name` and `full_name` fields to contribution table, to represent the contributor's name at time of publication of the specific contribution (which may be different from contributor's current name, as represented in contributor table).

If migrating from a version of the database which already contains contribution records with no name information, the new fields will automatically be filled out with the contributor's current name as stored in the contributor table. They can then be edited separately, without affecting the contributor table data.