### PR TITLE
Add filtering by publisher ID(s) to API GraphQL schema (#177)

### DIFF
--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -137,6 +137,18 @@ pub struct FundingOrderBy {
     pub direction: Direction,
 }
 
+fn get_publishers(context: &Context) -> Vec<Uuid> {
+    let mut publishers = Vec::new();
+    if let Some(jwt) = &context.token.jwt {
+        if !jwt.namespace.is_superuser {
+            for publisher in &jwt.namespace.linked_publishers {
+                publishers.push(publisher.publisher_id);
+            }
+        }
+    }
+    publishers
+}
+
 pub struct QueryRoot;
 
 #[juniper::object(Context = Context)]
@@ -352,7 +364,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -492,7 +504,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -613,7 +625,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(publisher_id.eq(pub_id));
         }
         query
@@ -724,7 +736,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(publisher_id.eq(pub_id));
         }
         query
@@ -965,7 +977,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(full_name.desc()),
             },
         }
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1093,7 +1105,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1203,7 +1215,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1311,7 +1323,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1416,7 +1428,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1523,7 +1535,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1732,7 +1744,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in publishers {
+        for pub_id in get_publishers(&context) {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -2680,10 +2680,6 @@ impl Work {
                 default = "".to_string(),
                 description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on subject_code",
             ),
-            publishers(
-                default = vec![],
-                description = "If set, only shows results connected to publishers with these IDs",
-            ),
         )
     )]
     pub fn subjects(

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -751,12 +751,25 @@ impl QueryRoot {
         }
     }
 
-    #[graphql(description = "Get the total number of imprints")]
-    fn imprint_count(context: &Context) -> i32 {
+    #[graphql(
+        description = "Get the total number of imprints",
+        arguments(
+            filter(
+                default = "".to_string(),
+                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on imprint_name and imprint_url",
+            ),
+        )
+    )]
+    fn imprint_count(context: &Context, filter: String) -> i32 {
         use crate::schema::imprint::dsl::*;
         let connection = context.db.get().unwrap();
         // see comment in work_count()
         imprint
+            .filter(
+                imprint_name
+                    .ilike(format!("%{}%", filter))
+                    .or(imprint_url.ilike(format!("%{}%", filter))),
+            )
             .count()
             .get_result::<i64>(&connection)
             .expect("Error loading imprint count")
@@ -1632,12 +1645,22 @@ impl QueryRoot {
         }
     }
 
-    #[graphql(description = "Get the total number of funders")]
-    fn funder_count(context: &Context) -> i32 {
+    #[graphql(
+        description = "Get the total number of funders",
+        arguments(
+            filter(
+                default = "".to_string(),
+                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on funderName and funderDoi",
+            ),
+        )
+    )]
+    fn funder_count(context: &Context, filter: String) -> i32 {
         use crate::schema::funder::dsl::*;
         let connection = context.db.get().unwrap();
         // see comment in work_count()
         funder
+            .filter(funder_name.ilike(format!("%{}%", filter)))
+            .or_filter(funder_doi.ilike(format!("%{}%", filter)))
             .count()
             .get_result::<i64>(&connection)
             .expect("Error loading funder count")

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -137,18 +137,6 @@ pub struct FundingOrderBy {
     pub direction: Direction,
 }
 
-fn get_publishers(context: &Context) -> Vec<Uuid> {
-    let mut publishers = Vec::new();
-    if let Some(jwt) = &context.token.jwt {
-        if !jwt.namespace.is_superuser {
-            for publisher in &jwt.namespace.linked_publishers {
-                publishers.push(publisher.publisher_id);
-            }
-        }
-    }
-    publishers
-}
-
 pub struct QueryRoot;
 
 #[juniper::object(Context = Context)]
@@ -364,7 +352,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -504,7 +492,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -625,7 +613,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(publisher_id.eq(pub_id));
         }
         query
@@ -736,7 +724,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(publisher_id.eq(pub_id));
         }
         query
@@ -977,7 +965,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(full_name.desc()),
             },
         }
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1105,7 +1093,7 @@ impl QueryRoot {
         // Ordering and construction of filters is important here: result needs to be
         // `WHERE (x = $1 [OR x = $2...]) AND (y ILIKE $3 [OR z ILIKE $3...])`.
         // Interchanging .filter, .or, and .or_filter would result in different bracketing.
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1215,7 +1203,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1323,7 +1311,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1428,7 +1416,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1535,7 +1523,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query
@@ -1744,7 +1732,7 @@ impl QueryRoot {
                 Direction::DESC => query = query.order(updated_at.desc()),
             },
         }
-        for pub_id in get_publishers(&context) {
+        for pub_id in publishers {
             query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
         }
         query


### PR DESCRIPTION
Closes #177.

Also fixes minor issue where Imprint and Funder counts as displayed in app listings were not updated as user changed search filter text.