### PR TITLE
Feature/acount service permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,6 +3686,7 @@ dependencies = [
  "anyhow",
  "log",
  "serde",
+ "serde_json",
  "thiserror",
  "thoth-api",
  "url 2.1.1",

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -11,15 +11,12 @@ use actix_web::{error, web, App, Error, HttpRequest, HttpResponse, HttpServer, R
 use dotenv::dotenv;
 use juniper::http::graphiql::graphiql_source;
 use juniper::http::GraphQLRequest;
-use thoth_api::account::model::Account;
+use thoth_api::account::model::AccountDetails;
 use thoth_api::account::model::DecodedToken;
-use thoth_api::account::model::Login;
 use thoth_api::account::model::LoginCredentials;
-use thoth_api::account::model::LoginSession;
-use thoth_api::account::model::Session;
+use thoth_api::account::service::get_account;
 use thoth_api::account::service::get_account_details;
 use thoth_api::account::service::login;
-use thoth_api::account::service::login_with_token;
 use thoth_api::db::establish_connection;
 use thoth_api::db::PgPool;
 use thoth_api::errors::ThothError;
@@ -90,32 +87,43 @@ async fn login_credentials(
 
     login(&r.email, &r.password, &pool)
         .and_then(|account| {
-            let token = account.issue_token(&pool).unwrap();
-            let user_string = serde_json::to_string(&account)
+            account.issue_token(&pool)?;
+            let details = get_account_details(&account.email, &pool).unwrap();
+            let user_string = serde_json::to_string(&details)
                 .map_err(|_| ThothError::InternalError("Serder error".into()))?;
             id.remember(user_string);
-            Ok(HttpResponse::Ok().json(Login(Session { token })))
+            Ok(HttpResponse::Ok().json(details))
         })
         .map_err(error::ErrorUnauthorized)
 }
 
 #[post("/account/token/renew")]
 async fn login_session(
-    payload: web::Json<LoginSession>,
     token: DecodedToken,
     id: Identity,
     pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, Error> {
-    let r = payload.into_inner();
-    token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
+    let email = match id.identity() {
+        Some(id) => {
+            let details: AccountDetails =
+                serde_json::from_str(&id).map_err(|_| ThothError::Unauthorised)?;
+            details.email
+        }
+        None => {
+            token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
+            let t = token.jwt.unwrap();
+            t.sub
+        }
+    };
 
-    login_with_token(&r.0.token, &pool)
+    get_account(&email, &pool)
         .and_then(|account| {
-            let token = account.issue_token(&pool).unwrap();
-            let user_string = serde_json::to_string(&account)
+            account.issue_token(&pool)?;
+            let details = get_account_details(&account.email, &pool).unwrap();
+            let user_string = serde_json::to_string(&details)
                 .map_err(|_| ThothError::InternalError("Serder error".into()))?;
             id.remember(user_string);
-            Ok(HttpResponse::Ok().json(Login(Session { token })))
+            Ok(HttpResponse::Ok().json(details))
         })
         .map_err(error::ErrorUnauthorized)
 }
@@ -128,9 +136,9 @@ async fn account_details(
 ) -> Result<HttpResponse, Error> {
     let email = match id.identity() {
         Some(id) => {
-            let account: Account =
+            let details: AccountDetails =
                 serde_json::from_str(&id).map_err(|_| ThothError::Unauthorised)?;
-            account.email
+            details.email
         }
         None => {
             token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -95,6 +95,7 @@ pub struct AccountDetails {
     pub name: String,
     pub surname: String,
     pub email: String,
+    pub token: Option<String>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
     pub resource_access: AccountAccess,
@@ -106,35 +107,7 @@ pub struct DecodedToken {
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
-pub struct Session {
-    pub token: String,
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct LoginCredentials {
     pub email: String,
     pub password: String,
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-pub struct Login(pub Session);
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-pub struct LoginSession(pub Session);
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-pub struct Logout(pub Session);
-
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
-pub struct LogoutResponse;
-
-impl Session {
-    pub fn new<T>(token: T) -> Self
-    where
-        String: From<T>,
-    {
-        Self {
-            token: token.into(),
-        }
-    }
 }

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -106,7 +106,7 @@ pub struct DecodedToken {
     pub jwt: Option<Token>,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize, Default)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
 pub struct LoginCredentials {
     pub email: String,
     pub password: String,

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -106,7 +106,7 @@ pub struct DecodedToken {
     pub jwt: Option<Token>,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Default)]
 pub struct LoginCredentials {
     pub email: String,
     pub password: String,

--- a/thoth-api/src/account/service.rs
+++ b/thoth-api/src/account/service.rs
@@ -26,12 +26,12 @@ pub fn login(user_email: &str, user_password: &str, pool: &PgPool) -> Result<Acc
     }
 }
 
-pub fn login_with_token(token: &str, pool: &PgPool) -> Result<Account, ThothError> {
+pub fn get_account(email: &str, pool: &PgPool) -> Result<Account, ThothError> {
     use crate::schema::account::dsl;
 
     let conn = pool.get().unwrap();
     let account = dsl::account
-        .filter(dsl::token.eq(token))
+        .filter(dsl::email.eq(email))
         .first::<Account>(&conn)
         .map_err(|_| ThothError::Unauthorised)?;
     Ok(account)
@@ -53,6 +53,7 @@ pub fn get_account_details(email: &str, pool: &PgPool) -> Result<AccountDetails,
         name: account.name,
         surname: account.surname,
         email: account.email,
+        token: account.token,
         created_at: account.created_at,
         updated_at: account.updated_at,
         resource_access,

--- a/thoth-app/Cargo.toml
+++ b/thoth-app/Cargo.toml
@@ -28,5 +28,6 @@ yewtil = { version = "0.3.2", features = ["fetch", "pure"] }
 wasm-bindgen = "0.2.67"
 wasm-logger = "0.2.0"
 serde = { version = "1.0.115", features = ["derive"] }
+serde_json = "1.0"
 url = "2.1.1"
 thoth-api = { version = "0.2.13", path = "../thoth-api"  }

--- a/thoth-app/src/agent/session_timer.rs
+++ b/thoth-app/src/agent/session_timer.rs
@@ -1,31 +1,16 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::time::Duration;
-use thoth_api::account::model::Login;
-use thoth_api::account::model::LoginSession;
-use thoth_api::account::model::Session;
 use yew::agent::Dispatcher;
-use yew::format::Json;
 use yew::prelude::worker::*;
 use yew::prelude::*;
-use yew::services::fetch::FetchTask;
 use yew::services::IntervalService;
 use yew::services::Task;
 
-use crate::authenticated_fetch;
-use crate::models::Response;
-use crate::service::account::AccountService;
-
 pub type SessionTimerDispatcher = Dispatcher<SessionTimerAgent>;
 
-pub enum Msg {
-    Fetch(Response<Login>),
-    Update,
-}
-
-#[derive(Deserialize, Serialize)]
 pub enum Request {
-    Start,
+    Start(Callback<()>),
     Stop,
 }
 
@@ -33,77 +18,29 @@ pub enum Request {
 pub struct TimerResponse;
 
 pub struct SessionTimerAgent {
-    agent_link: AgentLink<SessionTimerAgent>,
-    callback: Callback<()>,
-    account_service: AccountService,
-    fetch_task: Option<FetchTask>,
+    _link: AgentLink<SessionTimerAgent>,
     timer_task: Option<Box<dyn Task>>,
 }
 
 impl Agent for SessionTimerAgent {
     type Input = Request;
-    type Message = Msg;
+    type Message = ();
     type Output = TimerResponse;
     type Reach = Context<Self>;
 
-    fn create(link: AgentLink<Self>) -> Self {
+    fn create(_link: AgentLink<Self>) -> Self {
         Self {
-            callback: link.callback(|_| Msg::Update),
-            agent_link: link,
-            account_service: AccountService::new(),
-            fetch_task: None,
+            _link,
             timer_task: None,
         }
     }
 
-    fn update(&mut self, msg: Self::Message) {
-        match msg {
-            Msg::Update => {
-                log::info!("Updating current session");
-                if let Some(token) = self.account_service.get_token() {
-                    self.fetch_task = authenticated_fetch! {
-                        LoginSession(Session::new(token)) => "/account/token/renew",
-                        token,
-                        self.agent_link, Msg::Fetch,
-                        || {},
-                        || {
-                            log::warn!("Unable to create scheduled session login request");
-                        }
-                    };
-                }
-            }
-            Msg::Fetch(response) => {
-                let (meta, Json(body)) = response.into_parts();
-
-                // Check the response type
-                if meta.status.is_success() {
-                    match body {
-                        Ok(Login(Session { token })) => {
-                            log::info!("Scheduled session based login succeed");
-
-                            // Set the retrieved session cookie
-                            self.account_service.set_token(token);
-                        }
-                        _ => log::warn!("Got wrong scheduled session login response"),
-                    }
-                } else {
-                    // Authentication failed
-                    log::info!(
-                        "Scheduled session login failed with status: {}",
-                        meta.status
-                    );
-                }
-
-                // Remove the ongoing task
-                self.fetch_task = None;
-            }
-        }
-    }
+    fn update(&mut self, _msg: Self::Message) {}
 
     fn handle_input(&mut self, msg: Self::Input, _: HandlerId) {
         match msg {
-            Request::Start => {
-                let handle = IntervalService::spawn(Duration::from_secs(60), self.callback.clone());
+            Request::Start(callback) => {
+                let handle = IntervalService::spawn(Duration::from_secs(60), callback.clone());
                 self.timer_task = Some(Box::new(handle));
             }
             Request::Stop => {

--- a/thoth-app/src/agent/session_timer.rs
+++ b/thoth-app/src/agent/session_timer.rs
@@ -40,7 +40,7 @@ impl Agent for SessionTimerAgent {
     fn handle_input(&mut self, msg: Self::Input, _: HandlerId) {
         match msg {
             Request::Start(callback) => {
-                let handle = IntervalService::spawn(Duration::from_secs(60), callback.clone());
+                let handle = IntervalService::spawn(Duration::from_secs(60), callback);
                 self.timer_task = Some(Box::new(handle));
             }
             Request::Stop => {

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -55,7 +55,7 @@ impl Component for AdminComponent {
         AdminComponent {
             props,
             router: RouteAgentDispatcher::new(),
-            link: link,
+            link,
         }
     }
 

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -52,7 +52,6 @@ impl Component for AdminComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        log::debug!("admin create");
         AdminComponent {
             props,
             router: RouteAgentDispatcher::new(),
@@ -61,9 +60,7 @@ impl Component for AdminComponent {
     }
 
     fn rendered(&mut self, first_render: bool) {
-        log::debug!("admin rendered");
         if first_render && !self.props.current_user.is_some() {
-            log::debug!("admin rendered - redirect");
             self.link.send_message(Msg::RedirectToLogin);
         }
     }
@@ -72,16 +69,14 @@ impl Component for AdminComponent {
         match msg {
             Msg::RedirectToLogin => {
                 self.router.send(RouteRequest::ChangeRoute(Route::from(AppRoute::Login)));
-                true
+                false
             }
         }
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
         self.props = props;
-        log::debug!("admin changed");
         if !self.props.current_user.is_some() {
-            log::debug!("admin changed - redirect");
             self.link.send_message(Msg::RedirectToLogin);
         }
         true

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -60,7 +60,7 @@ impl Component for AdminComponent {
     }
 
     fn rendered(&mut self, first_render: bool) {
-        if first_render && !self.props.current_user.is_some() {
+        if first_render && self.props.current_user.is_none() {
             self.link.send_message(Msg::RedirectToLogin);
         }
     }

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -77,7 +77,7 @@ impl Component for AdminComponent {
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
         self.props = props;
-        if !self.props.current_user.is_some() {
+        if self.props.current_user.is_none() {
             self.link.send_message(Msg::RedirectToLogin);
         }
         true

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -68,7 +68,8 @@ impl Component for AdminComponent {
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::RedirectToLogin => {
-                self.router.send(RouteRequest::ChangeRoute(Route::from(AppRoute::Login)));
+                self.router
+                    .send(RouteRequest::ChangeRoute(Route::from(AppRoute::Login)));
                 false
             }
         }

--- a/thoth-app/src/component/login.rs
+++ b/thoth-app/src/component/login.rs
@@ -98,7 +98,7 @@ impl Component for LoginComponent {
             }
             Msg::Response(Ok(account_details)) => {
                 let token = account_details.token.clone().unwrap();
-                self.account_service.set_token(token.clone());
+                self.account_service.set_token(token.clone);
                 self.props.callback.emit(account_details);
                 self.task = None;
                 self.link.send_message(Msg::RedirectToAdmin);

--- a/thoth-app/src/component/login.rs
+++ b/thoth-app/src/component/login.rs
@@ -34,6 +34,12 @@ pub struct LoginComponent {
     account_service: AccountService,
     notification_bus: NotificationDispatcher,
     router: RouteAgentDispatcher<()>,
+    props: Props,
+}
+
+#[derive(PartialEq, Properties, Clone)]
+pub struct Props {
+    pub callback: Callback<()>,
 }
 
 pub enum Msg {
@@ -45,9 +51,9 @@ pub enum Msg {
 
 impl Component for LoginComponent {
     type Message = Msg;
-    type Properties = ();
+    type Properties = Props;
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
         let email = "".into();
         let password = "".into();
         let account_service = AccountService::new();
@@ -62,11 +68,13 @@ impl Component for LoginComponent {
             account_service,
             notification_bus,
             router,
+            props,
         }
     }
 
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props = props;
+        true
     }
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
@@ -96,6 +104,7 @@ impl Component for LoginComponent {
                     match body {
                         Ok(Login(Session { token })) => {
                             self.account_service.set_token(token);
+                            self.props.callback.emit(());
                             self.router.send(RouteRequest::ChangeRoute(Route::from(
                                 AppRoute::Admin(AdminRoute::Admin),
                             )));

--- a/thoth-app/src/component/login.rs
+++ b/thoth-app/src/component/login.rs
@@ -98,7 +98,7 @@ impl Component for LoginComponent {
             }
             Msg::Response(Ok(account_details)) => {
                 let token = account_details.token.clone().unwrap();
-                self.account_service.set_token(token.clone);
+                self.account_service.set_token(token);
                 self.props.callback.emit(account_details);
                 self.task = None;
                 self.link.send_message(Msg::RedirectToAdmin);

--- a/thoth-app/src/component/login.rs
+++ b/thoth-app/src/component/login.rs
@@ -15,8 +15,8 @@ use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
-use crate::service::account::AccountService;
 use crate::service::account::AccountError;
+use crate::service::account::AccountService;
 use crate::string::AUTHENTICATION_ERROR;
 use crate::string::INPUT_EMAIL;
 use crate::string::INPUT_PASSWORD;
@@ -83,13 +83,17 @@ impl Component for LoginComponent {
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::RedirectToAdmin => {
-                self.router.send(RouteRequest::ChangeRoute(Route::from(
-                    AppRoute::Admin(AdminRoute::Admin),
-                )));
+                self.router
+                    .send(RouteRequest::ChangeRoute(Route::from(AppRoute::Admin(
+                        AdminRoute::Admin,
+                    ))));
                 false
             }
             Msg::Request => {
-                self.task = Some(self.account_service.login(self.request.clone(), self.response.clone()));
+                self.task = Some(
+                    self.account_service
+                        .login(self.request.clone(), self.response.clone()),
+                );
                 true
             }
             Msg::Response(Ok(account_details)) => {

--- a/thoth-app/src/component/login.rs
+++ b/thoth-app/src/component/login.rs
@@ -62,7 +62,6 @@ impl Component for LoginComponent {
         let account_service = AccountService::new();
         let notification_bus = NotificationBus::dispatcher();
         let router = RouteAgentDispatcher::new();
-
         LoginComponent {
             email,
             password,
@@ -84,6 +83,9 @@ impl Component for LoginComponent {
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
         self.props = props;
+        if self.props.current_user.is_some() {
+            self.link.send_message(Msg::RedirectToAdmin);
+        }
         true
     }
 
@@ -93,7 +95,7 @@ impl Component for LoginComponent {
                 self.router.send(RouteRequest::ChangeRoute(Route::from(
                     AppRoute::Admin(AdminRoute::Admin),
                 )));
-                true
+                false
             }
             Msg::LoginRequest => {
                 self.fetch_task = fetch! {

--- a/thoth-app/src/component/navbar.rs
+++ b/thoth-app/src/component/navbar.rs
@@ -6,17 +6,14 @@ use thoth_api::account::model::AccountDetails;
 
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
-use crate::service::account::AccountService;
 use crate::THOTH_API;
 
 pub struct NavbarComponent {
     props: Props,
     link: ComponentLink<Self>,
-    account_service: AccountService,
 }
 
 pub enum Msg {
-    Login,
     Logout,
 }
 
@@ -31,11 +28,9 @@ impl Component for NavbarComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let account_service = AccountService::new();
         NavbarComponent {
             props,
             link,
-            account_service,
         }
     }
 
@@ -46,10 +41,6 @@ impl Component for NavbarComponent {
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
-            Msg::Login => {
-                self.account_service.redirect_to_login();
-                true
-            }
             Msg::Logout => {
                 self.props.callback.emit(());
                 true
@@ -58,20 +49,10 @@ impl Component for NavbarComponent {
     }
 
     fn view(&self) -> VNode {
-        let auth_action = match &self.props.current_user.is_some() {
-            true => self.link.callback(|e: MouseEvent| {
-                e.prevent_default();
-                Msg::Logout
-            }),
-            false => self.link.callback(|e: MouseEvent| {
-                e.prevent_default();
-                Msg::Login
-            }),
-        };
-        let auth_button = match &self.props.current_user.is_some() {
-            true => "Logout",
-            false => "Log in",
-        };
+        let logout = self.link.callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::Logout
+        });
         html! {
             <nav class="navbar is-warning" role="navigation" aria-label="main navigation">
                 <div class="navbar-brand">
@@ -129,12 +110,21 @@ impl Component for NavbarComponent {
                             <a class="button is-danger" href="https://github.com/thoth-pub/thoth/blob/master/CHANGELOG.md">
                                 {"v"}{ env!("CARGO_PKG_VERSION") }
                             </a>
-                            <button
-                                class="button is-light"
-                                onclick=auth_action
-                            >
-                                { auth_button }
-                            </button>
+                            {
+                                if self.props.current_user.is_some() {
+                                    html! {
+                                        <button class="button is-light" onclick=logout>
+                                            { "Logout" }
+                                        </button>
+                                    }
+                                } else {
+                                    html! {
+                                        <RouterAnchor<AppRoute> classes="button is-light" route=AppRoute::Login>
+                                            {"Login"}
+                                        </  RouterAnchor<AppRoute>>
+                                    }
+                                }
+                            }
                         </div>
                     </div>
                 </div>

--- a/thoth-app/src/component/navbar.rs
+++ b/thoth-app/src/component/navbar.rs
@@ -1,8 +1,8 @@
+use thoth_api::account::model::AccountDetails;
 use yew::html;
 use yew::prelude::*;
 use yew::virtual_dom::VNode;
 use yew_router::prelude::*;
-use thoth_api::account::model::AccountDetails;
 
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
@@ -28,10 +28,7 @@ impl Component for NavbarComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        NavbarComponent {
-            props,
-            link,
-        }
+        NavbarComponent { props, link }
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {

--- a/thoth-app/src/component/root.rs
+++ b/thoth-app/src/component/root.rs
@@ -1,12 +1,12 @@
-use yew::Callback;
+use thoth_api::account::model::AccountDetails;
 use yew::html;
 use yew::prelude::*;
 use yew::services::fetch::FetchTask;
 use yew::virtual_dom::VNode;
+use yew::Callback;
 use yew_router::prelude::*;
 use yew_router::route::Route;
 use yew_router::switch::Permissive;
-use thoth_api::account::model::AccountDetails;
 
 use crate::agent::session_timer;
 use crate::agent::session_timer::SessionTimerAgent;
@@ -18,8 +18,8 @@ use crate::component::login::LoginComponent;
 use crate::component::navbar::NavbarComponent;
 use crate::component::notification::NotificationComponent;
 use crate::route::AppRoute;
-use crate::service::account::AccountService;
 use crate::service::account::AccountError;
+use crate::service::account::AccountService;
 
 pub struct RootComponent {
     current_route: Option<AppRoute>,
@@ -77,11 +77,15 @@ impl Component for RootComponent {
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::FetchCurrentUser => {
-                let task = self.account_service.account_details(self.current_user_response.clone());
+                let task = self
+                    .account_service
+                    .account_details(self.current_user_response.clone());
                 self.current_user_task = Some(task);
             }
             Msg::RenewToken => {
-                let task = self.account_service.renew_token(self.renew_token_response.clone());
+                let task = self
+                    .account_service
+                    .renew_token(self.renew_token_response.clone());
                 self.renew_token_task = Some(task);
             }
             Msg::CurrentUserResponse(Ok(account_details)) => {
@@ -100,14 +104,12 @@ impl Component for RootComponent {
                 self.link.send_message(Msg::Logout);
                 self.current_user_task = None;
             }
-            Msg::Route(route) => {
-                self.current_route = AppRoute::switch(route)
-            }
+            Msg::Route(route) => self.current_route = AppRoute::switch(route),
             Msg::Login(account_details) => {
                 // start session timer
-                self.session_timer_agent.send(
-                    session_timer::Request::Start(self.link.callback(|_| Msg::RenewToken))
-                );
+                self.session_timer_agent.send(session_timer::Request::Start(
+                    self.link.callback(|_| Msg::RenewToken),
+                ));
                 self.current_user = Some(account_details);
             }
             Msg::Logout => {

--- a/thoth-app/src/component/root.rs
+++ b/thoth-app/src/component/root.rs
@@ -8,6 +8,8 @@ use yew_router::route::Route;
 use yew_router::switch::Permissive;
 use thoth_api::account::model::AccountDetails;
 
+use crate::agent::session_timer;
+use crate::agent::session_timer::SessionTimerAgent;
 use crate::component::admin::AdminComponent;
 use crate::component::catalogue::CatalogueComponent;
 use crate::component::hero::HeroComponent;
@@ -59,6 +61,8 @@ impl Component for RootComponent {
                 self.current_user_task = Some(task);
             }
             Msg::CurrentUserResponse(Ok(account_details)) => {
+                let mut session_timer_agent = SessionTimerAgent::dispatcher();
+                session_timer_agent.send(session_timer::Request::Start);
                 self.current_user = Some(account_details);
                 self.current_user_task = None;
             }
@@ -80,6 +84,7 @@ impl Component for RootComponent {
     fn view(&self) -> VNode {
         let callback_login = self.link.callback(|_| Msg::FetchCurrentUser);
         let callback_logout = self.link.callback(|_| Msg::Logout);
+        let current_user = self.current_user.clone();
 
         html! {
             <>
@@ -101,13 +106,12 @@ impl Component for RootComponent {
                                 },
                                 AppRoute::Login => html! {
                                     <div class="section">
-                                        <LoginComponent callback=callback_login.clone()/>
+                                        <LoginComponent current_user=&current_user callback=callback_login.clone()/>
                                     </div>
                                 },
                                 AppRoute::Admin(admin_route) => html! {
                                     <div class="section">
-                                        // <AdminComponent route={admin_route} current_user=&self.current_user/>
-                                        <AdminComponent route={admin_route}/>
+                                        <AdminComponent route={admin_route} current_user=&current_user/>
                                     </div>
                                 },
                                 AppRoute::Error(Permissive(None)) => html! {

--- a/thoth-app/src/component/root.rs
+++ b/thoth-app/src/component/root.rs
@@ -26,8 +26,7 @@ pub struct RootComponent {
     current_user: Option<AccountDetails>,
     current_user_response: Callback<Result<AccountDetails, AccountError>>,
     current_user_task: Option<FetchTask>,
-    #[allow(unused)]
-    router_agent: Box<dyn Bridge<RouteAgent>>,
+    _router_agent: Box<dyn Bridge<RouteAgent>>,
     link: ComponentLink<Self>,
 }
 
@@ -43,7 +42,7 @@ impl Component for RootComponent {
     type Properties = ();
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let router_agent = RouteAgent::bridge(link.callback(Msg::Route));
+        let _router_agent = RouteAgent::bridge(link.callback(Msg::Route));
         let route_service: RouteService = RouteService::new();
         let route = route_service.get_route();
 
@@ -53,7 +52,7 @@ impl Component for RootComponent {
             current_user: Default::default(),
             current_user_response: link.callback(Msg::CurrentUserResponse),
             current_user_task: Default::default(),
-            router_agent,
+            _router_agent,
             link,
         }
     }

--- a/thoth-app/src/models/mod.rs
+++ b/thoth-app/src/models/mod.rs
@@ -1,9 +1,3 @@
-use anyhow::Result;
-use yew::format::Json;
-use yew::services::fetch::Response as FetchResponse;
-
-pub type Response<T> = FetchResponse<Json<Result<T>>>;
-
 #[macro_export]
 macro_rules! graphql_query_builder {
     (
@@ -90,45 +84,6 @@ macro_rules! graphql_query_builder {
                 }
             }
         }
-    };
-}
-
-#[macro_export]
-macro_rules! fetch {
-    ($request:expr => $api:expr, $link:expr, $msg:expr, $succ:expr, $err:expr) => {
-        match ::yew::services::fetch::Request::post(format!("{}{}", crate::THOTH_API, $api))
-            .header("Content-Type", "application/json")
-            .body(Json(&$request))
-        {
-            Ok(body) => {
-                $succ();
-                ::yew::services::fetch::FetchService::fetch_binary(body, $link.callback($msg)).ok()
-            }
-            Err(_) => {
-                $err();
-                None
-            }
-        };
-    };
-}
-
-#[macro_export]
-macro_rules! authenticated_fetch {
-    ($request:expr => $api:expr, $token:expr, $link:expr, $msg:expr, $succ:expr, $err:expr) => {
-        match ::yew::services::fetch::Request::post(format!("{}{}", crate::THOTH_API, $api))
-            .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", $token))
-            .body(Json(&$request))
-        {
-            Ok(body) => {
-                $succ();
-                ::yew::services::fetch::FetchService::fetch_binary(body, $link.callback($msg)).ok()
-            }
-            Err(_) => {
-                $err();
-                None
-            }
-        };
     };
 }
 

--- a/thoth-app/src/service/account.rs
+++ b/thoth-app/src/service/account.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
 use serde::Serialize;
+use thiserror::Error;
+use thoth_api::account::model::AccountDetails;
+use thoth_api::account::model::LoginCredentials;
 use yew::callback::Callback;
 use yew::format::Json;
 use yew::format::Nothing;
@@ -10,9 +13,6 @@ use yew::services::fetch::Request;
 use yew::services::fetch::Response;
 use yew::services::storage::Area;
 use yew::services::storage::StorageService;
-use thiserror::Error;
-use thoth_api::account::model::AccountDetails;
-use thoth_api::account::model::LoginCredentials;
 
 use crate::string::STORAGE_ERROR;
 use crate::SESSION_KEY;
@@ -62,7 +62,7 @@ impl AccountService {
         self.update_storage(None)
     }
 
-   pub fn login(
+    pub fn login(
         &mut self,
         login_credentials: LoginCredentials,
         callback: Callback<Result<AccountDetails, AccountError>>,
@@ -78,13 +78,13 @@ impl AccountService {
         &mut self,
         callback: Callback<Result<AccountDetails, AccountError>>,
     ) -> FetchTask {
-        self.bodyless_post_request::<AccountDetails>(
-            "/account/token/renew".to_string(),
-            callback,
-        )
+        self.bodyless_post_request::<AccountDetails>("/account/token/renew".to_string(), callback)
     }
 
-    pub fn account_details(&mut self, callback: Callback<Result<AccountDetails, AccountError>>) -> FetchTask {
+    pub fn account_details(
+        &mut self,
+        callback: Callback<Result<AccountDetails, AccountError>>,
+    ) -> FetchTask {
         self.get_request::<AccountDetails>("/account".to_string(), callback)
     }
 
@@ -133,14 +133,22 @@ impl AccountService {
         FetchService::fetch(request, handler.into()).unwrap()
     }
 
-    fn get_request<T>(&mut self, url: String, callback: Callback<Result<T, AccountError>>) -> FetchTask
+    fn get_request<T>(
+        &mut self,
+        url: String,
+        callback: Callback<Result<T, AccountError>>,
+    ) -> FetchTask
     where
         for<'de> T: Deserialize<'de> + 'static + std::fmt::Debug,
     {
         self.request_builder("GET", url, Nothing, callback)
     }
 
-    fn bodyless_post_request<T>(&mut self, url: String, callback: Callback<Result<T, AccountError>>) -> FetchTask
+    fn bodyless_post_request<T>(
+        &mut self,
+        url: String,
+        callback: Callback<Result<T, AccountError>>,
+    ) -> FetchTask
     where
         for<'de> T: Deserialize<'de> + 'static + std::fmt::Debug,
     {

--- a/thoth-app/src/service/account.rs
+++ b/thoth-app/src/service/account.rs
@@ -10,13 +10,9 @@ use yew::services::fetch::Request;
 use yew::services::fetch::Response;
 use yew::services::storage::Area;
 use yew::services::storage::StorageService;
-use yew_router::agent::RouteAgentDispatcher;
-use yew_router::agent::RouteRequest;
-use yew_router::route::Route;
 use thiserror::Error;
 use thoth_api::account::model::AccountDetails;
 
-use crate::route::AppRoute;
 use crate::string::STORAGE_ERROR;
 use crate::SESSION_KEY;
 
@@ -28,14 +24,11 @@ pub enum AccountError {
     ResponseError,
 }
 
-pub struct AccountService {
-    login_route: Route,
-}
+pub struct AccountService {}
 
 impl AccountService {
     pub fn new() -> Self {
-        let login_route = Route::from(AppRoute::Login);
-        Self { login_route }
+        Self {}
     }
 
     pub fn get_token(&self) -> Option<String> {
@@ -66,11 +59,6 @@ impl AccountService {
 
     pub fn logout(&self) {
         self.update_storage(None)
-    }
-
-    pub fn redirect_to_login(&self) {
-        let mut router: RouteAgentDispatcher<()> = RouteAgentDispatcher::new();
-        router.send(RouteRequest::ChangeRoute(self.login_route.clone()))
     }
 
     pub fn account_details(&mut self, callback: Callback<Result<AccountDetails, AccountError>>) -> FetchTask {

--- a/thoth-app/src/service/account.rs
+++ b/thoth-app/src/service/account.rs
@@ -25,6 +25,9 @@ pub enum AccountError {
     ResponseError,
 }
 
+const HTTP_UNAUTHORIZED: u16 = 401;
+const HTTP_FORBIDDEN: u16 = 403;
+
 pub struct AccountService {}
 
 impl AccountService {
@@ -110,8 +113,8 @@ impl AccountService {
                     }
                 } else {
                     match meta.status.as_u16() {
-                        401 => callback.emit(Err(AccountError::AuthenticationError)),
-                        403 => callback.emit(Err(AccountError::AuthenticationError)),
+                        HTTP_UNAUTHORIZED => callback.emit(Err(AccountError::AuthenticationError)),
+                        HTTP_FORBIDDEN => callback.emit(Err(AccountError::AuthenticationError)),
                         _ => callback.emit(Err(AccountError::ResponseError)),
                     }
                 }

--- a/thoth-app/src/service/account.rs
+++ b/thoth-app/src/service/account.rs
@@ -78,7 +78,6 @@ impl AccountService {
     {
         let handler = move |response: Response<Text>| {
             if let (meta, Ok(data)) = response.into_parts() {
-                log::debug!("Response: {:?}", data);
                 if meta.status.is_success() {
                     let data: Result<T, _> = serde_json::from_str(&data);
                     if let Ok(data) = data {
@@ -107,7 +106,6 @@ impl AccountService {
             builder = builder.header("Authorization", format!("Bearer {}", token));
         }
         let request = builder.body(body).unwrap();
-        log::debug!("Request: {:?}", request);
 
         FetchService::fetch(request, handler.into()).unwrap()
     }

--- a/thoth-app/src/service/account.rs
+++ b/thoth-app/src/service/account.rs
@@ -12,6 +12,7 @@ use yew::services::storage::Area;
 use yew::services::storage::StorageService;
 use thiserror::Error;
 use thoth_api::account::model::AccountDetails;
+use thoth_api::account::model::LoginCredentials;
 
 use crate::string::STORAGE_ERROR;
 use crate::SESSION_KEY;
@@ -59,6 +60,28 @@ impl AccountService {
 
     pub fn logout(&self) {
         self.update_storage(None)
+    }
+
+   pub fn login(
+        &mut self,
+        login_credentials: LoginCredentials,
+        callback: Callback<Result<AccountDetails, AccountError>>,
+    ) -> FetchTask {
+        self.post_request::<LoginCredentials, AccountDetails>(
+            "/account/login".to_string(),
+            login_credentials,
+            callback,
+        )
+    }
+
+    pub fn renew_token(
+        &mut self,
+        callback: Callback<Result<AccountDetails, AccountError>>,
+    ) -> FetchTask {
+        self.bodyless_post_request::<AccountDetails>(
+            "/account/token/renew".to_string(),
+            callback,
+        )
     }
 
     pub fn account_details(&mut self, callback: Callback<Result<AccountDetails, AccountError>>) -> FetchTask {
@@ -115,6 +138,13 @@ impl AccountService {
         for<'de> T: Deserialize<'de> + 'static + std::fmt::Debug,
     {
         self.request_builder("GET", url, Nothing, callback)
+    }
+
+    fn bodyless_post_request<T>(&mut self, url: String, callback: Callback<Result<T, AccountError>>) -> FetchTask
+    where
+        for<'de> T: Deserialize<'de> + 'static + std::fmt::Debug,
+    {
+        self.request_builder("POST", url, Nothing, callback)
     }
 
     fn post_request<B, T>(


### PR DESCRIPTION
Restructure authentication completely in the APP. Key changes include:
- [APP] move all authentication related api actions to `AccountService` (remove the `fetch!` macro from model).
- [API] login requests return `AccountDetails` instead of just the token (`LoginSession` has been removed)
- [API] token is now included in `AccountDetails`
- [APP] `RootComponent` now contains `current_user` information and provides callbacks to its child components to change the state (e.g. `Logout` callback provided to `NavbarComponent`), as well as `current_user` is now passed as properties to `AdminComponent` and `NavbarComponent` for authentication checks
- [APP] `SessionTimer` no longer contains logic to update the token, it expects a callback as its start input instead