### PR TITLE
Add write checks in API to ensure that users can only edit their own publishers' objects (#161)

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -45,7 +45,7 @@ async fn graphql(
     token: DecodedToken,
     data: web::Json<GraphQLRequest>,
 ) -> Result<HttpResponse, Error> {
-    let ctx = Context::new(pool.into_inner(), token.get_user_permissions(), token);
+    let ctx = Context::new(pool.into_inner(), token);
     let result = web::block(move || {
         let res = data.execute(&st, &ctx);
         Ok::<_, serde_json::error::Error>(serde_json::to_string(&res)?)

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -45,7 +45,7 @@ async fn graphql(
     token: DecodedToken,
     data: web::Json<GraphQLRequest>,
 ) -> Result<HttpResponse, Error> {
-    let ctx = Context::new(pool.into_inner(), token);
+    let ctx = Context::new(pool.into_inner(), token.get_user_permissions(), token);
     let result = web::block(move || {
         let res = data.execute(&st, &ctx);
         Ok::<_, serde_json::error::Error>(serde_json::to_string(&res)?)

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -141,15 +141,15 @@ impl Session {
 
 impl DecodedToken {
     pub fn get_user_permissions(&self) -> AccountAccess {
-        let mut account_access = AccountAccess {
-            is_superuser: false,
-            is_bot: false,
-            linked_publishers: vec![],
-        };
         if let Some(jwt) = &self.jwt {
-            account_access = jwt.namespace.clone();
+            jwt.namespace.clone()
+        } else {
+            AccountAccess {
+                is_superuser: false,
+                is_bot: false,
+                linked_publishers: vec![],
+            }
         }
-        account_access
     }
 }
 

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -168,7 +168,7 @@ impl AccountAccess {
 
     pub fn can_edit(&self, pub_id: Uuid) -> Result<(), ThothError> {
         if !self.is_superuser && !self.id_in_linked_publishers(pub_id) {
-            Err(ThothError::Unauthorised.into())
+            Err(ThothError::Unauthorised)
         } else {
             Ok(())
         }

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -156,21 +156,17 @@ impl DecodedToken {
 }
 
 impl AccountAccess {
-    pub fn can_edit(&self, pub_id: Uuid) -> Result<()> {
+    pub fn can_edit(&self, publisher_id: Uuid) -> Result<()> {
         if self.is_superuser {
             Ok(())
+        } else if let Some(_found) = &self
+            .linked_publishers
+            .iter()
+            .position(|publisher| publisher.publisher_id == publisher_id)
+        {
+            Ok(())
         } else {
-            let mut id_found = false;
-            for publisher in &self.linked_publishers {
-                if publisher.publisher_id == pub_id {
-                    id_found = true;
-                    break;
-                }
-            }
-            match id_found {
-                true => Ok(()),
-                false => Err(ThothError::Unauthorised.into()),
-            }
+            Err(ThothError::Unauthorised.into())
         }
     }
 }

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -138,3 +138,30 @@ impl Session {
         }
     }
 }
+
+impl DecodedToken {
+    pub fn get_user_permissions(&self) -> AccountAccess {
+        let mut account_access = AccountAccess {
+            is_superuser: false,
+            is_bot: false,
+            linked_publishers: vec![],
+        };
+        if let Some(jwt) = &self.jwt {
+            account_access = jwt.namespace.clone();
+        }
+        account_access
+    }
+}
+
+impl AccountAccess {
+    pub fn id_in_linked_publishers(&self, id: Uuid) -> bool {
+        let mut id_found = false;
+        for publisher in &self.linked_publishers {
+            if publisher.publisher_id == id {
+                id_found = true;
+                break;
+            }
+        }
+        id_found
+    }
+}

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -2,6 +2,7 @@ use chrono::naive::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::errors::ThothError;
 #[cfg(feature = "backend")]
 use crate::schema::account;
 #[cfg(feature = "backend")]
@@ -163,5 +164,13 @@ impl AccountAccess {
             }
         }
         id_found
+    }
+
+    pub fn can_edit(&self, pub_id: Uuid) -> Result<(), ThothError> {
+        if !self.is_superuser && !self.id_in_linked_publishers(pub_id) {
+            Err(ThothError::Unauthorised.into())
+        } else {
+            Ok(())
+        }
     }
 }

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1931,9 +1931,17 @@ pub struct MutationRoot;
 #[juniper::object(Context = Context)]
 impl MutationRoot {
     fn create_work(context: &Context, data: NewWork) -> FieldResult<Work> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .select(publisher_id)
+            .filter(imprint_id.eq(data.imprint_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(work::table)
             .values(&data)
             .get_result(&connection)
@@ -1945,6 +1953,10 @@ impl MutationRoot {
 
     fn create_publisher(context: &Context, data: NewPublisher) -> FieldResult<Publisher> {
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
+        // Only superusers can create new publishers - NewPublisher has no ID field
+        if !context.account_access.is_superuser {
+            return Err(ThothError::Unauthorised.into());
+        }
 
         let connection = context.db.get().unwrap();
         match diesel::insert_into(publisher::table)
@@ -1984,9 +1996,18 @@ impl MutationRoot {
     }
 
     fn create_contribution(context: &Context, data: NewContribution) -> FieldResult<Contribution> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .inner_join(crate::schema::work::table)
+            .select(publisher_id)
+            .filter(crate::schema::work::work_id.eq(data.work_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(contribution::table)
             .values(&data)
             .get_result(&connection)
@@ -1997,9 +2018,18 @@ impl MutationRoot {
     }
 
     fn create_publication(context: &Context, data: NewPublication) -> FieldResult<Publication> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .inner_join(crate::schema::work::table)
+            .select(publisher_id)
+            .filter(crate::schema::work::work_id.eq(data.work_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(publication::table)
             .values(&data)
             .get_result(&connection)
@@ -2010,9 +2040,17 @@ impl MutationRoot {
     }
 
     fn create_series(context: &Context, data: NewSeries) -> FieldResult<Series> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .select(publisher_id)
+            .filter(imprint_id.eq(data.imprint_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(series::table)
             .values(&data)
             .get_result(&connection)
@@ -2023,9 +2061,18 @@ impl MutationRoot {
     }
 
     fn create_issue(context: &Context, data: NewIssue) -> FieldResult<Issue> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .inner_join(crate::schema::work::table)
+            .select(publisher_id)
+            .filter(crate::schema::work::work_id.eq(data.work_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(issue::table)
             .values(&data)
             .get_result(&connection)
@@ -2036,9 +2083,18 @@ impl MutationRoot {
     }
 
     fn create_language(context: &Context, data: NewLanguage) -> FieldResult<Language> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .inner_join(crate::schema::work::table)
+            .select(publisher_id)
+            .filter(crate::schema::work::work_id.eq(data.work_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(language::table)
             .values(&data)
             .get_result(&connection)
@@ -2062,9 +2118,18 @@ impl MutationRoot {
     }
 
     fn create_funding(context: &Context, data: NewFunding) -> FieldResult<Funding> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .inner_join(crate::schema::work::table)
+            .select(publisher_id)
+            .filter(crate::schema::work::work_id.eq(data.work_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(funding::table)
             .values(&data)
             .get_result(&connection)
@@ -2075,9 +2140,18 @@ impl MutationRoot {
     }
 
     fn create_price(context: &Context, data: NewPrice) -> FieldResult<Price> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
         let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .inner_join(crate::schema::work::table.inner_join(crate::schema::publication::table))
+            .select(publisher_id)
+            .filter(crate::schema::publication::publication_id.eq(data.publication_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
+
         match diesel::insert_into(price::table)
             .values(&data)
             .get_result(&connection)
@@ -2088,11 +2162,20 @@ impl MutationRoot {
     }
 
     fn create_subject(context: &Context, data: NewSubject) -> FieldResult<Subject> {
+        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
+        let connection = context.db.get().unwrap();
+        let pub_id = imprint
+            .inner_join(crate::schema::work::table)
+            .select(publisher_id)
+            .filter(crate::schema::work::work_id.eq(data.work_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
+
+        context.account_access.can_edit(pub_id)?;
 
         check_subject(&data.subject_type, &data.subject_code)?;
 
-        let connection = context.db.get().unwrap();
         match diesel::insert_into(subject::table)
             .values(&data)
             .get_result(&connection)

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1954,10 +1954,10 @@ impl MutationRoot {
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
 
         let account_access = context.token.get_user_permissions();
-        if !account_access.is_superuser {
-            if !account_access.id_in_linked_publishers(data.publisher_id) {
-                Err(ThothError::Unauthorised)?;
-            }
+        if !account_access.is_superuser
+            && !account_access.id_in_linked_publishers(data.publisher_id)
+        {
+            return Err(ThothError::Unauthorised.into());
         }
 
         let connection = context.db.get().unwrap();
@@ -2290,7 +2290,7 @@ impl MutationRoot {
         let account_access = context.token.get_user_permissions();
         // Early-exit allowing us to avoid unnecessary database calls
         if !account_access.is_superuser && account_access.linked_publishers.is_empty() {
-            Err(ThothError::Unauthorised)?;
+            return Err(ThothError::Unauthorised.into());
         }
 
         let connection = context.db.get().unwrap();
@@ -2307,7 +2307,7 @@ impl MutationRoot {
                 .first::<Uuid>(&connection)
                 .expect("Error checking permissions");
             if !account_access.id_in_linked_publishers(pub_id) {
-                Err(ThothError::Unauthorised)?;
+                return Err(ThothError::Unauthorised.into());
             }
         }
 
@@ -2334,7 +2334,7 @@ impl MutationRoot {
         let account_access = context.token.get_user_permissions();
         // Early-exit allowing us to avoid unnecessary database calls
         if !account_access.is_superuser && account_access.linked_publishers.is_empty() {
-            Err(ThothError::Unauthorised)?;
+            return Err(ThothError::Unauthorised.into());
         }
 
         let connection = context.db.get().unwrap();
@@ -2344,10 +2344,10 @@ impl MutationRoot {
         // Note that this may panic
         let imprint = result.unwrap();
 
-        if !account_access.is_superuser {
-            if !account_access.id_in_linked_publishers(imprint.publisher_id) {
-                Err(ThothError::Unauthorised)?;
-            }
+        if !account_access.is_superuser
+            && !account_access.id_in_linked_publishers(imprint.publisher_id)
+        {
+            return Err(ThothError::Unauthorised.into());
         }
 
         match diesel::delete(target).execute(&connection) {

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1952,13 +1952,7 @@ impl MutationRoot {
 
     fn create_imprint(context: &Context, data: NewImprint) -> FieldResult<Imprint> {
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-
-        let account_access = context.token.get_user_permissions();
-        if !account_access.is_superuser
-            && !account_access.id_in_linked_publishers(data.publisher_id)
-        {
-            return Err(ThothError::Unauthorised.into());
-        }
+        context.token.get_user_permissions().can_edit(data.publisher_id)?;
 
         let connection = context.db.get().unwrap();
         match diesel::insert_into(imprint::table)
@@ -2287,29 +2281,19 @@ impl MutationRoot {
     fn delete_work(context: &Context, work_id: Uuid) -> FieldResult<Work> {
         use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let account_access = context.token.get_user_permissions();
-        // Early-exit allowing us to avoid unnecessary database calls
-        if !account_access.is_superuser && account_access.linked_publishers.is_empty() {
-            return Err(ThothError::Unauthorised.into());
-        }
-
         let connection = context.db.get().unwrap();
 
         let target = crate::schema::work::dsl::work.find(work_id);
         let result = target.get_result::<Work>(&connection);
         // Note that this may panic
         let work = result.unwrap();
+        let pub_id = imprint
+            .select(publisher_id)
+            .filter(imprint_id.eq(work.imprint_id))
+            .first::<Uuid>(&connection)
+            .expect("Error checking permissions");
 
-        if !account_access.is_superuser {
-            let pub_id = imprint
-                .select(publisher_id)
-                .filter(imprint_id.eq(work.imprint_id))
-                .first::<Uuid>(&connection)
-                .expect("Error checking permissions");
-            if !account_access.id_in_linked_publishers(pub_id) {
-                return Err(ThothError::Unauthorised.into());
-            }
-        }
+        context.token.get_user_permissions().can_edit(pub_id)?;
 
         match diesel::delete(target).execute(&connection) {
             Ok(c) => Ok(work),
@@ -2331,12 +2315,6 @@ impl MutationRoot {
 
     fn delete_imprint(context: &Context, imprint_id: Uuid) -> FieldResult<Imprint> {
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let account_access = context.token.get_user_permissions();
-        // Early-exit allowing us to avoid unnecessary database calls
-        if !account_access.is_superuser && account_access.linked_publishers.is_empty() {
-            return Err(ThothError::Unauthorised.into());
-        }
-
         let connection = context.db.get().unwrap();
 
         let target = crate::schema::imprint::dsl::imprint.find(imprint_id);
@@ -2344,11 +2322,7 @@ impl MutationRoot {
         // Note that this may panic
         let imprint = result.unwrap();
 
-        if !account_access.is_superuser
-            && !account_access.id_in_linked_publishers(imprint.publisher_id)
-        {
-            return Err(ThothError::Unauthorised.into());
-        }
+        context.token.get_user_permissions().can_edit(imprint.publisher_id)?;
 
         match diesel::delete(target).execute(&connection) {
             Ok(c) => Ok(imprint),

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1996,18 +1996,11 @@ impl MutationRoot {
     }
 
     fn create_contribution(context: &Context, data: NewContribution) -> FieldResult<Contribution> {
-        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let connection = context.db.get().unwrap();
-        let pub_id = imprint
-            .inner_join(crate::schema::work::table)
-            .select(publisher_id)
-            .filter(crate::schema::work::work_id.eq(data.work_id))
-            .first::<Uuid>(&connection)
-            .expect("Error checking permissions");
-
+        let pub_id = publisher_id_from_work_id(data.work_id, &context);
         context.account_access.can_edit(pub_id)?;
 
+        let connection = context.db.get().unwrap();
         match diesel::insert_into(contribution::table)
             .values(&data)
             .get_result(&connection)
@@ -2018,18 +2011,11 @@ impl MutationRoot {
     }
 
     fn create_publication(context: &Context, data: NewPublication) -> FieldResult<Publication> {
-        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let connection = context.db.get().unwrap();
-        let pub_id = imprint
-            .inner_join(crate::schema::work::table)
-            .select(publisher_id)
-            .filter(crate::schema::work::work_id.eq(data.work_id))
-            .first::<Uuid>(&connection)
-            .expect("Error checking permissions");
-
+        let pub_id = publisher_id_from_work_id(data.work_id, &context);
         context.account_access.can_edit(pub_id)?;
 
+        let connection = context.db.get().unwrap();
         match diesel::insert_into(publication::table)
             .values(&data)
             .get_result(&connection)
@@ -2061,18 +2047,11 @@ impl MutationRoot {
     }
 
     fn create_issue(context: &Context, data: NewIssue) -> FieldResult<Issue> {
-        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let connection = context.db.get().unwrap();
-        let pub_id = imprint
-            .inner_join(crate::schema::work::table)
-            .select(publisher_id)
-            .filter(crate::schema::work::work_id.eq(data.work_id))
-            .first::<Uuid>(&connection)
-            .expect("Error checking permissions");
-
+        let pub_id = publisher_id_from_work_id(data.work_id, &context);
         context.account_access.can_edit(pub_id)?;
 
+        let connection = context.db.get().unwrap();
         match diesel::insert_into(issue::table)
             .values(&data)
             .get_result(&connection)
@@ -2083,18 +2062,11 @@ impl MutationRoot {
     }
 
     fn create_language(context: &Context, data: NewLanguage) -> FieldResult<Language> {
-        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let connection = context.db.get().unwrap();
-        let pub_id = imprint
-            .inner_join(crate::schema::work::table)
-            .select(publisher_id)
-            .filter(crate::schema::work::work_id.eq(data.work_id))
-            .first::<Uuid>(&connection)
-            .expect("Error checking permissions");
-
+        let pub_id = publisher_id_from_work_id(data.work_id, &context);
         context.account_access.can_edit(pub_id)?;
 
+        let connection = context.db.get().unwrap();
         match diesel::insert_into(language::table)
             .values(&data)
             .get_result(&connection)
@@ -2118,18 +2090,11 @@ impl MutationRoot {
     }
 
     fn create_funding(context: &Context, data: NewFunding) -> FieldResult<Funding> {
-        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let connection = context.db.get().unwrap();
-        let pub_id = imprint
-            .inner_join(crate::schema::work::table)
-            .select(publisher_id)
-            .filter(crate::schema::work::work_id.eq(data.work_id))
-            .first::<Uuid>(&connection)
-            .expect("Error checking permissions");
-
+        let pub_id = publisher_id_from_work_id(data.work_id, &context);
         context.account_access.can_edit(pub_id)?;
 
+        let connection = context.db.get().unwrap();
         match diesel::insert_into(funding::table)
             .values(&data)
             .get_result(&connection)
@@ -2162,20 +2127,13 @@ impl MutationRoot {
     }
 
     fn create_subject(context: &Context, data: NewSubject) -> FieldResult<Subject> {
-        use crate::schema::imprint::dsl::*;
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
-        let connection = context.db.get().unwrap();
-        let pub_id = imprint
-            .inner_join(crate::schema::work::table)
-            .select(publisher_id)
-            .filter(crate::schema::work::work_id.eq(data.work_id))
-            .first::<Uuid>(&connection)
-            .expect("Error checking permissions");
-
+        let pub_id = publisher_id_from_work_id(data.work_id, &context);
         context.account_access.can_edit(pub_id)?;
 
         check_subject(&data.subject_type, &data.subject_code)?;
 
+        let connection = context.db.get().unwrap();
         match diesel::insert_into(subject::table)
             .values(&data)
             .get_result(&connection)
@@ -3362,4 +3320,14 @@ pub type Schema = RootNode<'static, QueryRoot, MutationRoot>;
 
 pub fn create_schema() -> Schema {
     Schema::new(QueryRoot {}, MutationRoot {})
+}
+
+fn publisher_id_from_work_id(work_id: Uuid, context: &Context) -> Uuid {
+    use crate::schema::imprint::dsl::*;
+    imprint
+        .inner_join(crate::schema::work::table)
+        .select(publisher_id)
+        .filter(crate::schema::work::work_id.eq(work_id))
+        .first::<Uuid>(&context.db.get().unwrap())
+        .expect("Error checking permissions")
 }

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -7,7 +7,7 @@ use juniper::RootNode;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::account::model::DecodedToken;
+use crate::account::model::{AccountAccess, DecodedToken, LinkedPublisher};
 use crate::contribution::model::*;
 use crate::contributor::model::*;
 use crate::db::PgPool;
@@ -1920,6 +1920,29 @@ impl QueryRoot {
     }
 }
 
+fn get_user_permissions(token: &DecodedToken) -> AccountAccess {
+    let mut account_access = AccountAccess {
+        is_superuser: false,
+        is_bot: false,
+        linked_publishers: vec![],
+    };
+    if let Some(jwt) = &token.jwt {
+        account_access = jwt.namespace.clone();
+    }
+    account_access
+}
+
+fn id_in_linked_publishers(id: Uuid, linked_publishers: Vec<LinkedPublisher>) -> bool {
+    let mut id_found = false;
+    for publisher in linked_publishers {
+        if publisher.publisher_id == id {
+            id_found = true;
+            break;
+        }
+    }
+    id_found
+}
+
 pub struct MutationRoot;
 
 #[juniper::object(Context = Context)]
@@ -1952,6 +1975,13 @@ impl MutationRoot {
 
     fn create_imprint(context: &Context, data: NewImprint) -> FieldResult<Imprint> {
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
+
+        let account_access = get_user_permissions(&context.token);
+        if !account_access.is_superuser {
+            if !id_in_linked_publishers(data.publisher_id, account_access.linked_publishers) {
+                Err(ThothError::Unauthorised)?;
+            }
+        }
 
         let connection = context.db.get().unwrap();
         match diesel::insert_into(imprint::table)


### PR DESCRIPTION
Closes #161. Enforces the following checks:

- Users can only create objects if their proposed properties are linked to publishers they belong to
- Users can only delete objects if their properties as stored in the database are linked to publishers they belong to
- Users can only update objects if their proposed properties _and_ their database properties are linked to publishers they belong to (e.g. a user can't change a work's `imprint_id` from an imprint they own to an imprint they don't)

Note that superusers bypass all write checks.