### PR TITLE
App: restrict visibility of objects in Admin view based on current user's account permissions (#162)

### DIFF
--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -150,15 +150,14 @@ impl AccountAccess {
         }
     }
 
-    pub fn restricted_to(&self) -> Option<Vec<Uuid>> {
+    pub fn restricted_to(&self) -> Option<Vec<String>> {
         if self.is_superuser {
             None
         } else {
             Some(
-                self
-                    .linked_publishers
+                self.linked_publishers
                     .iter()
-                    .map(|publisher| publisher.publisher_id)
+                    .map(|publisher| publisher.publisher_id.to_string())
                     .collect(),
             )
         }

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -149,4 +149,18 @@ impl AccountAccess {
             Err(ThothError::Unauthorised.into())
         }
     }
+
+    pub fn restricted_to(&self) -> Option<Vec<Uuid>> {
+        if self.is_superuser {
+            None
+        } else {
+            Some(
+                self
+                    .linked_publishers
+                    .iter()
+                    .map(|publisher| publisher.publisher_id)
+                    .collect(),
+            )
+        }
+    }
 }

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -90,7 +90,7 @@ pub struct Token {
     pub namespace: AccountAccess,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountDetails {
     pub account_id: Uuid,

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -65,7 +65,7 @@ pub struct NewPublisherAccount {
     pub is_admin: bool,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountAccess {
     pub is_superuser: bool,
@@ -73,7 +73,7 @@ pub struct AccountAccess {
     pub linked_publishers: Vec<LinkedPublisher>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkedPublisher {
     pub publisher_id: Uuid,
@@ -90,7 +90,7 @@ pub struct Token {
     pub namespace: AccountAccess,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountDetails {
     pub account_id: Uuid,

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -96,21 +96,21 @@ impl Component for AdminComponent {
                         <div class="container">
                         {
                             match &self.props.route {
-                                AdminRoute::Admin => html!{<DashboardComponent current_user = &self.props.current_user />},
-                                AdminRoute::Dashboard => html!{<DashboardComponent current_user = &self.props.current_user />},
-                                AdminRoute::Works => html!{<WorksComponent current_user = &self.props.current_user />},
-                                AdminRoute::Work(id) => html!{<WorkComponent work_id = id, current_user = &self.props.current_user />},
-                                AdminRoute::NewWork => html!{<NewWorkComponent current_user = &self.props.current_user />},
-                                AdminRoute::Publishers => html!{<PublishersComponent current_user = &self.props.current_user />},
+                                AdminRoute::Admin => html!{<DashboardComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::Dashboard => html!{<DashboardComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::Works => html!{<WorksComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::Work(id) => html!{<WorkComponent work_id = id, current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::NewWork => html!{<NewWorkComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::Publishers => html!{<PublishersComponent current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::Publisher(id) => html!{<PublisherComponent publisher_id = id />},
                                 AdminRoute::NewPublisher => html!{<NewPublisherComponent/>},
-                                AdminRoute::Imprints => html!{<ImprintsComponent current_user = &self.props.current_user />},
-                                AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id, current_user = &self.props.current_user />},
-                                AdminRoute::NewImprint => html!{<NewImprintComponent current_user = &self.props.current_user />},
-                                AdminRoute::Funders => html!{<FundersComponent current_user = &self.props.current_user />},
+                                AdminRoute::Imprints => html!{<ImprintsComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id, current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::NewImprint => html!{<NewImprintComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::Funders => html!{<FundersComponent current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::Funder(id) => html!{<FunderComponent funder_id = id />},
                                 AdminRoute::NewFunder => html!{<NewFunderComponent/>},
-                                AdminRoute::Publications => html!{<PublicationsComponent current_user = &self.props.current_user />},
+                                AdminRoute::Publications => html!{<PublicationsComponent current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::Publication(id) => html!{<PublicationComponent publication_id = id />},
                                 AdminRoute::NewPublication => {
                                     html!{
@@ -121,12 +121,12 @@ impl Component for AdminComponent {
                                         </article>
                                     }
                                 }
-                                AdminRoute::Contributors => html!{<ContributorsComponent current_user = &self.props.current_user />},
+                                AdminRoute::Contributors => html!{<ContributorsComponent current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::Contributor(id) => html!{<ContributorComponent contributor_id = id />},
                                 AdminRoute::NewContributor => html!{<NewContributorComponent/>},
-                                AdminRoute::Serieses => html!{<SeriesesComponent current_user = &self.props.current_user />},
-                                AdminRoute::NewSeries => html!{<NewSeriesComponent current_user = &self.props.current_user />},
-                                AdminRoute::Series(id) => html!{<SeriesComponent series_id = id, current_user = &self.props.current_user />},
+                                AdminRoute::Serieses => html!{<SeriesesComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::NewSeries => html!{<NewSeriesComponent current_user = self.props.current_user.as_ref().unwrap() />},
+                                AdminRoute::Series(id) => html!{<SeriesComponent series_id = id, current_user = self.props.current_user.as_ref().unwrap() />},
                             }
                         }
                         </div>

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -96,7 +96,7 @@ impl Component for AdminComponent {
                         <div class="container">
                         {
                             match &self.props.route {
-                                AdminRoute::Dashboard => html!{<DashboardComponent/>},
+                                AdminRoute::Dashboard => html!{<DashboardComponent current_user = &self.props.current_user />},
                                 AdminRoute::Works => html!{<WorksComponent/>},
                                 AdminRoute::Work(id) => html!{<WorkComponent work_id = id />},
                                 AdminRoute::NewWork => html!{<NewWorkComponent/>},

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -96,6 +96,7 @@ impl Component for AdminComponent {
                         <div class="container">
                         {
                             match &self.props.route {
+                                AdminRoute::Admin => html!{<DashboardComponent current_user = &self.props.current_user />},
                                 AdminRoute::Dashboard => html!{<DashboardComponent current_user = &self.props.current_user />},
                                 AdminRoute::Works => html!{<WorksComponent/>},
                                 AdminRoute::Work(id) => html!{<WorkComponent work_id = id />},
@@ -126,7 +127,6 @@ impl Component for AdminComponent {
                                 AdminRoute::Serieses => html!{<SeriesesComponent/>},
                                 AdminRoute::NewSeries => html!{<NewSeriesComponent/>},
                                 AdminRoute::Series(id) => html!{<SeriesComponent series_id = id />},
-                                AdminRoute::Admin => html!{<DashboardComponent current_user = &self.props.current_user />},
                             }
                         }
                         </div>

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -98,19 +98,19 @@ impl Component for AdminComponent {
                             match &self.props.route {
                                 AdminRoute::Admin => html!{<DashboardComponent current_user = &self.props.current_user />},
                                 AdminRoute::Dashboard => html!{<DashboardComponent current_user = &self.props.current_user />},
-                                AdminRoute::Works => html!{<WorksComponent/>},
+                                AdminRoute::Works => html!{<WorksComponent current_user = &self.props.current_user />},
                                 AdminRoute::Work(id) => html!{<WorkComponent work_id = id />},
                                 AdminRoute::NewWork => html!{<NewWorkComponent/>},
-                                AdminRoute::Publishers => html!{<PublishersComponent/>},
+                                AdminRoute::Publishers => html!{<PublishersComponent current_user = &self.props.current_user />},
                                 AdminRoute::Publisher(id) => html!{<PublisherComponent publisher_id = id />},
                                 AdminRoute::NewPublisher => html!{<NewPublisherComponent/>},
-                                AdminRoute::Imprints => html!{<ImprintsComponent/>},
+                                AdminRoute::Imprints => html!{<ImprintsComponent current_user = &self.props.current_user />},
                                 AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id />},
                                 AdminRoute::NewImprint => html!{<NewImprintComponent/>},
                                 AdminRoute::Funders => html!{<FundersComponent/>},
                                 AdminRoute::Funder(id) => html!{<FunderComponent funder_id = id />},
                                 AdminRoute::NewFunder => html!{<NewFunderComponent/>},
-                                AdminRoute::Publications => html!{<PublicationsComponent/>},
+                                AdminRoute::Publications => html!{<PublicationsComponent current_user = &self.props.current_user />},
                                 AdminRoute::Publication(id) => html!{<PublicationComponent publication_id = id />},
                                 AdminRoute::NewPublication => {
                                     html!{
@@ -124,7 +124,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Contributors => html!{<ContributorsComponent/>},
                                 AdminRoute::Contributor(id) => html!{<ContributorComponent contributor_id = id />},
                                 AdminRoute::NewContributor => html!{<NewContributorComponent/>},
-                                AdminRoute::Serieses => html!{<SeriesesComponent/>},
+                                AdminRoute::Serieses => html!{<SeriesesComponent current_user = &self.props.current_user />},
                                 AdminRoute::NewSeries => html!{<NewSeriesComponent/>},
                                 AdminRoute::Series(id) => html!{<SeriesComponent series_id = id />},
                             }

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -99,7 +99,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Admin => html!{<DashboardComponent current_user = &self.props.current_user />},
                                 AdminRoute::Dashboard => html!{<DashboardComponent current_user = &self.props.current_user />},
                                 AdminRoute::Works => html!{<WorksComponent current_user = &self.props.current_user />},
-                                AdminRoute::Work(id) => html!{<WorkComponent work_id = id />},
+                                AdminRoute::Work(id) => html!{<WorkComponent work_id = id, current_user = &self.props.current_user />},
                                 AdminRoute::NewWork => html!{<NewWorkComponent/>},
                                 AdminRoute::Publishers => html!{<PublishersComponent current_user = &self.props.current_user />},
                                 AdminRoute::Publisher(id) => html!{<PublisherComponent publisher_id = id />},

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -105,7 +105,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Publisher(id) => html!{<PublisherComponent publisher_id = id />},
                                 AdminRoute::NewPublisher => html!{<NewPublisherComponent/>},
                                 AdminRoute::Imprints => html!{<ImprintsComponent current_user = &self.props.current_user />},
-                                AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id />},
+                                AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id, current_user = &self.props.current_user />},
                                 AdminRoute::NewImprint => html!{<NewImprintComponent/>},
                                 AdminRoute::Funders => html!{<FundersComponent/>},
                                 AdminRoute::Funder(id) => html!{<FunderComponent funder_id = id />},

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -107,7 +107,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Imprints => html!{<ImprintsComponent current_user = &self.props.current_user />},
                                 AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id, current_user = &self.props.current_user />},
                                 AdminRoute::NewImprint => html!{<NewImprintComponent current_user = &self.props.current_user />},
-                                AdminRoute::Funders => html!{<FundersComponent/>},
+                                AdminRoute::Funders => html!{<FundersComponent current_user = &self.props.current_user />},
                                 AdminRoute::Funder(id) => html!{<FunderComponent funder_id = id />},
                                 AdminRoute::NewFunder => html!{<NewFunderComponent/>},
                                 AdminRoute::Publications => html!{<PublicationsComponent current_user = &self.props.current_user />},
@@ -121,7 +121,7 @@ impl Component for AdminComponent {
                                         </article>
                                     }
                                 }
-                                AdminRoute::Contributors => html!{<ContributorsComponent/>},
+                                AdminRoute::Contributors => html!{<ContributorsComponent current_user = &self.props.current_user />},
                                 AdminRoute::Contributor(id) => html!{<ContributorComponent contributor_id = id />},
                                 AdminRoute::NewContributor => html!{<NewContributorComponent/>},
                                 AdminRoute::Serieses => html!{<SeriesesComponent current_user = &self.props.current_user />},

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -106,7 +106,7 @@ impl Component for AdminComponent {
                                 AdminRoute::NewPublisher => html!{<NewPublisherComponent/>},
                                 AdminRoute::Imprints => html!{<ImprintsComponent current_user = &self.props.current_user />},
                                 AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id, current_user = &self.props.current_user />},
-                                AdminRoute::NewImprint => html!{<NewImprintComponent/>},
+                                AdminRoute::NewImprint => html!{<NewImprintComponent current_user = &self.props.current_user />},
                                 AdminRoute::Funders => html!{<FundersComponent/>},
                                 AdminRoute::Funder(id) => html!{<FunderComponent funder_id = id />},
                                 AdminRoute::NewFunder => html!{<NewFunderComponent/>},

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -126,7 +126,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Serieses => html!{<SeriesesComponent/>},
                                 AdminRoute::NewSeries => html!{<NewSeriesComponent/>},
                                 AdminRoute::Series(id) => html!{<SeriesComponent series_id = id />},
-                                AdminRoute::Admin => html!{<DashboardComponent/>},
+                                AdminRoute::Admin => html!{<DashboardComponent current_user = &self.props.current_user />},
                             }
                         }
                         </div>

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -153,7 +153,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Work(id) => html!{<WorkComponent work_id = id, current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::NewWork => html!{<NewWorkComponent current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::Publishers => html!{<PublishersComponent current_user = self.props.current_user.as_ref().unwrap() />},
-                                AdminRoute::Publisher(id) => html!{<PublisherComponent publisher_id = id />},
+                                AdminRoute::Publisher(id) => html!{<PublisherComponent publisher_id = id, current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::NewPublisher => html!{<NewPublisherComponent/>},
                                 AdminRoute::Imprints => html!{<ImprintsComponent current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::Imprint(id) => html!{<ImprintComponent imprint_id = id, current_user = self.props.current_user.as_ref().unwrap() />},

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -125,8 +125,8 @@ impl Component for AdminComponent {
                                 AdminRoute::Contributor(id) => html!{<ContributorComponent contributor_id = id />},
                                 AdminRoute::NewContributor => html!{<NewContributorComponent/>},
                                 AdminRoute::Serieses => html!{<SeriesesComponent current_user = &self.props.current_user />},
-                                AdminRoute::NewSeries => html!{<NewSeriesComponent/>},
-                                AdminRoute::Series(id) => html!{<SeriesComponent series_id = id />},
+                                AdminRoute::NewSeries => html!{<NewSeriesComponent current_user = &self.props.current_user />},
+                                AdminRoute::Series(id) => html!{<SeriesComponent series_id = id, current_user = &self.props.current_user />},
                             }
                         }
                         </div>

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -100,7 +100,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Dashboard => html!{<DashboardComponent current_user = &self.props.current_user />},
                                 AdminRoute::Works => html!{<WorksComponent current_user = &self.props.current_user />},
                                 AdminRoute::Work(id) => html!{<WorkComponent work_id = id, current_user = &self.props.current_user />},
-                                AdminRoute::NewWork => html!{<NewWorkComponent/>},
+                                AdminRoute::NewWork => html!{<NewWorkComponent current_user = &self.props.current_user />},
                                 AdminRoute::Publishers => html!{<PublishersComponent current_user = &self.props.current_user />},
                                 AdminRoute::Publisher(id) => html!{<PublisherComponent publisher_id = id />},
                                 AdminRoute::NewPublisher => html!{<NewPublisherComponent/>},

--- a/thoth-app/src/component/admin.rs
+++ b/thoth-app/src/component/admin.rs
@@ -162,7 +162,7 @@ impl Component for AdminComponent {
                                 AdminRoute::Funder(id) => html!{<FunderComponent funder_id = id />},
                                 AdminRoute::NewFunder => html!{<NewFunderComponent/>},
                                 AdminRoute::Publications => html!{<PublicationsComponent current_user = self.props.current_user.as_ref().unwrap() />},
-                                AdminRoute::Publication(id) => html!{<PublicationComponent publication_id = id />},
+                                AdminRoute::Publication(id) => html!{<PublicationComponent publication_id = id, current_user = self.props.current_user.as_ref().unwrap() />},
                                 AdminRoute::NewPublication => {
                                     html!{
                                         <article class="message is-info">

--- a/thoth-app/src/component/catalogue.rs
+++ b/thoth-app/src/component/catalogue.rs
@@ -99,6 +99,8 @@ impl Component for CatalogueComponent {
                         limit: Some(self.limit),
                         offset: Some(self.offset),
                         filter: Some(filter),
+                        // Catalogue is public so results should never be filtered by logged-in user
+                        publishers: None,
                     },
                     ..Default::default()
                 };

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -39,16 +39,11 @@ impl Component for DashboardComponent {
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
         let mut publishers = None;
         if let Some(account) = props.current_user {
-            if !account.resource_access.is_superuser {
-                publishers = Some(
-                    account
-                        .resource_access
-                        .linked_publishers
-                        .iter()
-                        .map(|publisher| publisher.publisher_id.to_string())
-                        .collect(),
-                );
-            }
+            publishers = account
+                .resource_access
+                .restricted_to()
+                .map(|vec| vec.into_iter().map(|id| id.to_string())
+                .collect());
         }
         let body = StatsRequestBody {
             variables: Variables { publishers },

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -29,7 +29,6 @@ pub enum Msg {
 }
 #[derive(Clone, Properties)]
 pub struct Props {
-    #[prop_or_default]
     pub current_user: Option<AccountDetails>,
 }
 
@@ -50,19 +49,14 @@ impl Component for DashboardComponent {
             }
         }
         let body = StatsRequestBody {
-            variables: Variables {
-                publishers: publishers,
-            },
+            variables: Variables { publishers },
             ..Default::default()
         };
         let request = StatsRequest { body };
         let get_stats = Fetch::new(request);
         link.send_message(Msg::GetStats);
 
-        DashboardComponent {
-            get_stats,
-            link,
-        }
+        DashboardComponent { get_stats, link }
     }
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -37,15 +37,17 @@ impl Component for DashboardComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let mut publishers = vec![];
+        let mut publishers = None;
         if let Some(account) = props.current_user {
             if !account.resource_access.is_superuser {
-                publishers = account
-                    .resource_access
-                    .linked_publishers
-                    .iter()
-                    .map(|publisher| publisher.publisher_id.to_string())
-                    .collect();
+                publishers = Some(
+                    account
+                        .resource_access
+                        .linked_publishers
+                        .iter()
+                        .map(|publisher| publisher.publisher_id.to_string())
+                        .collect(),
+                );
             }
         }
         let body = StatsRequestBody {

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -73,8 +73,12 @@ impl Component for DashboardComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        let old_permissions = self.props.current_user.resource_access.clone();
         self.props = props;
-        true
+        if !(old_permissions == self.props.current_user.resource_access) {
+            self.link.send_message(Msg::GetStats);
+        }
+        false
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -19,7 +19,6 @@ use crate::route::AdminRoute;
 use crate::route::AppRoute;
 
 pub struct DashboardComponent {
-    props: Props,
     get_stats: FetchStats,
     link: ComponentLink<Self>,
 }
@@ -39,9 +38,20 @@ impl Component for DashboardComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        let mut publishers = vec![];
+        if let Some(account) = props.current_user {
+            if !account.resource_access.is_superuser {
+                publishers = account
+                    .resource_access
+                    .linked_publishers
+                    .iter()
+                    .map(|publisher| publisher.publisher_id.to_string())
+                    .collect();
+            }
+        }
         let body = StatsRequestBody {
             variables: Variables {
-
+                publishers: publishers,
             },
             ..Default::default()
         };
@@ -50,7 +60,6 @@ impl Component for DashboardComponent {
         link.send_message(Msg::GetStats);
 
         DashboardComponent {
-            props,
             get_stats,
             link,
         }

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -73,9 +73,10 @@ impl Component for DashboardComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             self.link.send_message(Msg::GetStats);
         }
         false

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -39,11 +39,7 @@ impl Component for DashboardComponent {
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
         let mut publishers = None;
         if let Some(account) = props.current_user {
-            publishers = account
-                .resource_access
-                .restricted_to()
-                .map(|vec| vec.into_iter().map(|id| id.to_string())
-                .collect());
+            publishers = account.resource_access.restricted_to();
         }
         let body = StatsRequestBody {
             variables: Variables { publishers },

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -1,7 +1,9 @@
+use thoth_api::account::model::AccountDetails;
 use yew::html;
 use yew::prelude::*;
 use yew::ComponentLink;
 use yew_router::prelude::RouterAnchor;
+use yewtil::fetch::Fetch;
 use yewtil::fetch::FetchAction;
 use yewtil::fetch::FetchState;
 use yewtil::future::LinkFuture;
@@ -10,10 +12,14 @@ use crate::component::utils::Loader;
 use crate::component::utils::Reloader;
 use crate::models::stats::stats_query::FetchActionStats;
 use crate::models::stats::stats_query::FetchStats;
+use crate::models::stats::stats_query::StatsRequest;
+use crate::models::stats::stats_query::StatsRequestBody;
+use crate::models::stats::stats_query::Variables;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
 
 pub struct DashboardComponent {
+    props: Props,
     get_stats: FetchStats,
     link: ComponentLink<Self>,
 }
@@ -22,16 +28,30 @@ pub enum Msg {
     SetStatsFetchState(FetchActionStats),
     GetStats,
 }
+#[derive(Clone, Properties)]
+pub struct Props {
+    #[prop_or_default]
+    pub current_user: Option<AccountDetails>,
+}
 
 impl Component for DashboardComponent {
     type Message = Msg;
-    type Properties = ();
+    type Properties = Props;
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        let body = StatsRequestBody {
+            variables: Variables {
+
+            },
+            ..Default::default()
+        };
+        let request = StatsRequest { body };
+        let get_stats = Fetch::new(request);
         link.send_message(Msg::GetStats);
 
         DashboardComponent {
-            get_stats: Default::default(),
+            props,
+            get_stats,
             link,
         }
     }

--- a/thoth-app/src/component/dashboard.rs
+++ b/thoth-app/src/component/dashboard.rs
@@ -29,7 +29,7 @@ pub enum Msg {
 }
 #[derive(Clone, Properties)]
 pub struct Props {
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
 }
 
 impl Component for DashboardComponent {
@@ -37,10 +37,7 @@ impl Component for DashboardComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let mut publishers = None;
-        if let Some(account) = props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = StatsRequestBody {
             variables: Variables { publishers },
             ..Default::default()

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -81,7 +81,7 @@ pub enum Msg {
 #[derive(Clone, Properties)]
 pub struct Props {
     pub imprint_id: String,
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
 }
 
 impl Component for ImprintComponent {
@@ -99,10 +99,7 @@ impl Component for ImprintComponent {
         let fetch_imprint = Fetch::new(request);
         let data: ImprintFormData = Default::default();
 
-        let mut publishers = None;
-        if let Some(account) = props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = PublishersRequestBody {
             variables: PublishersVariables {
                 publishers,

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -306,8 +306,12 @@ impl Component for ImprintComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        let old_permissions = self.props.current_user.resource_access.clone();
         self.props = props;
-        true
+        if !(old_permissions == self.props.current_user.resource_access) {
+            self.link.send_message(Msg::GetPublishers);
+        }
+        false
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -105,10 +105,8 @@ impl Component for ImprintComponent {
         }
         let body = PublishersRequestBody {
             variables: PublishersVariables {
-                limit: None,
-                offset: None,
-                filter: None,
                 publishers,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -318,9 +318,10 @@ impl Component for ImprintComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             self.link.send_message(Msg::GetPublishers);
         }
         false

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -1,3 +1,4 @@
+use thoth_api::account::model::AccountDetails;
 use yew::html;
 use yew::prelude::*;
 use yew::ComponentLink;
@@ -36,6 +37,9 @@ use crate::models::imprint::update_imprint_mutation::Variables as UpdateVariable
 use crate::models::imprint::Imprint;
 use crate::models::publisher::publishers_query::FetchActionPublishers;
 use crate::models::publisher::publishers_query::FetchPublishers;
+use crate::models::publisher::publishers_query::PublishersRequest;
+use crate::models::publisher::publishers_query::PublishersRequestBody;
+use crate::models::publisher::publishers_query::Variables as PublishersVariables;
 use crate::models::publisher::Publisher;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
@@ -77,6 +81,7 @@ pub enum Msg {
 #[derive(Clone, Properties)]
 pub struct Props {
     pub imprint_id: String,
+    pub current_user: Option<AccountDetails>,
 }
 
 impl Component for ImprintComponent {
@@ -93,7 +98,23 @@ impl Component for ImprintComponent {
         let request = ImprintRequest { body };
         let fetch_imprint = Fetch::new(request);
         let data: ImprintFormData = Default::default();
-        let fetch_publishers: FetchPublishers = Default::default();
+
+        let mut publishers = None;
+        if let Some(account) = props.current_user {
+            publishers = account.resource_access.restricted_to();
+        }
+        let body = PublishersRequestBody {
+            variables: PublishersVariables {
+                limit: None,
+                offset: None,
+                filter: None,
+                publishers,
+            },
+            ..Default::default()
+        };
+        let request = PublishersRequest { body };
+        let fetch_publishers = Fetch::new(request);
+
         let push_imprint = Default::default();
         let delete_imprint = Default::default();
         let notification_bus = NotificationBus::dispatcher();

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -155,6 +155,18 @@ impl Component for ImprintComponent {
                             Some(c) => c.to_owned(),
                             None => Default::default(),
                         };
+                        // If user doesn't have permission to edit this object, redirect to dashboard
+                        if let Some(publishers) =
+                            self.props.current_user.resource_access.restricted_to()
+                        {
+                            if !publishers
+                                .contains(&self.imprint.publisher.publisher_id.to_string())
+                            {
+                                self.router.send(RouteRequest::ChangeRoute(Route::from(
+                                    AppRoute::Admin(AdminRoute::Dashboard),
+                                )));
+                            }
+                        }
                         true
                     }
                     FetchState::Failed(_, _err) => false,

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -84,20 +84,10 @@ impl Component for IssuesFormComponent {
         let new_issue: Issue = Default::default();
         let show_add_form = false;
         let show_results = false;
+        let fetch_serieses = Default::default();
         let push_issue = Default::default();
         let delete_issue = Default::default();
         let notification_bus = NotificationBus::dispatcher();
-
-        let publishers = props.current_user.resource_access.restricted_to();
-        let body = SeriesesRequestBody {
-            variables: Variables {
-                publishers,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let request = SeriesesRequest { body };
-        let fetch_serieses = Fetch::new(request);
 
         link.send_message(Msg::GetSerieses);
 
@@ -132,6 +122,16 @@ impl Component for IssuesFormComponent {
                 true
             }
             Msg::GetSerieses => {
+                let body = SeriesesRequestBody {
+                    variables: Variables {
+                        publishers: self.props.current_user.resource_access.restricted_to(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+                let request = SeriesesRequest { body };
+                self.fetch_serieses = Fetch::new(request);
+
                 self.link
                     .send_future(self.fetch_serieses.fetch(Msg::SetSeriesesFetchState));
                 self.link
@@ -251,12 +251,11 @@ impl Component for IssuesFormComponent {
                 true
             }
             Msg::SearchSeries(value) => {
-                let publishers = self.props.current_user.resource_access.restricted_to();
                 let body = SeriesesRequestBody {
                     variables: Variables {
                         filter: Some(value),
                         limit: Some(9999),
-                        publishers,
+                        publishers: self.props.current_user.resource_access.restricted_to(),
                         ..Default::default()
                     },
                     ..Default::default()
@@ -276,6 +275,8 @@ impl Component for IssuesFormComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        // Note that with the addition of current_user to Props,
+        // this will always return True, as current_user.token will have changed
         self.props.neq_assign(props)
     }
 

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -67,7 +67,7 @@ pub enum Msg {
     DoNothing,
 }
 
-#[derive(Clone, Properties, PartialEq)]
+#[derive(Clone, Properties)]
 pub struct Props {
     pub issues: Option<Vec<Issue>>,
     pub work_id: String,
@@ -275,9 +275,12 @@ impl Component for IssuesFormComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        // Note that with the addition of current_user to Props,
-        // this will always return True, as current_user.token will have changed
-        self.props.neq_assign(props)
+        let old_permissions = self.props.current_user.resource_access.clone();
+        self.props = props;
+        if !(old_permissions == self.props.current_user.resource_access) {
+            self.link.send_message(Msg::GetSerieses);
+        }
+        false
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -275,9 +275,10 @@ impl Component for IssuesFormComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             self.link.send_message(Msg::GetSerieses);
         }
         false

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -71,7 +71,7 @@ pub enum Msg {
 pub struct Props {
     pub issues: Option<Vec<Issue>>,
     pub work_id: String,
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
     pub update_issues: Callback<Option<Vec<Issue>>>,
 }
 
@@ -88,10 +88,7 @@ impl Component for IssuesFormComponent {
         let delete_issue = Default::default();
         let notification_bus = NotificationBus::dispatcher();
 
-        let mut publishers = None;
-        if let Some(account) = &props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = SeriesesRequestBody {
             variables: Variables {
                 publishers,
@@ -254,10 +251,7 @@ impl Component for IssuesFormComponent {
                 true
             }
             Msg::SearchSeries(value) => {
-                let mut publishers = None;
-                if let Some(account) = &self.props.current_user {
-                    publishers = account.resource_access.restricted_to();
-                }
+                let publishers = self.props.current_user.resource_access.restricted_to();
                 let body = SeriesesRequestBody {
                     variables: Variables {
                         filter: Some(value),

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -14,7 +14,7 @@ macro_rules! pagination_helpers {
                     true => 1,
                     false => self.offset,
                 };
-                let limit_display = match self.limit > self.result_count {
+                let limit_display = match (self.limit + self.offset) > self.result_count {
                     true => self.result_count,
                     false => self.limit + self.offset,
                 };
@@ -26,7 +26,7 @@ macro_rules! pagination_helpers {
             }
 
             fn is_next_disabled(&self) -> bool {
-                self.limit >= self.result_count
+                self.limit + self.offset >= self.result_count
             }
 
             #[allow(dead_code)]

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -231,8 +231,12 @@ macro_rules! pagination_component {
             }
 
             fn change(&mut self, props: Self::Properties) -> ShouldRender {
+                let old_permissions = self.props.current_user.resource_access.clone();
                 self.props = props;
-                true
+                if !(old_permissions == self.props.current_user.resource_access) {
+                    self.link.send_message(Msg::PaginateData);
+                }
+                false
             }
 
             fn view(&self) -> Html {

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -231,9 +231,10 @@ macro_rules! pagination_component {
             }
 
             fn change(&mut self, props: Self::Properties) -> ShouldRender {
-                let old_permissions = self.props.current_user.resource_access.clone();
+                let updated_permissions =
+                    self.props.current_user.resource_access != props.current_user.resource_access;
                 self.props = props;
-                if !(old_permissions == self.props.current_user.resource_access) {
+                if updated_permissions {
                     self.link.send_message(Msg::PaginateData);
                 }
                 false

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -129,8 +129,7 @@ macro_rules! pagination_component {
 
         #[derive(Clone, Properties)]
         pub struct Props {
-            #[prop_or_default]
-            pub current_user: Option<AccountDetails>,
+            pub current_user: AccountDetails,
         }
 
         impl Component for $component {
@@ -147,11 +146,7 @@ macro_rules! pagination_component {
                 let data = Default::default();
                 let fetch_data = Default::default();
                 let table_headers = $table_headers;
-
-                let mut publishers = None;
-                if let Some(account) = props.current_user {
-                    publishers = account.resource_access.restricted_to();
-                }
+                let publishers = props.current_user.resource_access.restricted_to();
 
                 link.send_message(Msg::PaginateData);
 

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -112,7 +112,7 @@ macro_rules! pagination_component {
             fetch_data: $fetch_data,
             link: ComponentLink<Self>,
             router: RouteAgentDispatcher<()>,
-            publishers: Option<Vec<String>>,
+            props: Props,
         }
 
         pagination_helpers! {$component, $pagination_text, $search_text}
@@ -146,7 +146,6 @@ macro_rules! pagination_component {
                 let data = Default::default();
                 let fetch_data = Default::default();
                 let table_headers = $table_headers;
-                let publishers = props.current_user.resource_access.restricted_to();
 
                 link.send_message(Msg::PaginateData);
 
@@ -161,7 +160,7 @@ macro_rules! pagination_component {
                     fetch_data,
                     link,
                     router,
-                    publishers,
+                    props,
                 }
             }
 
@@ -193,7 +192,7 @@ macro_rules! pagination_component {
                                 limit: Some(self.limit),
                                 offset: Some(self.offset),
                                 filter: Some(filter),
-                                publishers: self.publishers.clone(),
+                                publishers: self.props.current_user.resource_access.restricted_to(),
                             },
                             ..Default::default()
                         };
@@ -231,8 +230,9 @@ macro_rules! pagination_component {
                 }
             }
 
-            fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-                false
+            fn change(&mut self, props: Self::Properties) -> ShouldRender {
+                self.props = props;
+                true
             }
 
             fn view(&self) -> Html {

--- a/thoth-app/src/component/new_imprint.rs
+++ b/thoth-app/src/component/new_imprint.rs
@@ -43,6 +43,7 @@ pub struct NewImprintComponent {
     link: ComponentLink<Self>,
     router: RouteAgentDispatcher<()>,
     notification_bus: NotificationDispatcher,
+    props: Props,
 }
 
 #[derive(Default)]
@@ -76,17 +77,7 @@ impl Component for NewImprintComponent {
         let imprint: Imprint = Default::default();
         let publisher_id: String = Default::default();
         let data: ImprintFormData = Default::default();
-
-        let publishers = props.current_user.resource_access.restricted_to();
-        let body = PublishersRequestBody {
-            variables: PublishersVariables {
-                publishers,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let request = PublishersRequest { body };
-        let fetch_publishers = Fetch::new(request);
+        let fetch_publishers: FetchPublishers = Default::default();
 
         link.send_message(Msg::GetPublishers);
 
@@ -99,6 +90,7 @@ impl Component for NewImprintComponent {
             link,
             router,
             notification_bus,
+            props,
         }
     }
 
@@ -115,6 +107,16 @@ impl Component for NewImprintComponent {
                 true
             }
             Msg::GetPublishers => {
+                let body = PublishersRequestBody {
+                    variables: PublishersVariables {
+                        publishers: self.props.current_user.resource_access.restricted_to(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+                let request = PublishersRequest { body };
+                self.fetch_publishers = Fetch::new(request);
+
                 self.link
                     .send_future(self.fetch_publishers.fetch(Msg::SetPublishersFetchState));
                 self.link
@@ -191,8 +193,9 @@ impl Component for NewImprintComponent {
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-        false
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props = props;
+        true
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/new_imprint.rs
+++ b/thoth-app/src/component/new_imprint.rs
@@ -62,7 +62,7 @@ pub enum Msg {
 }
 #[derive(Clone, Properties)]
 pub struct Props {
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
 }
 
 impl Component for NewImprintComponent {
@@ -77,10 +77,7 @@ impl Component for NewImprintComponent {
         let publisher_id: String = Default::default();
         let data: ImprintFormData = Default::default();
 
-        let mut publishers = None;
-        if let Some(account) = props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = PublishersRequestBody {
             variables: PublishersVariables {
                 publishers,

--- a/thoth-app/src/component/new_imprint.rs
+++ b/thoth-app/src/component/new_imprint.rs
@@ -194,8 +194,12 @@ impl Component for NewImprintComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        let old_permissions = self.props.current_user.resource_access.clone();
         self.props = props;
-        true
+        if !(old_permissions == self.props.current_user.resource_access) {
+            self.link.send_message(Msg::GetPublishers);
+        }
+        false
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/new_imprint.rs
+++ b/thoth-app/src/component/new_imprint.rs
@@ -194,9 +194,10 @@ impl Component for NewImprintComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             self.link.send_message(Msg::GetPublishers);
         }
         false

--- a/thoth-app/src/component/new_imprint.rs
+++ b/thoth-app/src/component/new_imprint.rs
@@ -83,10 +83,8 @@ impl Component for NewImprintComponent {
         }
         let body = PublishersRequestBody {
             variables: PublishersVariables {
-                limit: None,
-                offset: None,
-                filter: None,
                 publishers,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/thoth-app/src/component/new_series.rs
+++ b/thoth-app/src/component/new_series.rs
@@ -236,9 +236,10 @@ impl Component for NewSeriesComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             self.link.send_message(Msg::GetImprints);
         }
         false

--- a/thoth-app/src/component/new_series.rs
+++ b/thoth-app/src/component/new_series.rs
@@ -236,8 +236,12 @@ impl Component for NewSeriesComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        let old_permissions = self.props.current_user.resource_access.clone();
         self.props = props;
-        true
+        if !(old_permissions == self.props.current_user.resource_access) {
+            self.link.send_message(Msg::GetImprints);
+        }
+        false
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/new_series.rs
+++ b/thoth-app/src/component/new_series.rs
@@ -74,7 +74,7 @@ pub enum Msg {
 }
 #[derive(Clone, Properties)]
 pub struct Props {
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
 }
 
 impl Component for NewSeriesComponent {
@@ -89,10 +89,7 @@ impl Component for NewSeriesComponent {
         let fetch_series_types: FetchSeriesTypes = Default::default();
         let router = RouteAgentDispatcher::new();
 
-        let mut publishers = None;
-        if let Some(account) = props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = ImprintsRequestBody {
             variables: ImprintsVariables {
                 publishers,

--- a/thoth-app/src/component/new_series.rs
+++ b/thoth-app/src/component/new_series.rs
@@ -95,10 +95,8 @@ impl Component for NewSeriesComponent {
         }
         let body = ImprintsRequestBody {
             variables: ImprintsVariables {
-                limit: None,
-                offset: None,
-                filter: None,
                 publishers,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/thoth-app/src/component/new_work.rs
+++ b/thoth-app/src/component/new_work.rs
@@ -485,9 +485,10 @@ impl Component for NewWorkComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             self.link.send_message(Msg::GetImprints);
         }
         false

--- a/thoth-app/src/component/new_work.rs
+++ b/thoth-app/src/component/new_work.rs
@@ -110,7 +110,7 @@ pub enum Msg {
 }
 #[derive(Clone, Properties)]
 pub struct Props {
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
 }
 
 impl Component for NewWorkComponent {
@@ -127,10 +127,7 @@ impl Component for NewWorkComponent {
         let fetch_work_types: FetchWorkTypes = Default::default();
         let fetch_work_statuses: FetchWorkStatuses = Default::default();
 
-        let mut publishers = None;
-        if let Some(account) = props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = ImprintsRequestBody {
             variables: ImprintsVariables {
                 publishers,

--- a/thoth-app/src/component/new_work.rs
+++ b/thoth-app/src/component/new_work.rs
@@ -485,8 +485,12 @@ impl Component for NewWorkComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        let old_permissions = self.props.current_user.resource_access.clone();
         self.props = props;
-        true
+        if !(old_permissions == self.props.current_user.resource_access) {
+            self.link.send_message(Msg::GetImprints);
+        }
+        false
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/series.rs
+++ b/thoth-app/src/component/series.rs
@@ -351,9 +351,10 @@ impl Component for SeriesComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             self.link.send_message(Msg::GetImprints);
         }
         false

--- a/thoth-app/src/component/series.rs
+++ b/thoth-app/src/component/series.rs
@@ -95,7 +95,7 @@ pub enum Msg {
 #[derive(Clone, Properties)]
 pub struct Props {
     pub series_id: String,
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
 }
 
 impl Component for SeriesComponent {
@@ -119,10 +119,7 @@ impl Component for SeriesComponent {
         let fetch_series_types: FetchSeriesTypes = Default::default();
         let router = RouteAgentDispatcher::new();
 
-        let mut publishers = None;
-        if let Some(account) = props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = ImprintsRequestBody {
             variables: ImprintsVariables {
                 publishers,

--- a/thoth-app/src/component/series.rs
+++ b/thoth-app/src/component/series.rs
@@ -189,6 +189,18 @@ impl Component for SeriesComponent {
                             Some(c) => c.to_owned(),
                             None => Default::default(),
                         };
+                        // If user doesn't have permission to edit this object, redirect to dashboard
+                        if let Some(publishers) =
+                            self.props.current_user.resource_access.restricted_to()
+                        {
+                            if !publishers
+                                .contains(&self.series.imprint.publisher.publisher_id.to_string())
+                            {
+                                self.router.send(RouteRequest::ChangeRoute(Route::from(
+                                    AppRoute::Admin(AdminRoute::Dashboard),
+                                )));
+                            }
+                        }
                         true
                     }
                     FetchState::Failed(_, _err) => false,

--- a/thoth-app/src/component/series.rs
+++ b/thoth-app/src/component/series.rs
@@ -339,8 +339,12 @@ impl Component for SeriesComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        let old_permissions = self.props.current_user.resource_access.clone();
         self.props = props;
-        true
+        if !(old_permissions == self.props.current_user.resource_access) {
+            self.link.send_message(Msg::GetImprints);
+        }
+        false
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/series.rs
+++ b/thoth-app/src/component/series.rs
@@ -125,10 +125,8 @@ impl Component for SeriesComponent {
         }
         let body = ImprintsRequestBody {
             variables: ImprintsVariables {
-                limit: None,
-                offset: None,
-                filter: None,
                 publishers,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -538,7 +538,13 @@ impl Component for WorkComponent {
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        let old_permissions = self.props.current_user.resource_access.clone();
+        self.props = props;
+        if !(old_permissions == self.props.current_user.resource_access) {
+            // Required in order to retrieve updated list of imprints for dropdown
+            self.link.send_message(Msg::GetWork);
+        }
         false
     }
 

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -176,6 +176,19 @@ impl Component for WorkComponent {
                         self.data.imprints = body.data.imprints.to_owned();
                         self.data.work_types = body.data.work_types.enum_values.to_owned();
                         self.data.work_statuses = body.data.work_statuses.enum_values.to_owned();
+
+                        // If user doesn't have permission to edit this object, redirect to dashboard
+                        if let Some(publishers) =
+                            self.props.current_user.resource_access.restricted_to()
+                        {
+                            if !publishers
+                                .contains(&self.work.imprint.publisher.publisher_id.to_string())
+                            {
+                                self.router.send(RouteRequest::ChangeRoute(Route::from(
+                                    AppRoute::Admin(AdminRoute::Dashboard),
+                                )));
+                            }
+                        }
                         true
                     }
                     FetchState::Failed(_, _err) => false,

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -552,9 +552,10 @@ impl Component for WorkComponent {
     }
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        let old_permissions = self.props.current_user.resource_access.clone();
+        let updated_permissions =
+            self.props.current_user.resource_access != props.current_user.resource_access;
         self.props = props;
-        if !(old_permissions == self.props.current_user.resource_access) {
+        if updated_permissions {
             // Required in order to retrieve updated list of imprints for dropdown
             self.link.send_message(Msg::GetWork);
         }

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use thoth_api::account::model::AccountDetails;
 use thoth_api::work::model::WorkStatus;
 use thoth_api::work::model::WorkType;
 use yew::html;
@@ -128,6 +129,7 @@ pub enum Msg {
 #[derive(Clone, Properties)]
 pub struct Props {
     pub work_id: String,
+    pub current_user: Option<AccountDetails>,
 }
 
 impl Component for WorkComponent {
@@ -135,9 +137,14 @@ impl Component for WorkComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        let mut publishers = None;
+        if let Some(account) = props.current_user {
+            publishers = account.resource_access.restricted_to();
+        }
         let body = WorkRequestBody {
             variables: Variables {
                 work_id: Some(props.work_id),
+                publishers,
             },
             ..Default::default()
         };

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -72,6 +72,7 @@ pub struct WorkComponent {
     link: ComponentLink<Self>,
     router: RouteAgentDispatcher<()>,
     notification_bus: NotificationDispatcher,
+    current_user: Option<AccountDetails>,
 }
 
 #[derive(Default)]
@@ -138,7 +139,7 @@ impl Component for WorkComponent {
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
         let mut publishers = None;
-        if let Some(account) = props.current_user {
+        if let Some(account) = &props.current_user {
             publishers = account.resource_access.restricted_to();
         }
         let body = WorkRequestBody {
@@ -156,6 +157,7 @@ impl Component for WorkComponent {
         let work: Work = Default::default();
         let data: WorkFormData = Default::default();
         let router = RouteAgentDispatcher::new();
+        let current_user = props.current_user;
 
         link.send_message(Msg::GetWork);
 
@@ -168,6 +170,7 @@ impl Component for WorkComponent {
             link,
             router,
             notification_bus,
+            current_user,
         }
     }
 
@@ -816,6 +819,7 @@ impl Component for WorkComponent {
                         <IssuesFormComponent
                             issues=&self.work.issues
                             work_id=&self.work.work_id
+                            current_user=&self.current_user
                             update_issues=self.link.callback(|i: Option<Vec<Issue>>| Msg::UpdateIssues(i))
                         />
                         <FundingsFormComponent

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -72,7 +72,7 @@ pub struct WorkComponent {
     link: ComponentLink<Self>,
     router: RouteAgentDispatcher<()>,
     notification_bus: NotificationDispatcher,
-    current_user: Option<AccountDetails>,
+    current_user: AccountDetails,
 }
 
 #[derive(Default)]
@@ -130,7 +130,7 @@ pub enum Msg {
 #[derive(Clone, Properties)]
 pub struct Props {
     pub work_id: String,
-    pub current_user: Option<AccountDetails>,
+    pub current_user: AccountDetails,
 }
 
 impl Component for WorkComponent {
@@ -138,10 +138,7 @@ impl Component for WorkComponent {
     type Properties = Props;
 
     fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let mut publishers = None;
-        if let Some(account) = &props.current_user {
-            publishers = account.resource_access.restricted_to();
-        }
+        let publishers = props.current_user.resource_access.restricted_to();
         let body = WorkRequestBody {
             variables: Variables {
                 work_id: Some(props.work_id),

--- a/thoth-app/src/models/contributor/contributors_query.rs
+++ b/thoth-app/src/models/contributor/contributors_query.rs
@@ -34,6 +34,8 @@ pub struct Variables {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
     pub filter: Option<String>,
+    // Unused, but required by pagination_component macro
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/funder/funders_query.rs
+++ b/thoth-app/src/models/funder/funders_query.rs
@@ -31,6 +31,8 @@ pub struct Variables {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
     pub filter: Option<String>,
+    // Unused, but required by pagination_component macro
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/imprint/imprints_query.rs
+++ b/thoth-app/src/models/imprint/imprints_query.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 use super::Imprint;
 
 const IMPRINTS_QUERY: &str = "
-    query ImprintsQuery($limit: Int, $offset: Int, $filter: String) {
-        imprints(limit: $limit, offset: $offset, filter: $filter) {
+    query ImprintsQuery($limit: Int, $offset: Int, $filter: String, $publishers: [Uuid!]) {
+        imprints(limit: $limit, offset: $offset, filter: $filter, publishers: $publishers) {
             imprintId
             imprintName
             imprintUrl
@@ -16,7 +16,7 @@ const IMPRINTS_QUERY: &str = "
                 publisherUrl
             }
         }
-        imprintCount(filter: $filter)
+        imprintCount(filter: $filter, publishers: $publishers)
     }
 ";
 
@@ -37,6 +37,7 @@ pub struct Variables {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
     pub filter: Option<String>,
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/publication/mod.rs
+++ b/thoth-app/src/models/publication/mod.rs
@@ -19,6 +19,25 @@ pub struct Publication {
     pub isbn: Option<String>,
     pub publication_url: Option<String>,
     pub prices: Option<Vec<Price>>,
+    pub work: SlimWork,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SlimWork {
+    pub imprint: SlimImprint,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SlimImprint {
+    pub publisher: SlimPublisher,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SlimPublisher {
+    pub publisher_id: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -75,6 +94,7 @@ impl Default for Publication {
             isbn: None,
             publication_url: None,
             prices: Default::default(),
+            work: Default::default(),
         }
     }
 }

--- a/thoth-app/src/models/publication/publication_query.rs
+++ b/thoth-app/src/models/publication/publication_query.rs
@@ -17,6 +17,13 @@ pub const PUBLICATION_QUERY: &str = "
                 currencyCode
                 unitPrice
             }
+            work {
+                imprint {
+                    publisher {
+                        publisherId
+                    }
+                }
+            }
         }
     }
 ";

--- a/thoth-app/src/models/publication/publications_query.rs
+++ b/thoth-app/src/models/publication/publications_query.rs
@@ -5,8 +5,8 @@ use thoth_api::publication::model::PublicationType;
 use super::super::work::Work;
 
 pub const PUBLICATIONS_QUERY: &str = "
-    query PublicationsQuery($limit: Int, $offset: Int, $filter: String) {
-        publications(limit: $limit, offset: $offset, filter: $filter) {
+    query PublicationsQuery($limit: Int, $offset: Int, $filter: String, $publishers: [Uuid!]) {
+        publications(limit: $limit, offset: $offset, filter: $filter, publishers: $publishers) {
             publicationId
             publicationType
             workId
@@ -33,7 +33,7 @@ pub const PUBLICATIONS_QUERY: &str = "
                 }
             }
         }
-        publicationCount(filter: $filter)
+        publicationCount(filter: $filter, publishers: $publishers)
     }
 ";
 
@@ -54,6 +54,7 @@ pub struct Variables {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
     pub filter: Option<String>,
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/publisher/publishers_query.rs
+++ b/thoth-app/src/models/publisher/publishers_query.rs
@@ -4,14 +4,14 @@ use serde::Serialize;
 use super::Publisher;
 
 const PUBLISHERS_QUERY: &str = "
-    query PublishersQuery($limit: Int, $offset: Int, $filter: String) {
-        publishers(limit: $limit, offset: $offset, filter: $filter) {
+    query PublishersQuery($limit: Int, $offset: Int, $filter: String, $publishers: [Uuid!]) {
+        publishers(limit: $limit, offset: $offset, filter: $filter, publishers: $publishers) {
             publisherId
             publisherName
             publisherShortname
             publisherUrl
         }
-        publisherCount(filter: $filter)
+        publisherCount(filter: $filter, publishers: $publishers)
     }
 ";
 
@@ -32,6 +32,7 @@ pub struct Variables {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
     pub filter: Option<String>,
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/series/serieses_query.rs
+++ b/thoth-app/src/models/series/serieses_query.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 use super::Series;
 
 pub const SERIESES_QUERY: &str = "
-    query SeriesesQuery($limit: Int, $offset: Int, $filter: String) {
-        serieses(limit: $limit, offset: $offset, filter: $filter) {
+    query SeriesesQuery($limit: Int, $offset: Int, $filter: String, $publishers: [Uuid!]) {
+        serieses(limit: $limit, offset: $offset, filter: $filter, publishers: $publishers) {
             seriesId
             seriesType
             seriesName
@@ -23,7 +23,7 @@ pub const SERIESES_QUERY: &str = "
                 }
             }
         }
-        seriesCount(filter: $filter)
+        seriesCount(filter: $filter, publishers: $publishers)
     }
 ";
 
@@ -44,6 +44,7 @@ pub struct Variables {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
     pub filter: Option<String>,
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/stats/stats_query.rs
+++ b/thoth-app/src/models/stats/stats_query.rs
@@ -25,7 +25,7 @@ graphql_query_builder! {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Variables {
-    pub publishers: Vec<String>,
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/stats/stats_query.rs
+++ b/thoth-app/src/models/stats/stats_query.rs
@@ -24,7 +24,9 @@ graphql_query_builder! {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-pub struct Variables {}
+pub struct Variables {
+    pub publishers: Vec<String>,
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/thoth-app/src/models/stats/stats_query.rs
+++ b/thoth-app/src/models/stats/stats_query.rs
@@ -2,13 +2,13 @@ use serde::Deserialize;
 use serde::Serialize;
 
 const STATS_QUERY: &str = "
-    {
-        workCount
-        publisherCount
-        imprintCount
-        seriesCount
+    query StatsQuery($publishers: [Uuid!]) {
+        workCount(publishers: $publishers)
+        publisherCount(publishers: $publishers)
+        imprintCount(publishers: $publishers)
+        seriesCount(publishers: $publishers)
         contributorCount
-        publicationCount
+        publicationCount(publishers: $publishers)
     }
 ";
 

--- a/thoth-app/src/models/work/work_query.rs
+++ b/thoth-app/src/models/work/work_query.rs
@@ -65,6 +65,13 @@ pub const WORK_QUERY: &str = "
                     currencyCode
                     unitPrice
                 }
+                work {
+                    imprint {
+                        publisher {
+                            publisherId
+                        }
+                    }
+                }
             }
             languages {
                 languageId

--- a/thoth-app/src/models/work/work_query.rs
+++ b/thoth-app/src/models/work/work_query.rs
@@ -7,7 +7,7 @@ use super::WorkStatusDefinition;
 use super::WorkTypeDefinition;
 
 pub const WORK_QUERY: &str = "
-    query WorkQuery($workId: Uuid!) {
+    query WorkQuery($workId: Uuid!, $publishers: [Uuid!]) {
         work(workId: $workId) {
             workId
             workType
@@ -128,7 +128,7 @@ pub const WORK_QUERY: &str = "
                 }
             }
         }
-        imprints(limit: 9999) {
+        imprints(limit: 9999, publishers: $publishers) {
             imprintId
             imprintName
             publisher {
@@ -166,6 +166,7 @@ graphql_query_builder! {
 #[serde(rename_all = "camelCase")]
 pub struct Variables {
     pub work_id: Option<String>,
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/work/works_query.rs
+++ b/thoth-app/src/models/work/works_query.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 use super::Work;
 
 pub const WORKS_QUERY: &str = "
-    query WorksQuery($limit: Int, $offset: Int, $filter: String) {
-        works(limit: $limit, offset: $offset, filter: $filter) {
+    query WorksQuery($limit: Int, $offset: Int, $filter: String, $publishers: [Uuid!]) {
+        works(limit: $limit, offset: $offset, filter: $filter, publishers: $publishers) {
             workId
             workType
             workStatus
@@ -42,7 +42,7 @@ pub const WORKS_QUERY: &str = "
                 }
             }
         }
-        workCount(filter: $filter)
+        workCount(filter: $filter, publishers: $publishers)
     }
 ";
 
@@ -63,6 +63,7 @@ pub struct Variables {
     pub limit: Option<i32>,
     pub offset: Option<i32>,
     pub filter: Option<String>,
+    pub publishers: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/string.rs
+++ b/thoth-app/src/string.rs
@@ -40,4 +40,5 @@ strings! {
     SEARCH_CONTRIBUTORS => "Search by name or ORCID",
     SEARCH_PUBLICATIONS => "Search by ISBN or URL",
     STORAGE_ERROR => "local storage is disabled",
+    PERMISSIONS_ERROR => "This account is not permitted to access any data",
 }


### PR DESCRIPTION
Fixes #162. If user only has permissions for specific publishers (i.e. is not superuser), only the objects linked to these publishers are displayed. Note that Contributors and Funders are not linked to publishers so are always all visible.

- Dashboard: only displays stats for Works, Series, Publications, Publishers and Imprints linked to user's permissions
- Catalogue pages: tables only contain Works, Series, Publications, Publishers and Imprints linked to user's permissions
- New/Edit Work pages: Imprints and Issues dropdowns only contain objects linked to user's permissions
- New/Edit Imprint pages: Publisher dropdown only contains objects linked to user's permissions
- New/Edit Series pages: Imprint dropdown only contains objects linked to user's permissions
- Edit Object pages: if user attempts to access a Work, Series, Publication, Publisher or Imprint for which they don't have permissions (e.g. by directly editing URL, or clicking links in Contributor/Funder pages), app redirects to dashboard
- Login: if user is not superuser and has no linked publishers (i.e. permission set is empty), an error is raised and no objects are visible

If user's permissions in the backend change during a session, the view will update on the next `renew` to reflect the changed permissions.

Also fixes a minor bug in paginated views where Next Page button never became disabled and display string was inaccurate (e.g. `Displaying imprints 20-40 of 23`).