### PR TITLE
Prevent app from panicking if non-numeric value is entered in Issue Ordinal box (#181)

### DIFF
--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -253,7 +253,7 @@ impl Component for IssuesFormComponent {
                 false
             }
             Msg::ChangeOrdinal(ordinal) => {
-                let ordinal = ordinal.parse::<i32>().unwrap();
+                let ordinal = ordinal.parse::<i32>().unwrap_or(0);
                 self.new_issue.issue_ordinal.neq_assign(ordinal);
                 false // otherwise we re-render the component and reset the value
             }


### PR DESCRIPTION
Fixes #181.

In future, we may want to disable the `Add Issue` button while the value is non-numeric (currently, entering a non-numeric value is caught by an API check). Also note that following this fix, if the New Issue form is re-opened after attempting to enter a non-numeric value, the Issue Ordinal box value defaults to 0.