### PR TITLE
Prevent error when creating and deleting Publications (#197)

### DIFF
--- a/thoth-app/src/models/publication/create_publication_mutation.rs
+++ b/thoth-app/src/models/publication/create_publication_mutation.rs
@@ -22,6 +22,13 @@ const CREATE_PUBLICATION_MUTATION: &str = "
             isbn
             publicationUrl
             workId
+            work {
+                imprint {
+                    publisher {
+                        publisherId
+                    }
+                }
+            }
         }
     }
 ";

--- a/thoth-app/src/models/publication/delete_publication_mutation.rs
+++ b/thoth-app/src/models/publication/delete_publication_mutation.rs
@@ -13,6 +13,13 @@ const DELETE_PUBLICATION_MUTATION: &str = "
             publicationId
             publicationType
             workId
+            work {
+                imprint {
+                    publisher {
+                        publisherId
+                    }
+                }
+            }
         }
     }
 ";


### PR DESCRIPTION
Fixes #197. Note this bug affected all publications, not just ones with no ISBN, and the error was also raised on deletion.

Updated creation and deletion queries to match changed Publication struct following #162.