### PR TITLE
Raise confirmation prompt before deleting works, publishers, imprints, contributors, series, or funders

### DIFF
--- a/thoth-app/src/component/contributions_form.rs
+++ b/thoth-app/src/component/contributions_form.rs
@@ -36,6 +36,7 @@ use crate::models::contributor::contributors_query::FetchActionContributors;
 use crate::models::contributor::contributors_query::FetchContributors;
 use crate::models::contributor::contributors_query::Variables;
 use crate::models::contributor::Contributor;
+use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_CONTRIBUTIONS;
 use crate::string::NO;
 use crate::string::REMOVE_BUTTON;
@@ -479,7 +480,7 @@ impl Component for ContributionsFormComponent {
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/contributor.rs
+++ b/thoth-app/src/component/contributor.rs
@@ -314,6 +314,7 @@ impl Component for ContributorComponent {
                                 <p class="level-item">
                                     <ConfirmDeleteComponent
                                         onclick=self.link.callback(|_| Msg::DeleteContributor)
+                                        object_name=&self.contributor.full_name
                                     />
                                 </p>
                             </div>

--- a/thoth-app/src/component/contributor.rs
+++ b/thoth-app/src/component/contributor.rs
@@ -17,6 +17,7 @@ use crate::agent::notification_bus::NotificationBus;
 use crate::agent::notification_bus::NotificationDispatcher;
 use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
+use crate::component::utils::FormConfirmDelete;
 use crate::component::utils::FormTextInput;
 use crate::component::utils::FormUrlInput;
 use crate::component::utils::Loader;
@@ -314,10 +315,6 @@ impl Component for ContributorComponent {
                     e.prevent_default();
                     Msg::ToggleConfirmDeleteDisplay(true)
                 });
-                let close_modal = self.link.callback(|e: MouseEvent| {
-                    e.prevent_default();
-                    Msg::ToggleConfirmDeleteDisplay(false)
-                });
                 html! {
                     <>
                         <nav class="level">
@@ -333,34 +330,11 @@ impl Component for ContributorComponent {
                                     </button>
                                 </p>
                             </div>
-                            <div class=self.confirm_delete_status()>
-                                <div class="modal-background" onclick=&close_modal></div>
-                                <div class="modal-card">
-                                    <header class="modal-card-head">
-                                        <p class="modal-card-title">{ "Confirm deletion" }</p>
-                                    </header>
-                                    <section class="modal-card-body">
-                                        <p>{ "Are you sure you want to delete this object?" }</p>
-                                    </section>
-                                    <footer class="modal-card-foot">
-                                        <button
-                                            class="button is-success"
-                                            onclick=self.link.callback(|e: MouseEvent| {
-                                                e.prevent_default();
-                                                Msg::DeleteContributor
-                                            })
-                                        >
-                                            { "Delete" }
-                                        </button>
-                                        <button
-                                            class="button"
-                                            onclick=&close_modal
-                                        >
-                                            { "Cancel" }
-                                        </button>
-                                    </footer>
-                                </div>
-                            </div>
+                            <FormConfirmDelete
+                                onclick=self.link.callback(|_| Msg::DeleteContributor)
+                                oncancel=self.link.callback(|_| Msg::ToggleConfirmDeleteDisplay(false))
+                                show=self.show_confirm_delete
+                            />
                         </nav>
 
                         { if !self.contributor_activity.is_empty() {
@@ -428,15 +402,6 @@ impl Component for ContributorComponent {
                 }
             }
             FetchState::Failed(_, err) => html! {&err},
-        }
-    }
-}
-
-impl ContributorComponent {
-    fn confirm_delete_status(&self) -> String {
-        match self.show_confirm_delete {
-            true => "modal is-active".to_string(),
-            false => "modal".to_string(),
         }
     }
 }

--- a/thoth-app/src/component/delete_dialogue.rs
+++ b/thoth-app/src/component/delete_dialogue.rs
@@ -1,3 +1,4 @@
+use crate::string::CANCEL_BUTTON;
 use crate::string::DELETE_BUTTON;
 use yew::html;
 use yew::prelude::*;
@@ -55,10 +56,15 @@ impl Component for ConfirmDeleteComponent {
                     { DELETE_BUTTON }
                 </button>
                 <div class=self.confirm_delete_status()>
-                    <div class="modal-background"></div>
+                    <div class="modal-background" onclick=&close_modal></div>
                     <div class="modal-card">
                         <header class="modal-card-head">
                             <p class="modal-card-title">{ "Confirm deletion" }</p>
+                            <button
+                                class="delete"
+                                aria-label="close"
+                                onclick=&close_modal
+                            ></button>
                         </header>
                         <section class="modal-card-body">
                             <p>
@@ -72,13 +78,13 @@ impl Component for ConfirmDeleteComponent {
                                 class="button is-success"
                                 onclick=&self.props.onclick
                             >
-                                { "Delete" }
+                                { DELETE_BUTTON }
                             </button>
                             <button
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/delete_dialogue.rs
+++ b/thoth-app/src/component/delete_dialogue.rs
@@ -1,0 +1,93 @@
+use crate::string::DELETE_BUTTON;
+use yew::html;
+use yew::prelude::*;
+
+pub struct ConfirmDeleteComponent {
+    props: Props,
+    link: ComponentLink<Self>,
+}
+
+#[derive(Clone, Properties)]
+pub struct Props {
+    pub onclick: Callback<MouseEvent>,
+    #[prop_or(false)]
+    pub show: bool,
+}
+
+pub enum Msg {
+    ToggleConfirmDeleteDisplay(bool),
+}
+
+impl Component for ConfirmDeleteComponent {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        ConfirmDeleteComponent { props, link }
+    }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        false
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::ToggleConfirmDeleteDisplay(value) => {
+                self.props.show = value;
+                true
+            }
+        }
+    }
+
+    fn view(&self) -> Html {
+        let open_modal = self.link.callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::ToggleConfirmDeleteDisplay(true)
+        });
+        let close_modal = self.link.callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::ToggleConfirmDeleteDisplay(false)
+        });
+        html! {
+            <>
+                <button class="button is-danger" onclick=open_modal>
+                    { DELETE_BUTTON }
+                </button>
+                <div class=self.confirm_delete_status()>
+                    <div class="modal-background"></div>
+                    <div class="modal-card">
+                        <header class="modal-card-head">
+                            <p class="modal-card-title">{ "Confirm deletion" }</p>
+                        </header>
+                        <section class="modal-card-body">
+                            <p>{ "Are you sure you want to delete this object?" }</p>
+                        </section>
+                        <footer class="modal-card-foot">
+                            <button
+                                class="button is-success"
+                                onclick=&self.props.onclick
+                            >
+                                { "Delete" }
+                            </button>
+                            <button
+                                class="button"
+                                onclick=&close_modal
+                            >
+                                { "Cancel" }
+                            </button>
+                        </footer>
+                    </div>
+                </div>
+            </>
+        }
+    }
+}
+
+impl ConfirmDeleteComponent {
+    fn confirm_delete_status(&self) -> String {
+        match self.props.show {
+            true => "modal is-active".to_string(),
+            false => "modal".to_string(),
+        }
+    }
+}

--- a/thoth-app/src/component/delete_dialogue.rs
+++ b/thoth-app/src/component/delete_dialogue.rs
@@ -10,6 +10,7 @@ pub struct ConfirmDeleteComponent {
 #[derive(Clone, Properties)]
 pub struct Props {
     pub onclick: Callback<MouseEvent>,
+    pub object_name: String,
     #[prop_or(false)]
     pub show: bool,
 }
@@ -60,7 +61,11 @@ impl Component for ConfirmDeleteComponent {
                             <p class="modal-card-title">{ "Confirm deletion" }</p>
                         </header>
                         <section class="modal-card-body">
-                            <p>{ "Are you sure you want to delete this object?" }</p>
+                            <p>
+                                { "Are you sure you want to delete " }
+                                <i>{ &self.props.object_name }</i>
+                                { "?" }
+                            </p>
                         </section>
                         <footer class="modal-card-foot">
                             <button

--- a/thoth-app/src/component/funder.rs
+++ b/thoth-app/src/component/funder.rs
@@ -17,6 +17,7 @@ use crate::agent::notification_bus::NotificationBus;
 use crate::agent::notification_bus::NotificationDispatcher;
 use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
+use crate::component::delete_dialogue::ConfirmDeleteComponent;
 use crate::component::utils::FormTextInput;
 use crate::component::utils::FormUrlInput;
 use crate::component::utils::Loader;
@@ -40,7 +41,6 @@ use crate::models::funder::update_funder_mutation::Variables as UpdateVariables;
 use crate::models::funder::Funder;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
-use crate::string::DELETE_BUTTON;
 use crate::string::SAVE_BUTTON;
 
 pub struct FunderComponent {
@@ -286,9 +286,10 @@ impl Component for FunderComponent {
                             </div>
                             <div class="level-right">
                                 <p class="level-item">
-                                    <button class="button is-danger" onclick=self.link.callback(|_| Msg::DeleteFunder)>
-                                        { DELETE_BUTTON }
-                                    </button>
+                                    <ConfirmDeleteComponent
+                                        onclick=self.link.callback(|_| Msg::DeleteFunder)
+                                        object_name=&self.funder.funder_name
+                                    />
                                 </p>
                             </div>
                         </nav>

--- a/thoth-app/src/component/fundings_form.rs
+++ b/thoth-app/src/component/fundings_form.rs
@@ -29,6 +29,7 @@ use crate::models::funding::delete_funding_mutation::PushActionDeleteFunding;
 use crate::models::funding::delete_funding_mutation::PushDeleteFunding;
 use crate::models::funding::delete_funding_mutation::Variables as DeleteVariables;
 use crate::models::funding::Funding;
+use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_FUNDINGS;
 use crate::string::REMOVE_BUTTON;
 
@@ -413,7 +414,7 @@ impl Component for FundingsFormComponent {
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -15,6 +15,7 @@ use crate::agent::notification_bus::NotificationBus;
 use crate::agent::notification_bus::NotificationDispatcher;
 use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
+use crate::component::delete_dialogue::ConfirmDeleteComponent;
 use crate::component::utils::FormPublisherSelect;
 use crate::component::utils::FormTextInput;
 use crate::component::utils::FormUrlInput;
@@ -43,7 +44,6 @@ use crate::models::publisher::publishers_query::Variables as PublishersVariables
 use crate::models::publisher::Publisher;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
-use crate::string::DELETE_BUTTON;
 use crate::string::SAVE_BUTTON;
 
 pub struct ImprintComponent {
@@ -346,9 +346,10 @@ impl Component for ImprintComponent {
                             </div>
                             <div class="level-right">
                                 <p class="level-item">
-                                    <button class="button is-danger" onclick=self.link.callback(|_| Msg::DeleteImprint)>
-                                        { DELETE_BUTTON }
-                                    </button>
+                                    <ConfirmDeleteComponent
+                                        onclick=self.link.callback(|_| Msg::DeleteImprint)
+                                        object_name=&self.imprint.imprint_name
+                                    />
                                 </p>
                             </div>
                         </nav>

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -30,6 +30,7 @@ use crate::models::series::serieses_query::SeriesesRequest;
 use crate::models::series::serieses_query::SeriesesRequestBody;
 use crate::models::series::serieses_query::Variables;
 use crate::models::series::Series;
+use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_ISSUES;
 use crate::string::REMOVE_BUTTON;
 
@@ -386,7 +387,7 @@ impl Component for IssuesFormComponent {
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/languages_form.rs
+++ b/thoth-app/src/component/languages_form.rs
@@ -34,6 +34,7 @@ use crate::models::language::language_relations_query::FetchLanguageRelations;
 use crate::models::language::Language;
 use crate::models::language::LanguageCodeValues;
 use crate::models::language::LanguageRelationValues;
+use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_LANGUAGES;
 use crate::string::NO;
 use crate::string::REMOVE_BUTTON;
@@ -368,7 +369,7 @@ impl Component for LanguagesFormComponent {
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -312,6 +312,7 @@ pub mod contributions_form;
 pub mod contributor;
 pub mod contributors;
 pub mod dashboard;
+pub mod delete_dialogue;
 pub mod funder;
 pub mod funders;
 pub mod fundings_form;

--- a/thoth-app/src/component/prices_form.rs
+++ b/thoth-app/src/component/prices_form.rs
@@ -29,6 +29,7 @@ use crate::models::price::delete_price_mutation::PushDeletePrice;
 use crate::models::price::delete_price_mutation::Variables as DeleteVariables;
 use crate::models::price::CurrencyCodeValues;
 use crate::models::price::Price;
+use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_PRICES;
 use crate::string::REMOVE_BUTTON;
 
@@ -313,7 +314,7 @@ impl Component for PricesFormComponent {
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/publications_form.rs
+++ b/thoth-app/src/component/publications_form.rs
@@ -30,6 +30,7 @@ use crate::models::publication::publication_types_query::FetchActionPublicationT
 use crate::models::publication::publication_types_query::FetchPublicationTypes;
 use crate::models::publication::Publication;
 use crate::models::publication::PublicationTypeValues;
+use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_PUBLICATIONS;
 use crate::string::REMOVE_BUTTON;
 
@@ -332,7 +333,7 @@ impl Component for PublicationsFormComponent {
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/publisher.rs
+++ b/thoth-app/src/component/publisher.rs
@@ -15,6 +15,7 @@ use crate::agent::notification_bus::NotificationBus;
 use crate::agent::notification_bus::NotificationDispatcher;
 use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
+use crate::component::delete_dialogue::ConfirmDeleteComponent;
 use crate::component::utils::FormTextInput;
 use crate::component::utils::FormUrlInput;
 use crate::component::utils::Loader;
@@ -36,7 +37,6 @@ use crate::models::publisher::update_publisher_mutation::Variables as UpdateVari
 use crate::models::publisher::Publisher;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
-use crate::string::DELETE_BUTTON;
 use crate::string::SAVE_BUTTON;
 
 pub struct PublisherComponent {
@@ -286,9 +286,10 @@ impl Component for PublisherComponent {
                             </div>
                             <div class="level-right">
                                 <p class="level-item">
-                                    <button class="button is-danger" onclick=self.link.callback(|_| Msg::DeletePublisher)>
-                                        { DELETE_BUTTON }
-                                    </button>
+                                    <ConfirmDeleteComponent
+                                        onclick=self.link.callback(|_| Msg::DeletePublisher)
+                                        object_name=&self.publisher.publisher_name
+                                    />
                                 </p>
                             </div>
                         </nav>

--- a/thoth-app/src/component/series.rs
+++ b/thoth-app/src/component/series.rs
@@ -17,6 +17,7 @@ use crate::agent::notification_bus::NotificationBus;
 use crate::agent::notification_bus::NotificationDispatcher;
 use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
+use crate::component::delete_dialogue::ConfirmDeleteComponent;
 use crate::component::utils::FormImprintSelect;
 use crate::component::utils::FormSeriesTypeSelect;
 use crate::component::utils::FormTextInput;
@@ -49,7 +50,6 @@ use crate::models::series::Series;
 use crate::models::series::SeriesTypeValues;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
-use crate::string::DELETE_BUTTON;
 use crate::string::SAVE_BUTTON;
 
 pub struct SeriesComponent {
@@ -379,9 +379,10 @@ impl Component for SeriesComponent {
                             </div>
                             <div class="level-right">
                                 <p class="level-item">
-                                    <button class="button is-danger" onclick=self.link.callback(|_| Msg::DeleteSeries)>
-                                        { DELETE_BUTTON }
-                                    </button>
+                                    <ConfirmDeleteComponent
+                                        onclick=self.link.callback(|_| Msg::DeleteSeries)
+                                        object_name=&self.series.series_name
+                                    />
                                 </p>
                             </div>
                         </nav>

--- a/thoth-app/src/component/subjects_form.rs
+++ b/thoth-app/src/component/subjects_form.rs
@@ -30,6 +30,7 @@ use crate::models::subject::subject_types_query::FetchActionSubjectTypes;
 use crate::models::subject::subject_types_query::FetchSubjectTypes;
 use crate::models::subject::Subject;
 use crate::models::subject::SubjectTypeValues;
+use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_SUBJECTS;
 use crate::string::REMOVE_BUTTON;
 
@@ -319,7 +320,7 @@ impl Component for SubjectsFormComponent {
                                 class="button"
                                 onclick=&close_modal
                             >
-                                { "Cancel" }
+                                { CANCEL_BUTTON }
                             </button>
                         </footer>
                     </div>

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -52,6 +52,7 @@ pub type FormCurrencyCodeSelect = Pure<PureCurrencyCodeSelect>;
 pub type FormBooleanSelect = Pure<PureBooleanSelect>;
 pub type FormImprintSelect = Pure<PureImprintSelect>;
 pub type FormPublisherSelect = Pure<PurePublisherSelect>;
+pub type FormConfirmDelete = Pure<PureConfirmDelete>;
 pub type Loader = Pure<PureLoader>;
 pub type Reloader = Pure<PureReloader>;
 
@@ -259,6 +260,13 @@ pub struct PurePublisherSelect {
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
     pub required: bool,
+}
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct PureConfirmDelete {
+    pub onclick: Callback<MouseEvent>,
+    pub oncancel: Callback<MouseEvent>,
+    pub show: bool,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -629,6 +637,38 @@ impl PureComponent for PurePublisherSelect {
     }
 }
 
+impl PureComponent for PureConfirmDelete {
+    fn render(&self) -> VNode {
+        html! {
+            <div class=self.confirm_delete_status()>
+                <div class="modal-background"></div>
+                <div class="modal-card">
+                    <header class="modal-card-head">
+                        <p class="modal-card-title">{ "Confirm deletion" }</p>
+                    </header>
+                    <section class="modal-card-body">
+                        <p>{ "Are you sure you want to delete this object?" }</p>
+                    </section>
+                    <footer class="modal-card-foot">
+                        <button
+                            class="button is-success"
+                            onclick=&self.onclick
+                        >
+                            { "Delete" }
+                        </button>
+                        <button
+                            class="button"
+                            onclick=&self.oncancel
+                        >
+                            { "Cancel" }
+                        </button>
+                    </footer>
+                </div>
+            </div>
+        }
+    }
+}
+
 impl PureWorkTypeSelect {
     fn render_worktype(&self, w: &WorkTypeValues) -> VNode {
         if w.name == self.value {
@@ -803,6 +843,15 @@ impl PurePublisherSelect {
             html! {
                 <option value={&p.publisher_id}>{&p.publisher_name}</option>
             }
+        }
+    }
+}
+
+impl PureConfirmDelete {
+    fn confirm_delete_status(&self) -> String {
+        match self.show {
+            true => "modal is-active".to_string(),
+            false => "modal".to_string(),
         }
     }
 }

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -52,7 +52,6 @@ pub type FormCurrencyCodeSelect = Pure<PureCurrencyCodeSelect>;
 pub type FormBooleanSelect = Pure<PureBooleanSelect>;
 pub type FormImprintSelect = Pure<PureImprintSelect>;
 pub type FormPublisherSelect = Pure<PurePublisherSelect>;
-pub type FormConfirmDelete = Pure<PureConfirmDelete>;
 pub type Loader = Pure<PureLoader>;
 pub type Reloader = Pure<PureReloader>;
 
@@ -260,13 +259,6 @@ pub struct PurePublisherSelect {
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
     pub required: bool,
-}
-
-#[derive(Clone, PartialEq, Properties)]
-pub struct PureConfirmDelete {
-    pub onclick: Callback<MouseEvent>,
-    pub oncancel: Callback<MouseEvent>,
-    pub show: bool,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -637,38 +629,6 @@ impl PureComponent for PurePublisherSelect {
     }
 }
 
-impl PureComponent for PureConfirmDelete {
-    fn render(&self) -> VNode {
-        html! {
-            <div class=self.confirm_delete_status()>
-                <div class="modal-background"></div>
-                <div class="modal-card">
-                    <header class="modal-card-head">
-                        <p class="modal-card-title">{ "Confirm deletion" }</p>
-                    </header>
-                    <section class="modal-card-body">
-                        <p>{ "Are you sure you want to delete this object?" }</p>
-                    </section>
-                    <footer class="modal-card-foot">
-                        <button
-                            class="button is-success"
-                            onclick=&self.onclick
-                        >
-                            { "Delete" }
-                        </button>
-                        <button
-                            class="button"
-                            onclick=&self.oncancel
-                        >
-                            { "Cancel" }
-                        </button>
-                    </footer>
-                </div>
-            </div>
-        }
-    }
-}
-
 impl PureWorkTypeSelect {
     fn render_worktype(&self, w: &WorkTypeValues) -> VNode {
         if w.name == self.value {
@@ -843,15 +803,6 @@ impl PurePublisherSelect {
             html! {
                 <option value={&p.publisher_id}>{&p.publisher_name}</option>
             }
-        }
-    }
-}
-
-impl PureConfirmDelete {
-    fn confirm_delete_status(&self) -> String {
-        match self.show {
-            true => "modal is-active".to_string(),
-            false => "modal".to_string(),
         }
     }
 }

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -19,6 +19,7 @@ use crate::agent::notification_bus::NotificationDispatcher;
 use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
 use crate::component::contributions_form::ContributionsFormComponent;
+use crate::component::delete_dialogue::ConfirmDeleteComponent;
 use crate::component::fundings_form::FundingsFormComponent;
 use crate::component::issues_form::IssuesFormComponent;
 use crate::component::languages_form::LanguagesFormComponent;
@@ -60,7 +61,6 @@ use crate::models::work::WorkStatusValues;
 use crate::models::work::WorkTypeValues;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
-use crate::string::DELETE_BUTTON;
 use crate::string::SAVE_BUTTON;
 
 pub struct WorkComponent {
@@ -581,9 +581,10 @@ impl Component for WorkComponent {
                             </div>
                             <div class="level-right">
                                 <p class="level-item">
-                                    <button class="button is-danger" onclick=self.link.callback(|_| Msg::DeleteWork)>
-                                        { DELETE_BUTTON }
-                                    </button>
+                                    <ConfirmDeleteComponent
+                                        onclick=self.link.callback(|_| Msg::DeleteWork)
+                                        object_name=&self.work.title
+                                    />
                                 </p>
                             </div>
                         </nav>

--- a/thoth-app/src/string.rs
+++ b/thoth-app/src/string.rs
@@ -12,6 +12,7 @@ strings! {
     TEXT_LOGIN => "Login",
     SAVE_BUTTON => "Save",
     DELETE_BUTTON => "Delete",
+    CANCEL_BUTTON => "Cancel",
     REMOVE_BUTTON => "Remove",
     RELOAD_BUTTON => "Reload",
     NEXT_PAGE_BUTTON => "Next page",


### PR DESCRIPTION
Fixes #195.

Implemented as a generic `Component` rather than a `PureComponent` to allow the modal dialogue to handle its own open/closed state.