### PR TITLE
Add constraints to ensure an Issue's Series and Work have the same Imprint (#182)

### DIFF
--- a/thoth-api/src/errors.rs
+++ b/thoth-api/src/errors.rs
@@ -38,6 +38,8 @@ pub enum ThothError {
     InvalidToken,
     #[fail(display = "No cookie found.")]
     CookieError(),
+    #[fail(display = "Issue's Work and Series cannot have different Imprints.")]
+    IssueImprintsError,
 }
 
 impl juniper::IntoFieldError for ThothError {

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -2170,6 +2170,7 @@ impl MutationRoot {
     fn create_issue(context: &Context, data: NewIssue) -> FieldResult<Issue> {
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
         user_can_edit_work(data.work_id, context)?;
+        issue_imprints_match(data.work_id, data.series_id, context)?;
 
         let connection = context.db.get().unwrap();
         match diesel::insert_into(issue::table)
@@ -2439,6 +2440,7 @@ impl MutationRoot {
     fn update_issue(context: &Context, data: PatchIssue) -> FieldResult<Issue> {
         context.token.jwt.as_ref().ok_or(ThothError::Unauthorised)?;
         user_can_edit_work(data.work_id, context)?;
+        issue_imprints_match(data.work_id, data.series_id, context)?;
 
         let connection = context.db.get().unwrap();
 
@@ -3612,4 +3614,22 @@ fn user_can_edit_publication(publication_id: Uuid, context: &Context) -> Result<
         .first::<Uuid>(&context.db.get().unwrap())
         .expect("Error checking permissions");
     context.account_access.can_edit(pub_id)
+}
+
+fn issue_imprints_match(work_id: Uuid, series_id: Uuid, context: &Context) -> Result<()> {
+    let series_imprint = crate::schema::series::table
+        .select(crate::schema::series::imprint_id)
+        .filter(crate::schema::series::series_id.eq(series_id))
+        .first::<Uuid>(&context.db.get().unwrap())
+        .expect("Error loading series for issue");
+    let work_imprint = crate::schema::work::table
+        .select(crate::schema::work::imprint_id)
+        .filter(crate::schema::work::work_id.eq(work_id))
+        .first::<Uuid>(&context.db.get().unwrap())
+        .expect("Error loading work for issue");
+    if work_imprint == series_imprint {
+        Ok(())
+    } else {
+        Err(ThothError::IssueImprintsError.into())
+    }
 }

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -68,7 +68,7 @@ pub enum Msg {
     DoNothing,
 }
 
-#[derive(Clone, Properties)]
+#[derive(Clone, Properties, PartialEq)]
 pub struct Props {
     pub issues: Option<Vec<Issue>>,
     pub work_id: String,
@@ -278,11 +278,13 @@ impl Component for IssuesFormComponent {
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
         let updated_permissions =
             self.props.current_user.resource_access != props.current_user.resource_access;
-        self.props = props;
+        let should_render = self.props.neq_assign(props);
         if updated_permissions {
             self.link.send_message(Msg::GetSerieses);
         }
-        false
+        // Don't need to re-render if permissions props changed, as another re-render
+        // will be triggered when the message query response is received.
+        should_render && !updated_permissions
     }
 
     fn view(&self) -> Html {

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -72,6 +72,7 @@ pub enum Msg {
 pub struct Props {
     pub issues: Option<Vec<Issue>>,
     pub work_id: String,
+    pub imprint_id: String,
     pub current_user: AccountDetails,
     pub update_issues: Callback<Option<Vec<Issue>>>,
 }
@@ -331,6 +332,9 @@ impl Component for IssuesFormComponent {
                                             .iter()
                                             .position(|ser| ser.series_id == series.series_id)
                                         {
+                                            html! {}
+                                        // avoid listing series whose imprint doesn't match work
+                                        } else if series.imprint.imprint_id != self.props.imprint_id {
                                             html! {}
                                         } else {
                                             s.as_dropdown_item(

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -843,6 +843,7 @@ impl Component for WorkComponent {
                         <IssuesFormComponent
                             issues=&self.work.issues
                             work_id=&self.work.work_id
+                            imprint_id=&self.work.imprint.imprint_id
                             current_user=&self.props.current_user
                             update_issues=self.link.callback(|i: Option<Vec<Issue>>| Msg::UpdateIssues(i))
                         />

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -571,6 +571,12 @@ impl Component for WorkComponent {
                     event.prevent_default();
                     Msg::UpdateWork
                 });
+                // FormImprintSelect: while the work has any related issues, the imprint cannot
+                // be changed, because an issue's series and work must both have the same imprint.
+                let imprints = match self.work.issues.as_ref().unwrap_or(&vec![]).is_empty() {
+                    true => self.data.imprints.clone(),
+                    false => vec![self.work.imprint.clone()],
+                };
                 html! {
                     <>
                         <nav class="level">
@@ -621,7 +627,7 @@ impl Component for WorkComponent {
                                     <FormImprintSelect
                                         label = "Imprint"
                                         value=&self.work.imprint.imprint_id
-                                        data=&self.data.imprints
+                                        data=&imprints
                                         onchange=self.link.callback(|event| match event {
                                             ChangeData::Select(elem) => {
                                                 let value = elem.value();

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -65,6 +65,7 @@ use crate::string::SAVE_BUTTON;
 
 pub struct WorkComponent {
     work: Work,
+    imprint_id: String,
     data: WorkFormData,
     fetch_work: FetchWork,
     push_work: PushUpdateWork,
@@ -143,6 +144,8 @@ impl Component for WorkComponent {
         let delete_work = Default::default();
         let notification_bus = NotificationBus::dispatcher();
         let work: Work = Default::default();
+        // Track imprint stored in database, as distinct from imprint selected in dropdown
+        let imprint_id = work.imprint.imprint_id.clone();
         let data: WorkFormData = Default::default();
         let router = RouteAgentDispatcher::new();
 
@@ -150,6 +153,7 @@ impl Component for WorkComponent {
 
         WorkComponent {
             work,
+            imprint_id,
             data,
             fetch_work,
             push_work,
@@ -173,6 +177,7 @@ impl Component for WorkComponent {
                             Some(w) => w.to_owned(),
                             None => Default::default(),
                         };
+                        self.imprint_id = self.work.imprint.imprint_id.clone();
                         self.data.imprints = body.data.imprints.to_owned();
                         self.data.work_types = body.data.work_types.enum_values.to_owned();
                         self.data.work_statuses = body.data.work_statuses.enum_values.to_owned();
@@ -222,6 +227,7 @@ impl Component for WorkComponent {
                                 format!("Saved {}", w.title),
                                 NotificationStatus::Success,
                             )));
+                            self.imprint_id = self.work.imprint.imprint_id.clone();
                             true
                         }
                         None => {
@@ -843,7 +849,7 @@ impl Component for WorkComponent {
                         <IssuesFormComponent
                             issues=&self.work.issues
                             work_id=&self.work.work_id
-                            imprint_id=&self.work.imprint.imprint_id
+                            imprint_id=&self.imprint_id
                             current_user=&self.props.current_user
                             update_issues=self.link.callback(|i: Option<Vec<Issue>>| Msg::UpdateIssues(i))
                         />


### PR DESCRIPTION
Fixes #182.

In addition to the constraints on the Issue form/table described in the original issue, constraints were added to the Work form/table to prevent a Work's Imprint being changed while it has any related Issues. (Logically, the only valid Imprint in this situation is the current Imprint, as the Issues must all belong to Series connected to the current Imprint only.) Note that constraints are only required on `update_work`, not `create_work`, as Issues are not part of the initial creation data of a Work.

Also fixed minor issue where Issues form failed to refresh when an Issue was deleted.

As the Imprint dropdown and Issues dropdown are far apart on the Work page, these checks may be somewhat confusing or frustrating for users, as it may not be obvious why they can't access a desired dropdown object. In particular, there is the possibility that they will change the Imprint selection without saving it, add an Issue (from a Series linked to the previous Imprint), then click "Save" on the main body of the Work and find that it fails (due to the newly-added Issue preventing changes to the Imprint). These sorts of problems hopefully shouldn't come up too often in normal use, but ideas for mitigating them would be welcome!