### PR TITLE
Fix incorrect display of dropdown value when re-opening subform after add (#228)

### DIFF
--- a/thoth-app/src/component/languages_form.rs
+++ b/thoth-app/src/component/languages_form.rs
@@ -169,7 +169,6 @@ impl Component for LanguagesFormComponent {
                             let mut languages: Vec<Language> =
                                 self.props.languages.clone().unwrap_or_default();
                             languages.push(language);
-                            self.new_language = Default::default();
                             self.props.update_languages.emit(Some(languages));
                             self.link.send_message(Msg::ToggleAddFormDisplay(false));
                             true

--- a/thoth-app/src/component/prices_form.rs
+++ b/thoth-app/src/component/prices_form.rs
@@ -134,7 +134,6 @@ impl Component for PricesFormComponent {
                             let mut prices: Vec<Price> =
                                 self.props.prices.clone().unwrap_or_default();
                             prices.push(price);
-                            self.new_price = Default::default();
                             self.props.update_prices.emit(Some(prices));
                             self.link.send_message(Msg::ToggleAddFormDisplay(false));
                             true

--- a/thoth-app/src/component/publications_form.rs
+++ b/thoth-app/src/component/publications_form.rs
@@ -135,7 +135,6 @@ impl Component for PublicationsFormComponent {
                             let mut publications: Vec<Publication> =
                                 self.props.publications.clone().unwrap_or_default();
                             publications.push(publication);
-                            self.new_publication = Default::default();
                             self.props.update_publications.emit(Some(publications));
                             self.link.send_message(Msg::ToggleAddFormDisplay(false));
                             true

--- a/thoth-app/src/component/subjects_form.rs
+++ b/thoth-app/src/component/subjects_form.rs
@@ -135,7 +135,6 @@ impl Component for SubjectsFormComponent {
                             let mut subjects: Vec<Subject> =
                                 self.props.subjects.clone().unwrap_or_default();
                             subjects.push(subject);
-                            self.new_subject = Default::default();
                             self.props.update_subjects.emit(Some(subjects));
                             self.link.send_message(Msg::ToggleAddFormDisplay(false));
                             true


### PR DESCRIPTION
Fixes #228. On investigation, the issue was found to also affect Publications, Languages and Prices, in addition to Subjects. All of the dropdown menus involved in adding new instances of these objects were displaying the last selected item but were underlyingly set to the default selection.

This change brings the behaviour of these subforms into line with the Contributions and Fundings subforms. Note that as a result, all previously entered data is now retained when re-opening the subforms after adding an object, including free text data. This also matches the behaviour of all subforms when re-opening after pressing Cancel.