### PR TITLE
Feature/isolate errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,6 +3891,7 @@ dependencies = [
  "thoth-api",
  "thoth-api-server",
  "thoth-app-server",
+ "thoth-errors",
  "thoth-export-server",
 ]
 
@@ -3902,12 +3903,10 @@ dependencies = [
  "argon2rs",
  "cargo-husky",
  "chrono",
- "csv",
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
  "dotenv",
- "failure",
  "futures 0.3.5",
  "jsonwebtoken",
  "juniper",
@@ -3915,13 +3914,12 @@ dependencies = [
  "phf",
  "rand 0.7.3",
  "regex 1.4.3",
- "reqwest 0.10.3",
  "serde",
  "serde_derive",
  "serde_json",
  "strum 0.20.0",
+ "thoth-errors",
  "uuid 0.7.4",
- "xml-rs",
 ]
 
 [[package]]
@@ -3936,6 +3934,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thoth-api",
+ "thoth-errors",
 ]
 
 [[package]]
@@ -3950,6 +3949,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "thoth-api",
+ "thoth-errors",
  "url 2.1.1",
  "uuid 0.7.4",
  "wasm-bindgen",
@@ -3979,7 +3979,23 @@ dependencies = [
  "serde",
  "serde_json",
  "thoth-api",
+ "thoth-errors",
  "uuid 0.7.4",
+]
+
+[[package]]
+name = "thoth-errors"
+version = "0.4.0"
+dependencies = [
+ "actix-web",
+ "csv",
+ "diesel",
+ "failure",
+ "juniper",
+ "reqwest 0.10.3",
+ "serde",
+ "uuid 0.7.4",
+ "xml-rs",
 ]
 
 [[package]]
@@ -3996,8 +4012,8 @@ dependencies = [
  "paperclip",
  "serde",
  "serde_json",
- "thoth-api",
  "thoth-client",
+ "thoth-errors",
  "uuid 0.7.4",
  "xml-rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ travis-ci = { repository = "openbookpublishers/thoth" }
 maintenance = { status = "actively-developed" }
 
 [workspace]
-members = ["thoth-api", "thoth-api-server", "thoth-app", "thoth-app-server", "thoth-client", "thoth-export-server"]
+members = ["thoth-api", "thoth-api-server", "thoth-app", "thoth-app-server", "thoth-client", "thoth-errors", "thoth-export-server"]
 
 [dependencies]
 thoth-api = { version = "0.4.0", path = "thoth-api", features = ["backend"] }
 thoth-api-server = { version = "0.4.0", path = "thoth-api-server" }
 thoth-app-server = { version = "0.4.0", path = "thoth-app-server" }
+thoth-errors = { version = "0.4.0", path = "thoth-errors" }
 thoth-export-server = { version = "0.4.0", path = "thoth-export-server" }
 clap = "2.33.3"
 dialoguer = "0.7.1"

--- a/src/bin/thoth.rs
+++ b/src/bin/thoth.rs
@@ -5,10 +5,10 @@ use std::env;
 use thoth::api::account::model::{AccountData, LinkedPublisher};
 use thoth::api::account::service::{all_emails, all_publishers, register, update_password};
 use thoth::api::db::{establish_connection, run_migrations};
-use thoth_errors::ThothResult;
 use thoth::api_server;
 use thoth::app_server;
 use thoth::export_server;
+use thoth_errors::ThothResult;
 
 fn host_argument(env_value: &'static str) -> Arg<'static, 'static> {
     Arg::with_name("host")

--- a/src/bin/thoth.rs
+++ b/src/bin/thoth.rs
@@ -5,7 +5,7 @@ use std::env;
 use thoth::api::account::model::{AccountData, LinkedPublisher};
 use thoth::api::account::service::{all_emails, all_publishers, register, update_password};
 use thoth::api::db::{establish_connection, run_migrations};
-use thoth::api::errors::ThothResult;
+use thoth_errors::ThothResult;
 use thoth::api_server;
 use thoth::app_server;
 use thoth::export_server;

--- a/thoth-api-server/Cargo.toml
+++ b/thoth-api-server/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 thoth-api = { version = "0.4.0", path = "../thoth-api", features = ["backend"] }
+thoth-errors = { version = "0.4.0", path = "../thoth-errors" }
 actix-web = "3.3.2"
 actix-cors = "0.5.4"
 actix-identity = "0.3.1"

--- a/thoth-api-server/src/lib.rs
+++ b/thoth-api-server/src/lib.rs
@@ -19,10 +19,10 @@ use thoth_api::{
     account::service::login,
     db::establish_connection,
     db::PgPool,
-    errors::ThothError,
     graphql::model::Context,
     graphql::model::{create_schema, Schema},
 };
+use thoth_errors::ThothError;
 
 use crate::graphiql::graphiql_source;
 

--- a/thoth-api/Cargo.toml
+++ b/thoth-api/Cargo.toml
@@ -13,18 +13,17 @@ travis-ci = { repository = "openbookpublishers/thoth" }
 maintenance = { status = "actively-developed" }
 
 [features]
-backend = ["csv", "diesel", "diesel-derive-enum", "diesel_migrations", "actix-web", "futures"]
+backend = ["diesel", "diesel-derive-enum", "diesel_migrations", "futures", "actix-web"]
 
 [dependencies]
+thoth-errors = { version = "0.4.0", path = "../thoth-errors" }
 actix-web = { version = "3.3.2", optional = true }
 argon2rs = "0.2.5"
 chrono = { version = "0.4", features = ["serde"] }
-csv = { version = "1.1.6", optional = true }
 diesel = { version = "1.4.0", features = ["postgres", "uuidv07", "chrono", "r2d2", "64-column-tables", "serde_json"], optional = true }
 diesel-derive-enum = { version = "1.1.0", features = ["postgres"], optional = true }
 diesel_migrations = { version = "1.4.0", features = ["postgres"], optional = true }
 dotenv = "0.9.0"
-failure = "0.1.6"
 futures = { version  = "0.3.5", optional = true }
 jsonwebtoken = "7.2.0"
 juniper = "0.14.2"
@@ -32,13 +31,11 @@ lazy_static = "1.4.0"
 phf = { version = "0.8", features = ["macros"] }
 rand = "0.7.3"
 regex = "1.4.1"
-reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 strum = { version = "0.20", features = ["derive"] }
 uuid = { version = "0.7", features = ["serde", "v4"] }
-xml-rs = "0.8.0"
 
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = ["prepush-hook", "run-cargo-check", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"] }

--- a/thoth-api/src/account/handler.rs
+++ b/thoth-api/src/account/handler.rs
@@ -20,7 +20,7 @@ use crate::account::service::get_account;
 use crate::account::util::make_hash;
 use crate::account::util::make_salt;
 use crate::db::PgPool;
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 
 impl Account {
     pub fn get_permissions(&self, pool: &PgPool) -> ThothResult<Vec<LinkedPublisher>> {

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -3,8 +3,8 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::errors::ThothError;
-use crate::errors::ThothResult;
+use thoth_errors::ThothError;
+use thoth_errors::ThothResult;
 #[cfg(feature = "backend")]
 use crate::schema::account;
 #[cfg(feature = "backend")]

--- a/thoth-api/src/account/model.rs
+++ b/thoth-api/src/account/model.rs
@@ -3,12 +3,12 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use thoth_errors::ThothError;
-use thoth_errors::ThothResult;
 #[cfg(feature = "backend")]
 use crate::schema::account;
 #[cfg(feature = "backend")]
 use crate::schema::publisher_account;
+use thoth_errors::ThothError;
+use thoth_errors::ThothResult;
 
 #[cfg_attr(feature = "backend", derive(Queryable))]
 #[derive(Debug, PartialEq, Deserialize, Serialize)]

--- a/thoth-api/src/account/service.rs
+++ b/thoth-api/src/account/service.rs
@@ -10,8 +10,8 @@ use crate::account::model::NewPublisherAccount;
 use crate::account::model::PublisherAccount;
 use crate::account::util::verify;
 use crate::db::PgPool;
-use thoth_errors::{ThothError, ThothResult};
 use crate::publisher::model::Publisher;
+use thoth_errors::{ThothError, ThothResult};
 
 pub fn login(user_email: &str, user_password: &str, pool: &PgPool) -> ThothResult<Account> {
     use crate::schema::account::dsl;

--- a/thoth-api/src/account/service.rs
+++ b/thoth-api/src/account/service.rs
@@ -10,7 +10,7 @@ use crate::account::model::NewPublisherAccount;
 use crate::account::model::PublisherAccount;
 use crate::account::util::verify;
 use crate::db::PgPool;
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::publisher::model::Publisher;
 
 pub fn login(user_email: &str, user_password: &str, pool: &PgPool) -> ThothResult<Account> {

--- a/thoth-api/src/contribution/crud.rs
+++ b/thoth-api/src/contribution/crud.rs
@@ -2,13 +2,13 @@ use super::model::{
     Contribution, ContributionField, ContributionHistory, ContributionType, NewContribution,
     NewContributionHistory, PatchContribution,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::ContributionOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{contribution, contribution_history};
 use crate::{crud_methods, db_insert};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Contribution {

--- a/thoth-api/src/contribution/crud.rs
+++ b/thoth-api/src/contribution/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     Contribution, ContributionField, ContributionHistory, ContributionType, NewContribution,
     NewContributionHistory, PatchContribution,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::ContributionOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};

--- a/thoth-api/src/contributor/crud.rs
+++ b/thoth-api/src/contributor/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     Contributor, ContributorField, ContributorHistory, ContributorOrderBy, NewContributor,
     NewContributorHistory, PatchContributor,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{contributor, contributor_history};

--- a/thoth-api/src/contributor/crud.rs
+++ b/thoth-api/src/contributor/crud.rs
@@ -2,7 +2,6 @@ use super::model::{
     Contributor, ContributorField, ContributorHistory, ContributorOrderBy, NewContributor,
     NewContributorHistory, PatchContributor,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{contributor, contributor_history};
@@ -10,6 +9,7 @@ use crate::{crud_methods, db_insert};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Contributor {

--- a/thoth-api/src/db.rs
+++ b/thoth-api/src/db.rs
@@ -6,7 +6,7 @@ use diesel::r2d2::{ConnectionManager, Pool};
 use diesel_migrations::embed_migrations;
 use dotenv::dotenv;
 
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 
 pub type PgPool = Pool<ConnectionManager<PgConnection>>;
 

--- a/thoth-api/src/funder/crud.rs
+++ b/thoth-api/src/funder/crud.rs
@@ -1,7 +1,6 @@
 use super::model::{
     Funder, FunderField, FunderHistory, FunderOrderBy, NewFunder, NewFunderHistory, PatchFunder,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{funder, funder_history};
@@ -9,6 +8,7 @@ use crate::{crud_methods, db_insert};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Funder {

--- a/thoth-api/src/funder/crud.rs
+++ b/thoth-api/src/funder/crud.rs
@@ -1,7 +1,7 @@
 use super::model::{
     Funder, FunderField, FunderHistory, FunderOrderBy, NewFunder, NewFunderHistory, PatchFunder,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{funder, funder_history};

--- a/thoth-api/src/funding/crud.rs
+++ b/thoth-api/src/funding/crud.rs
@@ -1,13 +1,13 @@
 use super::model::{
     Funding, FundingField, FundingHistory, NewFunding, NewFundingHistory, PatchFunding,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::FundingOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{funding, funding_history};
 use crate::{crud_methods, db_insert};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Funding {

--- a/thoth-api/src/funding/crud.rs
+++ b/thoth-api/src/funding/crud.rs
@@ -1,7 +1,7 @@
 use super::model::{
     Funding, FundingField, FundingHistory, NewFunding, NewFundingHistory, PatchFunding,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::FundingOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -11,7 +11,6 @@ use crate::account::model::DecodedToken;
 use crate::contribution::model::*;
 use crate::contributor::model::*;
 use crate::db::PgPool;
-use thoth_errors::{ThothError, ThothResult};
 use crate::funder::model::*;
 use crate::funding::model::*;
 use crate::imprint::model::*;
@@ -24,6 +23,7 @@ use crate::publisher::model::*;
 use crate::series::model::*;
 use crate::subject::model::*;
 use crate::work::model::*;
+use thoth_errors::{ThothError, ThothResult};
 
 use super::utils::Direction;
 

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -11,7 +11,7 @@ use crate::account::model::DecodedToken;
 use crate::contribution::model::*;
 use crate::contributor::model::*;
 use crate::db::PgPool;
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::funder::model::*;
 use crate::funding::model::*;
 use crate::imprint::model::*;

--- a/thoth-api/src/imprint/crud.rs
+++ b/thoth-api/src/imprint/crud.rs
@@ -2,7 +2,6 @@ use super::model::{
     Imprint, ImprintField, ImprintHistory, ImprintOrderBy, NewImprint, NewImprintHistory,
     PatchImprint,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{imprint, imprint_history};
@@ -10,6 +9,7 @@ use crate::{crud_methods, db_insert};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Imprint {

--- a/thoth-api/src/imprint/crud.rs
+++ b/thoth-api/src/imprint/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     Imprint, ImprintField, ImprintHistory, ImprintOrderBy, NewImprint, NewImprintHistory,
     PatchImprint,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{imprint, imprint_history};

--- a/thoth-api/src/issue/crud.rs
+++ b/thoth-api/src/issue/crud.rs
@@ -1,11 +1,11 @@
 use super::model::{Issue, IssueField, IssueHistory, NewIssue, NewIssueHistory, PatchIssue};
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::IssueOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{issue, issue_history};
 use crate::{crud_methods, db_insert};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Issue {

--- a/thoth-api/src/issue/crud.rs
+++ b/thoth-api/src/issue/crud.rs
@@ -1,5 +1,5 @@
 use super::model::{Issue, IssueField, IssueHistory, NewIssue, NewIssueHistory, PatchIssue};
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::IssueOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};

--- a/thoth-api/src/language/crud.rs
+++ b/thoth-api/src/language/crud.rs
@@ -2,13 +2,13 @@ use super::model::{
     Language, LanguageCode, LanguageField, LanguageHistory, LanguageRelation, NewLanguage,
     NewLanguageHistory, PatchLanguage,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::LanguageOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{language, language_history};
 use crate::{crud_methods, db_insert};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Language {

--- a/thoth-api/src/language/crud.rs
+++ b/thoth-api/src/language/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     Language, LanguageCode, LanguageField, LanguageHistory, LanguageRelation, NewLanguage,
     NewLanguageHistory, PatchLanguage,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::LanguageOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};

--- a/thoth-api/src/lib.rs
+++ b/thoth-api/src/lib.rs
@@ -8,7 +8,6 @@ extern crate diesel_derive_enum;
 #[macro_use]
 extern crate diesel_migrations;
 extern crate dotenv;
-#[macro_use]
 extern crate juniper;
 
 pub mod account;
@@ -16,7 +15,6 @@ pub mod contribution;
 pub mod contributor;
 #[cfg(feature = "backend")]
 pub mod db;
-pub mod errors;
 pub mod funder;
 pub mod funding;
 pub mod graphql;

--- a/thoth-api/src/model/mod.rs
+++ b/thoth-api/src/model/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "backend")]
-use crate::errors::ThothResult;
+use thoth_errors::ThothResult;
 #[cfg(feature = "backend")]
 use uuid::Uuid;
 

--- a/thoth-api/src/price/crud.rs
+++ b/thoth-api/src/price/crud.rs
@@ -1,13 +1,13 @@
 use super::model::{
     CurrencyCode, NewPrice, NewPriceHistory, PatchPrice, Price, PriceField, PriceHistory,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::PriceOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{price, price_history};
 use crate::{crud_methods, db_insert};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Price {

--- a/thoth-api/src/price/crud.rs
+++ b/thoth-api/src/price/crud.rs
@@ -1,7 +1,7 @@
 use super::model::{
     CurrencyCode, NewPrice, NewPriceHistory, PatchPrice, Price, PriceField, PriceHistory,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::PriceOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};

--- a/thoth-api/src/publication/crud.rs
+++ b/thoth-api/src/publication/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     NewPublication, NewPublicationHistory, PatchPublication, Publication, PublicationField,
     PublicationHistory, PublicationOrderBy, PublicationType,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{publication, publication_history};

--- a/thoth-api/src/publication/crud.rs
+++ b/thoth-api/src/publication/crud.rs
@@ -2,7 +2,6 @@ use super::model::{
     NewPublication, NewPublicationHistory, PatchPublication, Publication, PublicationField,
     PublicationHistory, PublicationOrderBy, PublicationType,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{publication, publication_history};
@@ -10,6 +9,7 @@ use crate::{crud_methods, db_insert};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Publication {

--- a/thoth-api/src/publisher/crud.rs
+++ b/thoth-api/src/publisher/crud.rs
@@ -2,7 +2,6 @@ use super::model::{
     NewPublisher, NewPublisherHistory, PatchPublisher, Publisher, PublisherField, PublisherHistory,
     PublisherOrderBy,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{publisher, publisher_history};
@@ -10,6 +9,7 @@ use crate::{crud_methods, db_insert};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Publisher {

--- a/thoth-api/src/publisher/crud.rs
+++ b/thoth-api/src/publisher/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     NewPublisher, NewPublisherHistory, PatchPublisher, Publisher, PublisherField, PublisherHistory,
     PublisherOrderBy,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{publisher, publisher_history};

--- a/thoth-api/src/series/crud.rs
+++ b/thoth-api/src/series/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     NewSeries, NewSeriesHistory, PatchSeries, Series, SeriesField, SeriesHistory, SeriesOrderBy,
     SeriesType,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{series, series_history};

--- a/thoth-api/src/series/crud.rs
+++ b/thoth-api/src/series/crud.rs
@@ -2,7 +2,6 @@ use super::model::{
     NewSeries, NewSeriesHistory, PatchSeries, Series, SeriesField, SeriesHistory, SeriesOrderBy,
     SeriesType,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{series, series_history};
@@ -10,6 +9,7 @@ use crate::{crud_methods, db_insert};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Series {

--- a/thoth-api/src/subject/crud.rs
+++ b/thoth-api/src/subject/crud.rs
@@ -1,7 +1,7 @@
 use super::model::{
     NewSubject, NewSubjectHistory, PatchSubject, Subject, SubjectField, SubjectHistory, SubjectType,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::SubjectOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};

--- a/thoth-api/src/subject/crud.rs
+++ b/thoth-api/src/subject/crud.rs
@@ -1,13 +1,13 @@
 use super::model::{
     NewSubject, NewSubjectHistory, PatchSubject, Subject, SubjectField, SubjectHistory, SubjectType,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::model::SubjectOrderBy;
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{subject, subject_history};
 use crate::{crud_methods, db_insert};
 use diesel::{ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl};
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Crud for Subject {

--- a/thoth-api/src/subject/model.rs
+++ b/thoth-api/src/subject/model.rs
@@ -7,8 +7,8 @@ use strum::Display;
 use strum::EnumString;
 use uuid::Uuid;
 
-use crate::errors::ThothError;
-use crate::errors::ThothResult;
+use thoth_errors::ThothError;
+use thoth_errors::ThothResult;
 #[cfg(feature = "backend")]
 use crate::schema::subject;
 #[cfg(feature = "backend")]

--- a/thoth-api/src/subject/model.rs
+++ b/thoth-api/src/subject/model.rs
@@ -7,12 +7,12 @@ use strum::Display;
 use strum::EnumString;
 use uuid::Uuid;
 
-use thoth_errors::ThothError;
-use thoth_errors::ThothResult;
 #[cfg(feature = "backend")]
 use crate::schema::subject;
 #[cfg(feature = "backend")]
 use crate::schema::subject_history;
+use thoth_errors::ThothError;
+use thoth_errors::ThothResult;
 
 #[cfg_attr(feature = "backend", derive(DbEnum, juniper::GraphQLEnum))]
 #[cfg_attr(feature = "backend", DieselType = "Subject_type")]

--- a/thoth-api/src/work/crud.rs
+++ b/thoth-api/src/work/crud.rs
@@ -2,7 +2,6 @@ use super::model::{
     NewWork, NewWorkHistory, PatchWork, Work, WorkField, WorkHistory, WorkOrderBy, WorkStatus,
     WorkType,
 };
-use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{work, work_history};
@@ -10,6 +9,7 @@ use crate::{crud_methods, db_insert};
 use diesel::{
     BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
 };
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 impl Work {

--- a/thoth-api/src/work/crud.rs
+++ b/thoth-api/src/work/crud.rs
@@ -2,7 +2,7 @@ use super::model::{
     NewWork, NewWorkHistory, PatchWork, Work, WorkField, WorkHistory, WorkOrderBy, WorkStatus,
     WorkType,
 };
-use crate::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{work, work_history};

--- a/thoth-app/Cargo.toml
+++ b/thoth-app/Cargo.toml
@@ -34,3 +34,4 @@ serde_json = "1.0"
 url = "2.1.1"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 thoth-api = { version = "0.4.0", path = "../thoth-api"  }
+thoth-errors = { version = "0.4.0", path = "../thoth-errors" }

--- a/thoth-app/src/component/root.rs
+++ b/thoth-app/src/component/root.rs
@@ -1,6 +1,6 @@
 use semver::Version;
 use thoth_api::account::model::AccountDetails;
-use thoth_api::errors::ThothError;
+use thoth_errors::ThothError;
 use yew::html;
 use yew::prelude::worker::*;
 use yew::prelude::*;

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -841,7 +841,7 @@ impl PureCurrencyCodeSelect {
 
 impl PureImprintSelect {
     fn render_imprint(&self, i: &Imprint) -> VNode {
-        let value = &self.value.clone().unwrap_or_default();
+        let value = &self.value.unwrap_or_default();
         if &i.imprint_id == value {
             html! {
                 <option value={i.imprint_id.to_string()} selected=true>
@@ -858,7 +858,7 @@ impl PureImprintSelect {
 
 impl PurePublisherSelect {
     fn render_publisher(&self, p: &Publisher) -> VNode {
-        let value = &self.value.clone().unwrap_or_default();
+        let value = &self.value.unwrap_or_default();
         if &p.publisher_id == value {
             html! {
                 <option value={p.publisher_id.to_string()} selected=true>

--- a/thoth-app/src/service/version.rs
+++ b/thoth-app/src/service/version.rs
@@ -1,6 +1,6 @@
 use semver::Version;
 use serde_json::Value;
-use thoth_api::errors::ThothError;
+use thoth_errors::ThothError;
 use yew::callback::Callback;
 use yew::format::Nothing;
 use yew::format::Text;

--- a/thoth-client/Cargo.toml
+++ b/thoth-client/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 thoth-api = {version = "0.4.0", path = "../thoth-api" }
+thoth-errors = {version = "0.4.0", path = "../thoth-errors" }
 graphql_client = "0.9.0"
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.10", features = ["json"] }

--- a/thoth-client/src/lib.rs
+++ b/thoth-client/src/lib.rs
@@ -48,7 +48,7 @@ impl ThothClient {
     /// # Example
     ///
     /// ```no_run
-    /// # use thoth_api::errors::ThothResult;
+    /// # use thoth_errors::ThothResult;
     /// # use thoth_client::{ThothClient, Work};
     /// # use uuid::Uuid;
     ///
@@ -78,7 +78,7 @@ impl ThothClient {
     /// # Example
     ///
     /// ```no_run
-    /// # use thoth_api::errors::ThothResult;
+    /// # use thoth_errors::ThothResult;
     /// # use thoth_client::{ThothClient, Work};
     /// # use uuid::Uuid;
     ///

--- a/thoth-client/src/lib.rs
+++ b/thoth-client/src/lib.rs
@@ -5,7 +5,7 @@ use graphql_client::GraphQLQuery;
 use graphql_client::Response;
 use serde::Serialize;
 use std::future::Future;
-use thoth_api::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
 pub use crate::queries::work_query::*;

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "thoth-errors"
+version = "0.4.0"
+authors = ["Javier Arias <javi@openbookpublishers.com>", "Ross Higman <ross@openbookpublishers.com>"]
+edition = "2018"
+license = "Apache-2.0"
+description = "Errors library for Thoth"
+repository = "https://github.com/thoth-pub/thoth"
+readme = "README.md"
+
+[dependencies]
+failure = "0.1.6"
+juniper = "0.14.2"
+reqwest = { version = "0.10", features = ["json"] }
+serde = "1.0.115"
+uuid = { version = "0.7", features = ["serde", "v4"] }
+xml-rs = "0.8.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+actix-web = "3.3.2"
+diesel = "1.4.0"
+csv = "1.1.6"
+

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -14,10 +14,10 @@ juniper = "0.14.2"
 reqwest = { version = "0.10", features = ["json"] }
 serde = "1.0.115"
 uuid = { version = "0.7", features = ["serde", "v4"] }
-xml-rs = "0.8.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 actix-web = "3.3.2"
 diesel = "1.4.0"
 csv = "1.1.6"
+xml-rs = "0.8.0"
 

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1.6"
-juniper = "0.14.2"
 reqwest = { version = "0.10", features = ["json"] }
 serde = "1.0.115"
 uuid = { version = "0.7", features = ["serde", "v4"] }
@@ -19,5 +18,6 @@ uuid = { version = "0.7", features = ["serde", "v4"] }
 actix-web = "3.3.2"
 diesel = "1.4.0"
 csv = "1.1.6"
+juniper = "0.14.2"
 xml-rs = "0.8.0"
 

--- a/thoth-errors/LICENSE
+++ b/thoth-errors/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Open Book Publishers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/thoth-errors/README.md
+++ b/thoth-errors/README.md
@@ -1,0 +1,17 @@
+<div align="center">
+  <img src="https://www.openbookpublishers.com/shopimages/thoth-logo.png" height="400" />
+
+  <h1>Thoth Errors</h1>
+
+  <p>
+    <strong>Errors library for <a href="https://github.com/thoth-pub/thoth/">Thoth</a>'s, metadata management and dissemination system</strong>
+  </p>
+
+  <p>
+    <a href="https://github.com/thoth-pub/thoth/actions"><img alt="GitHub Workflow" src="https://img.shields.io/github/workflow/status/thoth-pub/thoth/build-and-test/master"></a>
+    <a href="https://github.com/thoth-pub/thoth/releases"><img alt="Thoth Releases" src="https://img.shields.io/github/release/thoth-pub/thoth.svg?colorB=58839b&maxAge=86400"/></a>
+    <a href="https://crates.io/crates/thoth-errors"><img alt="Crate Info" src="https://img.shields.io/crates/v/thoth-errors.svg?maxAge=86400"/></a>
+    <a href="https://github.com/thoth-pub/thoth/blob/master/LICENSE"><img alt="License Info" src="https://img.shields.io/github/license/thoth-pub/thoth.svg?colorB=blue"/></a>
+  </p>
+</div>
+

--- a/thoth-errors/README.md
+++ b/thoth-errors/README.md
@@ -4,7 +4,7 @@
   <h1>Thoth Errors</h1>
 
   <p>
-    <strong>Errors library for <a href="https://github.com/thoth-pub/thoth/">Thoth</a>'s, metadata management and dissemination system</strong>
+    <strong>Errors library for <a href="https://github.com/thoth-pub/thoth/">Thoth</a>, metadata management and dissemination system</strong>
   </p>
 
   <p>

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -34,6 +34,7 @@ pub enum ThothError {
     IncompleteMetadataRecord(String, String),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl juniper::IntoFieldError for ThothError {
     fn into_field_error(self) -> juniper::FieldError {
         use juniper::graphql_value;

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -120,6 +120,7 @@ impl From<reqwest::Error> for ThothError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<xml::writer::Error> for ThothError {
     fn from(error: xml::writer::Error) -> ThothError {
         ThothError::InternalError(error.to_string())

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -148,6 +148,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_csv_error() {
+        // We are just testing that _a_ `csv::error` is converted to `ThothError::CsvError`.
+        // The test instantiation is copied from the library: https://github.com/BurntSushi/rust-csv/blob/40ea4c49d7467d2b607a6396424f8e0e101adae1/src/writer.rs#L1268
+        let mut wtr = csv::WriterBuilder::new().from_writer(vec![]);
+        wtr.write_record(&csv::ByteRecord::from(vec!["a", "b", "c"])).unwrap();
+        let err = wtr.write_record(&csv::ByteRecord::from(vec!["a"])).unwrap_err();
+        assert!(matches!(ThothError::from(err), ThothError::CsvError { .. }));
+    }
+
+    #[test]
     fn test_uuid_error() {
         assert_eq!(
             ThothError::from(uuid::Uuid::parse_str("not-a-uuid").unwrap_err()),

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -145,7 +145,7 @@ impl From<uuid::parser::ParseError> for ThothError {
 
 #[cfg(test)]
 mod tests {
-    use thoth_api::errors::*;
+    use super::*;
 
     #[test]
     fn test_uuid_error() {

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -1,3 +1,4 @@
+use core::convert::From;
 use failure::Fail;
 
 /// A specialised result type for returning Thoth data
@@ -35,6 +36,7 @@ pub enum ThothError {
 
 impl juniper::IntoFieldError for ThothError {
     fn into_field_error(self) -> juniper::FieldError {
+        use juniper::graphql_value;
         match self {
             ThothError::InvalidSubjectCode { .. } => juniper::FieldError::new(
                 self.to_string(),
@@ -58,7 +60,7 @@ impl juniper::IntoFieldError for ThothError {
     }
 }
 
-#[cfg(feature = "backend")]
+#[cfg(not(target_arch = "wasm32"))]
 impl actix_web::error::ResponseError for ThothError {
     fn error_response(&self) -> actix_web::HttpResponse {
         use actix_web::HttpResponse;
@@ -78,7 +80,7 @@ impl actix_web::error::ResponseError for ThothError {
     }
 }
 
-#[cfg(feature = "backend")]
+#[cfg(not(target_arch = "wasm32"))]
 impl From<diesel::result::Error> for ThothError {
     fn from(error: diesel::result::Error) -> ThothError {
         use diesel::result::Error;
@@ -93,7 +95,7 @@ impl From<diesel::result::Error> for ThothError {
     }
 }
 
-#[cfg(feature = "backend")]
+#[cfg(not(target_arch = "wasm32"))]
 impl From<csv::Error> for ThothError {
     fn from(e: csv::Error) -> Self {
         ThothError::CsvError(e.to_string())
@@ -141,7 +143,7 @@ impl From<uuid::parser::ParseError> for ThothError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use thoth_api::errors::*;
 
     #[test]
     fn test_uuid_error() {

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -152,8 +152,11 @@ mod tests {
         // We are just testing that _a_ `csv::error` is converted to `ThothError::CsvError`.
         // The test instantiation is copied from the library: https://github.com/BurntSushi/rust-csv/blob/40ea4c49d7467d2b607a6396424f8e0e101adae1/src/writer.rs#L1268
         let mut wtr = csv::WriterBuilder::new().from_writer(vec![]);
-        wtr.write_record(&csv::ByteRecord::from(vec!["a", "b", "c"])).unwrap();
-        let err = wtr.write_record(&csv::ByteRecord::from(vec!["a"])).unwrap_err();
+        wtr.write_record(&csv::ByteRecord::from(vec!["a", "b", "c"]))
+            .unwrap();
+        let err = wtr
+            .write_record(&csv::ByteRecord::from(vec!["a"]))
+            .unwrap_err();
         assert!(matches!(ThothError::from(err), ThothError::CsvError { .. }));
     }
 

--- a/thoth-export-server/Cargo.toml
+++ b/thoth-export-server/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/thoth-pub/thoth"
 readme = "README.md"
 
 [dependencies]
-thoth-api = { version = "0.4.0", path = "../thoth-api" }
+thoth-errors = { version = "0.4.0", path = "../thoth-errors" }
 thoth-client = { version = "0.4.0", path = "../thoth-client" }
 actix-web = "3.3.2"
 actix-cors = "0.5.4"

--- a/thoth-export-server/README.md
+++ b/thoth-export-server/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="https://www.openbookpublishers.com/shopimages/thoth-logo.png" height="400" />
 
-  <h1>Thoth Client</h1>
+  <h1>Thoth Export API</h1>
 
   <p>
     <strong>Web server for <a href="https://github.com/thoth-pub/thoth/">Thoth</a>'s, metadata management and dissemination system, metadata exports API</strong>

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -1,7 +1,7 @@
 use csv::Writer;
 use serde::Serialize;
 use std::io::Write;
-use thoth_api::errors::ThothResult;
+use thoth_errors::ThothResult;
 use thoth_client::{
     SubjectType, Work, WorkContributions, WorkFundings, WorkIssues, WorkLanguages,
     WorkPublications, WorkPublicationsPrices, WorkSubjects,

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -1,11 +1,11 @@
 use csv::Writer;
 use serde::Serialize;
 use std::io::Write;
-use thoth_errors::ThothResult;
 use thoth_client::{
     SubjectType, Work, WorkContributions, WorkFundings, WorkIssues, WorkLanguages,
     WorkPublications, WorkPublicationsPrices, WorkSubjects,
 };
+use thoth_errors::ThothResult;
 
 use super::{CsvCell, CsvRow, CsvSpecification};
 

--- a/thoth-export-server/src/csv/mod.rs
+++ b/thoth-export-server/src/csv/mod.rs
@@ -1,6 +1,6 @@
 use csv::{QuoteStyle, Writer, WriterBuilder};
 use std::io::Write;
-use thoth_api::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use thoth_client::Work;
 
 pub(crate) trait CsvSpecification {

--- a/thoth-export-server/src/csv/mod.rs
+++ b/thoth-export-server/src/csv/mod.rs
@@ -1,7 +1,7 @@
 use csv::{QuoteStyle, Writer, WriterBuilder};
 use std::io::Write;
-use thoth_errors::{ThothError, ThothResult};
 use thoth_client::Work;
+use thoth_errors::{ThothError, ThothResult};
 
 pub(crate) trait CsvSpecification {
     const QUOTE_STYLE: QuoteStyle = QuoteStyle::Always;

--- a/thoth-export-server/src/data.rs
+++ b/thoth-export-server/src/data.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use thoth_api::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 
 use crate::format::model::Format;
 use crate::platform::model::Platform;

--- a/thoth-export-server/src/record.rs
+++ b/thoth-export-server/src/record.rs
@@ -5,8 +5,8 @@ use paperclip::util::{ready, Ready};
 use paperclip::v2::models::{DefaultOperationRaw, Either, Response};
 use paperclip::v2::schema::Apiv2Schema;
 use std::str::FromStr;
-use thoth_errors::{ThothError, ThothResult};
 use thoth_client::Work;
+use thoth_errors::{ThothError, ThothResult};
 
 use crate::csv::{CsvSpecification, CsvThoth};
 use crate::xml::{Onix3ProjectMuse, XmlSpecification};

--- a/thoth-export-server/src/record.rs
+++ b/thoth-export-server/src/record.rs
@@ -5,7 +5,7 @@ use paperclip::util::{ready, Ready};
 use paperclip::v2::models::{DefaultOperationRaw, Either, Response};
 use paperclip::v2::schema::Apiv2Schema;
 use std::str::FromStr;
-use thoth_api::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 use thoth_client::Work;
 
 use crate::csv::{CsvSpecification, CsvThoth};

--- a/thoth-export-server/src/xml/mod.rs
+++ b/thoth-export-server/src/xml/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::Write;
-use thoth_api::errors::{ThothError, ThothResult};
 use thoth_client::Work;
+use thoth_errors::{ThothError, ThothResult};
 use xml::writer::events::StartElementBuilder;
 use xml::writer::{EmitterConfig, EventWriter, XmlEvent};
 

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -9,7 +9,7 @@ use xml::writer::{EventWriter, XmlEvent};
 
 use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
-use thoth_api::errors::{ThothError, ThothResult};
+use thoth_errors::{ThothError, ThothResult};
 
 pub struct Onix3ProjectMuse {}
 


### PR DESCRIPTION
Move `ThothError` to its own crate.

Note that in order to enable usage by `thoth-app` we're excluding incompatible crate usages with `#[cfg(not(target_arch = "wasm32"))]` (inline) and `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` (in `Cargo.toml`) (previously handled with the `backend` feature in `thoth-api`)