### PR TITLE
Implement ONIX XML output matching OAPEN specifications (#48)

### DIFF
--- a/thoth-app/src/models/work/mod.rs
+++ b/thoth-app/src/models/work/mod.rs
@@ -103,7 +103,8 @@ impl MetadataTable for WorkWithRelations {
 }
 
 pub trait DisplayWork {
-    fn onix_endpoint(&self) -> String;
+    fn onix_projectmuse_endpoint(&self) -> String;
+    fn onix_oapen_endpoint(&self) -> String;
     fn csv_endpoint(&self) -> String;
     fn cover_alt_text(&self) -> String;
     fn license_icons(&self) -> Html;
@@ -112,9 +113,16 @@ pub trait DisplayWork {
 }
 
 impl DisplayWork for WorkWithRelations {
-    fn onix_endpoint(&self) -> String {
+    fn onix_projectmuse_endpoint(&self) -> String {
         format!(
             "{}/specifications/onix_3.0::project_muse/work/{}",
+            THOTH_EXPORT_API, &self.work_id
+        )
+    }
+
+    fn onix_oapen_endpoint(&self) -> String {
+        format!(
+            "{}/specifications/onix_3.0::oapen/work/{}",
             THOTH_EXPORT_API, &self.work_id
         )
     }
@@ -308,10 +316,16 @@ impl DisplayWork for WorkWithRelations {
                                     <div class="dropdown-menu" id="dropdown-menu" role="menu">
                                         <div class="dropdown-content">
                                             <a
-                                                href={self.onix_endpoint()}
+                                                href={self.onix_projectmuse_endpoint()}
                                                 class="dropdown-item"
                                             >
-                                            {"ONIX"}
+                                            {"ONIX (Project Muse)"}
+                                            </a>
+                                            <a
+                                                href={self.onix_oapen_endpoint()}
+                                                class="dropdown-item"
+                                            >
+                                            {"ONIX (OAPEN)"}
                                             </a>
                                             <a
                                                 href={self.csv_endpoint()}

--- a/thoth-client/assets/queries.graphql
+++ b/thoth-client/assets/queries.graphql
@@ -52,6 +52,7 @@ fragment Work on Work {
         mainContribution
         biography
         institution
+        contributionOrdinal
         contributor {
             orcid
         }

--- a/thoth-client/assets/schema.json
+++ b/thoth-client/assets/schema.json
@@ -5637,6 +5637,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "contributionOrdinal",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "work",
               "type": {
                 "kind": "NON_NULL",

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -359,6 +359,7 @@ mod tests {
                     main_contribution: true,
                     biography: None,
                     institution: None,
+                    contribution_ordinal: 1,
                     contributor: WorkContributionsContributor {
                         orcid: Some("https://orcid.org/0000-0000-0000-0001".to_string()),
                     },
@@ -371,6 +372,7 @@ mod tests {
                     main_contribution: true,
                     biography: None,
                     institution: None,
+                    contribution_ordinal: 2,
                     contributor: WorkContributionsContributor {
                         orcid: None,
                     },

--- a/thoth-export-server/src/data.rs
+++ b/thoth-export-server/src/data.rs
@@ -14,6 +14,12 @@ lazy_static! {
             accepted_by: vec![concat!(env!("THOTH_EXPORT_API"), "/platforms/project_muse"),],
         },
         Specification {
+            id: "onix_3.0::oapen",
+            name: "OAPEN ONIX 3.0",
+            format: concat!(env!("THOTH_EXPORT_API"), "/formats/onix_3.0"),
+            accepted_by: vec![concat!(env!("THOTH_EXPORT_API"), "/platforms/oapen"),],
+        },
+        Specification {
             id: "csv::thoth",
             name: "Thoth CSV",
             format: concat!(env!("THOTH_EXPORT_API"), "/formats/csv"),
@@ -37,16 +43,27 @@ lazy_static! {
                 "/specifications/onix_3.0::project_muse"
             ),],
         },
+        Platform {
+            id: "oapen",
+            name: "OAPEN",
+            accepts: vec![concat!(
+                env!("THOTH_EXPORT_API"),
+                "/specifications/onix_3.0::oapen"
+            ),],
+        },
     ];
     pub(crate) static ref ALL_FORMATS: Vec<Format<'static>> = vec![
         Format {
             id: "onix_3.0",
             name: "ONIX",
             version: Some("3.0"),
-            specifications: vec![concat!(
-                env!("THOTH_EXPORT_API"),
-                "/specifications/onix_3.0::project_muse"
-            ),],
+            specifications: vec![
+                concat!(
+                    env!("THOTH_EXPORT_API"),
+                    "/specifications/onix_3.0::project_muse"
+                ),
+                concat!(env!("THOTH_EXPORT_API"), "/specifications/onix_3.0::oapen"),
+            ],
         },
         Format {
             id: "csv",

--- a/thoth-export-server/src/record.rs
+++ b/thoth-export-server/src/record.rs
@@ -9,13 +9,14 @@ use thoth_client::Work;
 use thoth_errors::{ThothError, ThothResult};
 
 use crate::csv::{CsvSpecification, CsvThoth};
-use crate::xml::{Onix3ProjectMuse, XmlSpecification};
+use crate::xml::{Onix3Oapen, Onix3ProjectMuse, XmlSpecification};
 
 pub(crate) trait AsRecord {}
 impl AsRecord for Vec<Work> {}
 
 pub(crate) enum MetadataSpecification {
     Onix3ProjectMuse(Onix3ProjectMuse),
+    Onix3Oapen(Onix3Oapen),
     CsvThoth(CsvThoth),
 }
 
@@ -45,6 +46,7 @@ where
     fn content_type(&self) -> &'static str {
         match &self.specification {
             MetadataSpecification::Onix3ProjectMuse(_) => Self::XML_MIME_TYPE,
+            MetadataSpecification::Onix3Oapen(_) => Self::XML_MIME_TYPE,
             MetadataSpecification::CsvThoth(_) => Self::CSV_MIME_TYPE,
         }
     }
@@ -52,6 +54,7 @@ where
     fn file_name(&self) -> String {
         match &self.specification {
             MetadataSpecification::Onix3ProjectMuse(_) => self.xml_file_name(),
+            MetadataSpecification::Onix3Oapen(_) => self.xml_file_name(),
             MetadataSpecification::CsvThoth(_) => self.csv_file_name(),
         }
     }
@@ -84,6 +87,7 @@ impl MetadataRecord<Vec<Work>> {
             MetadataSpecification::Onix3ProjectMuse(onix3_project_muse) => {
                 onix3_project_muse.generate(&self.data)
             }
+            MetadataSpecification::Onix3Oapen(onix3_oapen) => onix3_oapen.generate(&self.data),
             MetadataSpecification::CsvThoth(csv_thoth) => csv_thoth.generate(&self.data),
         }
     }
@@ -134,6 +138,7 @@ impl FromStr for MetadataSpecification {
             "onix_3.0::project_muse" => {
                 Ok(MetadataSpecification::Onix3ProjectMuse(Onix3ProjectMuse {}))
             }
+            "onix_3.0::oapen" => Ok(MetadataSpecification::Onix3Oapen(Onix3Oapen {})),
             "csv::thoth" => Ok(MetadataSpecification::CsvThoth(CsvThoth {})),
             _ => Err(ThothError::InvalidMetadataSpecification(input.to_string())),
         }
@@ -144,6 +149,7 @@ impl ToString for MetadataSpecification {
     fn to_string(&self) -> String {
         match self {
             MetadataSpecification::Onix3ProjectMuse(_) => "onix_3.0::project_muse".to_string(),
+            MetadataSpecification::Onix3Oapen(_) => "onix_3.0::oapen".to_string(),
             MetadataSpecification::CsvThoth(_) => "csv::thoth".to_string(),
         }
     }
@@ -181,6 +187,15 @@ mod tests {
         assert_eq!(
             to_test.file_name(),
             "onix_3.0__project_muse__some_id.xml".to_string()
-        )
+        );
+        let to_test = MetadataRecord::new(
+            "some_id".to_string(),
+            MetadataSpecification::Onix3Oapen(Onix3Oapen {}),
+            vec![],
+        );
+        assert_eq!(
+            to_test.file_name(),
+            "onix_3.0__oapen__some_id.xml".to_string()
+        );
     }
 }

--- a/thoth-export-server/src/xml/mod.rs
+++ b/thoth-export-server/src/xml/mod.rs
@@ -77,3 +77,5 @@ pub(crate) trait XmlElementBlock<T: XmlSpecification> {
 
 mod onix3_project_muse;
 pub(crate) use onix3_project_muse::Onix3ProjectMuse;
+mod onix3_oapen;
+pub(crate) use onix3_oapen::Onix3Oapen;

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -1,0 +1,522 @@
+use chrono::Utc;
+use std::collections::HashMap;
+use std::io::Write;
+use thoth_client::{
+    ContributionType, LanguageRelation, PublicationType, SubjectType, Work, WorkContributions,
+    WorkLanguages, WorkPublications, WorkStatus,
+};
+use xml::writer::{EventWriter, XmlEvent};
+
+use super::{write_element_block, XmlElement, XmlSpecification};
+use crate::xml::{write_full_element_block, XmlElementBlock};
+use thoth_api::model::DOI_DOMAIN;
+use thoth_errors::{ThothError, ThothResult};
+
+pub struct Onix3Oapen {}
+
+impl XmlSpecification for Onix3Oapen {
+    fn handle_event<W: Write>(w: &mut EventWriter<W>, works: &[Work]) -> ThothResult<()> {
+        let mut attr_map: HashMap<&str, &str> = HashMap::new();
+
+        attr_map.insert("release", "3.0");
+        attr_map.insert("xmlns", "http://ns.editeur.org/onix/3.0/reference");
+
+        write_full_element_block("ONIXMessage", None, Some(attr_map), w, |w| {
+            write_element_block("Header", w, |w| {
+                write_element_block("Sender", w, |w| {
+                    write_element_block("SenderName", w, |w| {
+                        w.write(XmlEvent::Characters("Thoth")).map_err(|e| e.into())
+                    })?;
+                    write_element_block("EmailAddress", w, |w| {
+                        w.write(XmlEvent::Characters("info@thoth.pub"))
+                            .map_err(|e| e.into())
+                    })
+                })?;
+                write_element_block("SentDateTime", w, |w| {
+                    w.write(XmlEvent::Characters(
+                        &Utc::now().format("%Y%m%dT%H%M%S").to_string(),
+                    ))
+                    .map_err(|e| e.into())
+                })
+            })?;
+
+            match works.len() {
+                0 => Err(ThothError::IncompleteMetadataRecord(
+                    "onix_3.0::oapen".to_string(),
+                    "Not enough data".to_string(),
+                )),
+                1 => XmlElementBlock::<Onix3Oapen>::xml_element(works.first().unwrap(), w),
+                _ => {
+                    for work in works.iter() {
+                        XmlElementBlock::<Onix3Oapen>::xml_element(work, w).ok();
+                    }
+                    Ok(())
+                }
+            }
+        })
+    }
+}
+
+impl XmlElementBlock<Onix3Oapen> for Work {
+    fn xml_element<W: Write>(&self, w: &mut EventWriter<W>) -> ThothResult<()> {
+        let work_id = format!("urn:uuid:{}", self.work_id.to_string());
+        let (main_isbn, isbns) = get_publications_data(&self.publications);
+        // We can only generate the document if there's a PDF
+        if let Some(pdf_url) = self
+            .publications
+            .iter()
+            .find(|p| p.publication_type.eq(&PublicationType::PDF))
+            .and_then(|p| p.publication_url.as_ref())
+        {
+            write_element_block("Product", w, |w| {
+                write_element_block("RecordReference", w, |w| {
+                    w.write(XmlEvent::Characters(&work_id))
+                        .map_err(|e| e.into())
+                })?;
+                // 03 Notification confirmed on publication
+                write_element_block("NotificationType", w, |w| {
+                    w.write(XmlEvent::Characters("03")).map_err(|e| e.into())
+                })?;
+                // 01 Publisher
+                write_element_block("RecordSourceType", w, |w| {
+                    w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
+                })?;
+                write_element_block("ProductIdentifier", w, |w| {
+                    // 01 Proprietary
+                    write_element_block("ProductIDType", w, |w| {
+                        w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
+                    })?;
+                    write_element_block("IDValue", w, |w| {
+                        w.write(XmlEvent::Characters(&work_id))
+                            .map_err(|e| e.into())
+                    })
+                })?;
+                write_element_block("ProductIdentifier", w, |w| {
+                    // 15 ISBN-13
+                    write_element_block("ProductIDType", w, |w| {
+                        w.write(XmlEvent::Characters("15")).map_err(|e| e.into())
+                    })?;
+                    write_element_block("IDValue", w, |w| {
+                        w.write(XmlEvent::Characters(&main_isbn))
+                            .map_err(|e| e.into())
+                    })
+                })?;
+                if let Some(doi) = &self.doi {
+                    write_element_block("ProductIdentifier", w, |w| {
+                        write_element_block("ProductIDType", w, |w| {
+                            w.write(XmlEvent::Characters("06")).map_err(|e| e.into())
+                        })?;
+                        write_element_block("IDValue", w, |w| {
+                            w.write(XmlEvent::Characters(&doi.replace(DOI_DOMAIN, "")))
+                                .map_err(|e| e.into())
+                        })
+                    })?;
+                }
+                write_element_block("DescriptiveDetail", w, |w| {
+                    // 00 Single-component retail product
+                    write_element_block("ProductComposition", w, |w| {
+                        w.write(XmlEvent::Characters("00")).map_err(|e| e.into())
+                    })?;
+                    // EB Digital download and online
+                    write_element_block("ProductForm", w, |w| {
+                        w.write(XmlEvent::Characters("EB")).map_err(|e| e.into())
+                    })?;
+                    // E107 PDF
+                    write_element_block("ProductFormDetail", w, |w| {
+                        w.write(XmlEvent::Characters("E107")).map_err(|e| e.into())
+                    })?;
+                    // 10 Text (eye-readable)
+                    write_element_block("PrimaryContentType", w, |w| {
+                        w.write(XmlEvent::Characters("10")).map_err(|e| e.into())
+                    })?;
+                    if let Some(license) = &self.license {
+                        write_element_block("EpubLicense", w, |w| {
+                            write_element_block("EpubLicenseName", w, |w| {
+                                w.write(XmlEvent::Characters("Creative Commons License"))
+                                    .map_err(|e| e.into())
+                            })?;
+                            write_element_block("EpubLicenseExpression", w, |w| {
+                                write_element_block("EpubLicenseExpressionType", w, |w| {
+                                    w.write(XmlEvent::Characters("02")).map_err(|e| e.into())
+                                })?;
+                                write_element_block("EpubLicenseExpressionLink", w, |w| {
+                                    w.write(XmlEvent::Characters(&license))
+                                        .map_err(|e| e.into())
+                                })
+                            })
+                        })?;
+                    }
+                    write_element_block("TitleDetail", w, |w| {
+                        // 01 Distinctive title (book)
+                        write_element_block("TitleType", w, |w| {
+                            w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
+                        })?;
+                        write_element_block("TitleElement", w, |w| {
+                            // 01 Product
+                            write_element_block("TitleElementLevel", w, |w| {
+                                w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
+                            })?;
+                            if let Some(subtitle) = &self.subtitle {
+                                write_element_block("TitleText", w, |w| {
+                                    w.write(XmlEvent::Characters(&self.title))
+                                        .map_err(|e| e.into())
+                                })?;
+                                write_element_block("Subtitle", w, |w| {
+                                    w.write(XmlEvent::Characters(&subtitle))
+                                        .map_err(|e| e.into())
+                                })
+                            } else {
+                                write_element_block("TitleText", w, |w| {
+                                    w.write(XmlEvent::Characters(&self.full_title))
+                                        .map_err(|e| e.into())
+                                })
+                            }
+                        })
+                    })?;
+                    XmlElementBlock::<Onix3Oapen>::xml_element(&self.contributions, w).ok();
+                    for language in &self.languages {
+                        XmlElementBlock::<Onix3Oapen>::xml_element(language, w).ok();
+                    }
+                    if let Some(page_count) = self.page_count {
+                        write_element_block("Extent", w, |w| {
+                            // 00 Main content
+                            write_element_block("ExtentType", w, |w| {
+                                w.write(XmlEvent::Characters("00")).map_err(|e| e.into())
+                            })?;
+                            write_element_block("ExtentValue", w, |w| {
+                                w.write(XmlEvent::Characters(&page_count.to_string()))
+                                    .map_err(|e| e.into())
+                            })?;
+                            // 03 Pages
+                            write_element_block("ExtentUnit", w, |w| {
+                                w.write(XmlEvent::Characters("03")).map_err(|e| e.into())
+                            })
+                        })?;
+                    }
+                    for subject in &self.subjects {
+                        write_element_block("Subject", w, |w| {
+                            XmlElement::<Onix3Oapen>::xml_element(&subject.subject_type, w)?;
+                            write_element_block("SubjectCode", w, |w| {
+                                w.write(XmlEvent::Characters(&subject.subject_code))
+                                    .map_err(|e| e.into())
+                            })
+                        })?;
+                    }
+                    Ok(())
+                })?;
+                if self.long_abstract.is_some() || self.toc.is_some() {
+                    write_element_block("CollateralDetail", w, |w| {
+                        if let Some(labstract) = &self.long_abstract {
+                            write_element_block("TextContent", w, |w| {
+                                let mut lang_fmt: HashMap<&str, &str> = HashMap::new();
+                                lang_fmt.insert("language", "eng");
+                                // 03 Description ("30 Abstract" not implemented in OAPEN)
+                                write_element_block("TextType", w, |w| {
+                                    w.write(XmlEvent::Characters("03")).map_err(|e| e.into())
+                                })?;
+                                // 00 Unrestricted
+                                write_element_block("ContentAudience", w, |w| {
+                                    w.write(XmlEvent::Characters("00")).map_err(|e| e.into())
+                                })?;
+                                write_full_element_block("Text", None, Some(lang_fmt), w, |w| {
+                                    w.write(XmlEvent::Characters(&labstract))
+                                        .map_err(|e| e.into())
+                                })
+                            })?;
+                        }
+                        if let Some(toc) = &self.toc {
+                            write_element_block("TextContent", w, |w| {
+                                // 04 Table of contents
+                                write_element_block("TextType", w, |w| {
+                                    w.write(XmlEvent::Characters("04")).map_err(|e| e.into())
+                                })?;
+                                // 00 Unrestricted
+                                write_element_block("ContentAudience", w, |w| {
+                                    w.write(XmlEvent::Characters("00")).map_err(|e| e.into())
+                                })?;
+                                write_element_block("Text", w, |w| {
+                                    w.write(XmlEvent::Characters(&toc)).map_err(|e| e.into())
+                                })
+                            })?;
+                        }
+                        Ok(())
+                    })?;
+                }
+                write_element_block("PublishingDetail", w, |w| {
+                    write_element_block("Imprint", w, |w| {
+                        write_element_block("ImprintName", w, |w| {
+                            w.write(XmlEvent::Characters(&self.imprint.imprint_name))
+                                .map_err(|e| e.into())
+                        })
+                    })?;
+                    write_element_block("Publisher", w, |w| {
+                        // 01 Publisher
+                        write_element_block("PublishingRole", w, |w| {
+                            w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
+                        })?;
+                        write_element_block("PublisherName", w, |w| {
+                            w.write(XmlEvent::Characters(&self.imprint.publisher.publisher_name))
+                                .map_err(|e| e.into())
+                        })
+                    })?;
+                    if let Some(place) = &self.place {
+                        write_element_block("CityOfPublication", w, |w| {
+                            w.write(XmlEvent::Characters(&place)).map_err(|e| e.into())
+                        })?;
+                    }
+                    XmlElement::<Onix3Oapen>::xml_element(&self.work_status, w)?;
+                    if let Some(date) = self.publication_date {
+                        write_element_block("PublishingDate", w, |w| {
+                            let mut date_fmt: HashMap<&str, &str> = HashMap::new();
+                            date_fmt.insert("dateformat", "01"); // 01 YYYYMM
+
+                            write_element_block("PublishingDateRole", w, |w| {
+                                // 19 Publication date of print counterpart
+                                w.write(XmlEvent::Characters("19")).map_err(|e| e.into())
+                            })?;
+                            // dateformat="01" YYYYMM
+                            write_full_element_block("Date", None, Some(date_fmt), w, |w| {
+                                w.write(XmlEvent::Characters(&date.format("%Y%m").to_string()))
+                                    .map_err(|e| e.into())
+                            })
+                        })?;
+                    }
+                    Ok(())
+                })?;
+                if !isbns.is_empty() {
+                    write_element_block("RelatedMaterial", w, |w| {
+                        for isbn in &isbns {
+                            write_element_block("RelatedProduct", w, |w| {
+                                // 06 Alternative format
+                                write_element_block("ProductRelationCode", w, |w| {
+                                    w.write(XmlEvent::Characters("06")).map_err(|e| e.into())
+                                })?;
+                                write_element_block("ProductIdentifier", w, |w| {
+                                    // 06 ISBN
+                                    write_element_block("ProductIDType", w, |w| {
+                                        w.write(XmlEvent::Characters("06")).map_err(|e| e.into())
+                                    })?;
+                                    write_element_block("IDValue", w, |w| {
+                                        w.write(XmlEvent::Characters(&isbn)).map_err(|e| e.into())
+                                    })
+                                })
+                            })?;
+                        }
+                        Ok(())
+                    })?;
+                }
+                write_element_block("ProductSupply", w, |w| {
+                    let mut supplies: HashMap<String, String> = HashMap::new();
+                    supplies.insert(
+                        pdf_url.to_string(),
+                        "Publisher's website: download the title".to_string(),
+                    );
+                    if let Some(landing_page) = &self.landing_page {
+                        supplies.insert(
+                            landing_page.to_string(),
+                            "Publisher's website: web shop".to_string(),
+                        );
+                    }
+                    for (url, description) in supplies.iter() {
+                        write_element_block("SupplyDetail", w, |w| {
+                            write_element_block("Supplier", w, |w| {
+                                // 09 Publisher to end-customers
+                                write_element_block("SupplierRole", w, |w| {
+                                    w.write(XmlEvent::Characters("11")).map_err(|e| e.into())
+                                })?;
+                                write_element_block("SupplierName", w, |w| {
+                                    w.write(XmlEvent::Characters(
+                                        &self.imprint.publisher.publisher_name,
+                                    ))
+                                    .map_err(|e| e.into())
+                                })?;
+                                write_element_block("Website", w, |w| {
+                                    // 01 Publisher’s corporate website
+                                    write_element_block("WebsiteRole", w, |w| {
+                                        w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
+                                    })?;
+                                    write_element_block("WebsiteDescription", w, |w| {
+                                        w.write(XmlEvent::Characters(&description))
+                                            .map_err(|e| e.into())
+                                    })?;
+                                    write_element_block("WebsiteLink", w, |w| {
+                                        w.write(XmlEvent::Characters(&url)).map_err(|e| e.into())
+                                    })
+                                })
+                            })?;
+                            // 99 Contact supplier
+                            write_element_block("ProductAvailability", w, |w| {
+                                w.write(XmlEvent::Characters("99")).map_err(|e| e.into())
+                            })?;
+                            // 04 Contact supplier
+                            write_element_block("UnpricedItemType", w, |w| {
+                                w.write(XmlEvent::Characters("04")).map_err(|e| e.into())
+                            })
+                        })?;
+                    }
+                    Ok(())
+                })
+            })
+        } else {
+            Err(ThothError::IncompleteMetadataRecord(
+                "onix_3.0::oapen".to_string(),
+                "Missing PDF URL".to_string(),
+            ))
+        }
+    }
+}
+
+fn get_publications_data(publications: &[WorkPublications]) -> (String, Vec<String>) {
+    let mut main_isbn = "".to_string();
+    let mut isbns: Vec<String> = Vec::new();
+
+    for publication in publications {
+        if let Some(isbn) = &publication.isbn {
+            isbns.push(isbn.replace("-", ""));
+            // The default product ISBN is the PDF's
+            if publication.publication_type.eq(&PublicationType::PDF) {
+                main_isbn = isbn.replace("-", "");
+            }
+            // Books that don't have a PDF ISBN will use the paperback's
+            if publication.publication_type.eq(&PublicationType::PAPERBACK) && main_isbn.is_empty()
+            {
+                main_isbn = isbn.replace("-", "");
+            }
+        }
+    }
+
+    (main_isbn, isbns)
+}
+
+impl XmlElement<Onix3Oapen> for WorkStatus {
+    const ELEMENT: &'static str = "PublishingStatus";
+
+    fn value(&self) -> &'static str {
+        match self {
+            WorkStatus::UNSPECIFIED => "00",
+            WorkStatus::CANCELLED => "01",
+            WorkStatus::FORTHCOMING => "02",
+            WorkStatus::POSTPONED_INDEFINITELY => "03",
+            WorkStatus::ACTIVE => "04",
+            WorkStatus::NO_LONGER_OUR_PRODUCT => "05",
+            WorkStatus::OUT_OF_STOCK_INDEFINITELY => "06",
+            WorkStatus::OUT_OF_PRINT => "07",
+            WorkStatus::INACTIVE => "08",
+            WorkStatus::UNKNOWN => "09",
+            WorkStatus::REMAINDERED => "10",
+            WorkStatus::WITHDRAWN_FROM_SALE => "11",
+            WorkStatus::RECALLED => "15",
+            WorkStatus::Other(_) => unreachable!(),
+        }
+    }
+}
+
+impl XmlElement<Onix3Oapen> for SubjectType {
+    const ELEMENT: &'static str = "SubjectSchemeIdentifier";
+
+    fn value(&self) -> &'static str {
+        match self {
+            SubjectType::BIC => "12",
+            SubjectType::BISAC => "10",
+            SubjectType::KEYWORD => "20",
+            SubjectType::LCC => "04",
+            SubjectType::THEMA => "93",
+            SubjectType::CUSTOM => "B2",
+            SubjectType::Other(_) => unreachable!(),
+        }
+    }
+}
+
+impl XmlElement<Onix3Oapen> for LanguageRelation {
+    const ELEMENT: &'static str = "LanguageRole";
+
+    fn value(&self) -> &'static str {
+        match self {
+            LanguageRelation::ORIGINAL => "01",
+            LanguageRelation::TRANSLATED_FROM => "02",
+            LanguageRelation::TRANSLATED_INTO => "01",
+            LanguageRelation::Other(_) => unreachable!(),
+        }
+    }
+}
+
+impl XmlElement<Onix3Oapen> for ContributionType {
+    const ELEMENT: &'static str = "ContributorRole";
+
+    fn value(&self) -> &'static str {
+        match self {
+            ContributionType::AUTHOR => "A01",
+            ContributionType::EDITOR => "B01",
+            ContributionType::TRANSLATOR => "B06",
+            ContributionType::PHOTOGRAPHER => "A13",
+            ContributionType::ILUSTRATOR => "A12",
+            ContributionType::MUSIC_EDITOR => "B25",
+            ContributionType::FOREWORD_BY => "A23",
+            ContributionType::INTRODUCTION_BY => "A24",
+            ContributionType::AFTERWORD_BY => "A19",
+            ContributionType::PREFACE_BY => "A15",
+            ContributionType::Other(_) => unreachable!(),
+        }
+    }
+}
+
+// Replace with implementation for WorkContributions (without the vector)
+// when we implement contribution ordering
+impl XmlElementBlock<Onix3Oapen> for Vec<WorkContributions> {
+    fn xml_element<W: Write>(&self, w: &mut EventWriter<W>) -> ThothResult<()> {
+        for (mut sequence_number, contribution) in self.iter().enumerate() {
+            sequence_number += 1;
+            write_element_block("Contributor", w, |w| {
+                write_element_block("SequenceNumber", w, |w| {
+                    w.write(XmlEvent::Characters(&sequence_number.to_string()))
+                        .map_err(|e| e.into())
+                })?;
+                XmlElement::<Onix3Oapen>::xml_element(&contribution.contribution_type, w)?;
+
+                if let Some(orcid) = &contribution.contributor.orcid {
+                    write_element_block("NameIdentifier", w, |w| {
+                        write_element_block("NameIDType", w, |w| {
+                            w.write(XmlEvent::Characters("21")).map_err(|e| e.into())
+                        })?;
+                        write_element_block("IDValue", w, |w| {
+                            w.write(XmlEvent::Characters(&orcid)).map_err(|e| e.into())
+                        })
+                    })?;
+                }
+                if let Some(first_name) = &contribution.first_name {
+                    write_element_block("NamesBeforeKey", w, |w| {
+                        w.write(XmlEvent::Characters(&first_name))
+                            .map_err(|e| e.into())
+                    })?;
+                    write_element_block("KeyNames", w, |w| {
+                        w.write(XmlEvent::Characters(&contribution.last_name))
+                            .map_err(|e| e.into())
+                    })?;
+                } else {
+                    write_element_block("PersonName", w, |w| {
+                        w.write(XmlEvent::Characters(&contribution.full_name))
+                            .map_err(|e| e.into())
+                    })?;
+                }
+                Ok(())
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl XmlElementBlock<Onix3Oapen> for WorkLanguages {
+    fn xml_element<W: Write>(&self, w: &mut EventWriter<W>) -> ThothResult<()> {
+        write_element_block("Language", w, |w| {
+            XmlElement::<Onix3Oapen>::xml_element(&self.language_relation, w).ok();
+            // not worth implementing XmlElement for LanguageCode as all cases would
+            // need to be exhaustively matched and the codes are equivalent anyway
+            write_element_block("LanguageCode", w, |w| {
+                w.write(XmlEvent::Characters(
+                    &self.language_code.to_string().to_lowercase(),
+                ))
+                .map_err(|e| e.into())
+            })
+        })
+    }
+}

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -176,7 +176,9 @@ impl XmlElementBlock<Onix3Oapen> for Work {
                             }
                         })
                     })?;
-                    XmlElementBlock::<Onix3Oapen>::xml_element(&self.contributions, w).ok();
+                    for contribution in &self.contributions {
+                        XmlElementBlock::<Onix3Oapen>::xml_element(contribution, w).ok();
+                    }
                     for language in &self.languages {
                         XmlElementBlock::<Onix3Oapen>::xml_element(language, w).ok();
                     }
@@ -506,48 +508,42 @@ impl XmlElement<Onix3Oapen> for ContributionType {
     }
 }
 
-// Replace with implementation for WorkContributions (without the vector)
-// when we implement contribution ordering
-impl XmlElementBlock<Onix3Oapen> for Vec<WorkContributions> {
+impl XmlElementBlock<Onix3Oapen> for WorkContributions {
     fn xml_element<W: Write>(&self, w: &mut EventWriter<W>) -> ThothResult<()> {
-        for (mut sequence_number, contribution) in self.iter().enumerate() {
-            sequence_number += 1;
-            write_element_block("Contributor", w, |w| {
-                write_element_block("SequenceNumber", w, |w| {
-                    w.write(XmlEvent::Characters(&sequence_number.to_string()))
+        write_element_block("Contributor", w, |w| {
+            write_element_block("SequenceNumber", w, |w| {
+                w.write(XmlEvent::Characters(&self.contribution_ordinal.to_string()))
+                    .map_err(|e| e.into())
+            })?;
+            XmlElement::<Onix3Oapen>::xml_element(&self.contribution_type, w)?;
+
+            if let Some(orcid) = &self.contributor.orcid {
+                write_element_block("NameIdentifier", w, |w| {
+                    write_element_block("NameIDType", w, |w| {
+                        w.write(XmlEvent::Characters("21")).map_err(|e| e.into())
+                    })?;
+                    write_element_block("IDValue", w, |w| {
+                        w.write(XmlEvent::Characters(&orcid)).map_err(|e| e.into())
+                    })
+                })?;
+            }
+            if let Some(first_name) = &self.first_name {
+                write_element_block("NamesBeforeKey", w, |w| {
+                    w.write(XmlEvent::Characters(&first_name))
                         .map_err(|e| e.into())
                 })?;
-                XmlElement::<Onix3Oapen>::xml_element(&contribution.contribution_type, w)?;
-
-                if let Some(orcid) = &contribution.contributor.orcid {
-                    write_element_block("NameIdentifier", w, |w| {
-                        write_element_block("NameIDType", w, |w| {
-                            w.write(XmlEvent::Characters("21")).map_err(|e| e.into())
-                        })?;
-                        write_element_block("IDValue", w, |w| {
-                            w.write(XmlEvent::Characters(&orcid)).map_err(|e| e.into())
-                        })
-                    })?;
-                }
-                if let Some(first_name) = &contribution.first_name {
-                    write_element_block("NamesBeforeKey", w, |w| {
-                        w.write(XmlEvent::Characters(&first_name))
-                            .map_err(|e| e.into())
-                    })?;
-                    write_element_block("KeyNames", w, |w| {
-                        w.write(XmlEvent::Characters(&contribution.last_name))
-                            .map_err(|e| e.into())
-                    })?;
-                } else {
-                    write_element_block("PersonName", w, |w| {
-                        w.write(XmlEvent::Characters(&contribution.full_name))
-                            .map_err(|e| e.into())
-                    })?;
-                }
-                Ok(())
-            })?;
-        }
-        Ok(())
+                write_element_block("KeyNames", w, |w| {
+                    w.write(XmlEvent::Characters(&self.last_name))
+                        .map_err(|e| e.into())
+                })?;
+            } else {
+                write_element_block("PersonName", w, |w| {
+                    w.write(XmlEvent::Characters(&self.full_name))
+                        .map_err(|e| e.into())
+                })?;
+            }
+            Ok(())
+        })
     }
 }
 

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -231,7 +231,7 @@ impl XmlElementBlock<Onix3Oapen> for Work {
                     })?;
                     Ok(())
                 })?;
-                if self.long_abstract.is_some() || self.toc.is_some() {
+                if self.long_abstract.is_some() || self.cover_url.is_some() {
                     write_element_block("CollateralDetail", w, |w| {
                         if let Some(labstract) = &self.long_abstract {
                             write_element_block("TextContent", w, |w| {
@@ -637,5 +637,503 @@ impl XmlElementBlock<Onix3Oapen> for WorkFundings {
             }
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Testing note: XML nodes cannot be guaranteed to be output in the same order every time
+    // We therefore rely on `assert!(contains)` rather than `assert_eq!`
+    use super::*;
+    use std::str::FromStr;
+    use thoth_client::{
+        ContributionType, LanguageCode, LanguageRelation, PublicationType,
+        WorkContributionsContributor, WorkImprint, WorkImprintPublisher, WorkIssuesSeries,
+        WorkStatus, WorkType,
+    };
+    use uuid::Uuid;
+
+    fn generate_test_output(input: &impl XmlElementBlock<Onix3Oapen>) -> String {
+        // Helper function based on `XmlSpecification::generate`
+        let mut buffer = Vec::new();
+        let mut writer = xml::writer::EmitterConfig::new()
+            .perform_indent(true)
+            .create_writer(&mut buffer);
+        let wrapped_output = XmlElementBlock::<Onix3Oapen>::xml_element(input, &mut writer)
+            .map(|_| buffer)
+            .and_then(|onix| {
+                String::from_utf8(onix)
+                    .map_err(|_| ThothError::InternalError("Could not parse XML".to_string()))
+            });
+        assert!(wrapped_output.is_ok());
+        wrapped_output.unwrap()
+    }
+
+    #[test]
+    fn test_onix3_oapen_contributions() {
+        let mut test_contribution = WorkContributions {
+            contribution_type: ContributionType::AUTHOR,
+            first_name: Some("Author".to_string()),
+            last_name: "1".to_string(),
+            full_name: "Author 1".to_string(),
+            main_contribution: true,
+            biography: None,
+            institution: None,
+            contribution_ordinal: 1,
+            contributor: WorkContributionsContributor {
+                orcid: Some("https://orcid.org/0000-0000-0000-0001".to_string()),
+            },
+        };
+
+        // Test standard output
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <SequenceNumber>1</SequenceNumber>"#));
+        assert!(output.contains(r#"  <ContributorRole>A01</ContributorRole>"#));
+        assert!(output.contains(r#"  <NameIdentifier>"#));
+        assert!(output.contains(r#"    <NameIDType>21</NameIDType>"#));
+        assert!(output.contains(r#"    <IDValue>https://orcid.org/0000-0000-0000-0001</IDValue>"#));
+        assert!(output.contains(r#"  </NameIdentifier>"#));
+        // Given name is output as NamesBeforeKey and family name as KeyNames
+        assert!(output.contains(r#"  <NamesBeforeKey>Author</NamesBeforeKey>"#));
+        assert!(output.contains(r#"  <KeyNames>1</KeyNames>"#));
+        // PersonName is not output when given name is supplied
+        assert!(!output.contains(r#"  <PersonName>Author 1</PersonName>"#));
+
+        // Change all possible values to test that output is updated
+        test_contribution.contribution_type = ContributionType::EDITOR;
+        test_contribution.contribution_ordinal = 2;
+        test_contribution.contributor.orcid = None;
+        test_contribution.first_name = None;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <SequenceNumber>2</SequenceNumber>"#));
+        assert!(output.contains(r#"  <ContributorRole>B01</ContributorRole>"#));
+        // No ORCID supplied
+        assert!(!output.contains(r#"  <NameIdentifier>"#));
+        assert!(!output.contains(r#"    <NameIDType>21</NameIDType>"#));
+        assert!(!output.contains(r#"    <IDValue>https://orcid.org/0000-0000-0000-0001</IDValue>"#));
+        assert!(!output.contains(r#"  </NameIdentifier>"#));
+        // No given name supplied, so PersonName is output instead of KeyNames and NamesBeforeKey
+        assert!(!output.contains(r#"  <NamesBeforeKey>Author</NamesBeforeKey>"#));
+        assert!(!output.contains(r#"  <KeyNames>1</KeyNames>"#));
+        assert!(output.contains(r#"  <PersonName>Author 1</PersonName>"#));
+
+        // All roles except Author and Editor are output as Z01
+        for contribution_type in [
+            ContributionType::TRANSLATOR,
+            ContributionType::PHOTOGRAPHER,
+            ContributionType::ILUSTRATOR,
+            ContributionType::MUSIC_EDITOR,
+            ContributionType::FOREWORD_BY,
+            ContributionType::INTRODUCTION_BY,
+            ContributionType::AFTERWORD_BY,
+            ContributionType::PREFACE_BY,
+        ] {
+            test_contribution.contribution_type = contribution_type;
+            let output = generate_test_output(&test_contribution);
+            assert!(output.contains(r#"  <ContributorRole>Z01</ContributorRole>"#));
+        }
+    }
+
+    #[test]
+    fn test_onix3_oapen_languages() {
+        let mut test_language = WorkLanguages {
+            language_code: LanguageCode::SPA,
+            language_relation: LanguageRelation::TRANSLATED_FROM,
+            main_language: true,
+        };
+
+        // Test standard output
+        let output = generate_test_output(&test_language);
+        assert!(output.contains(r#"  <LanguageRole>02</LanguageRole>"#));
+        assert!(output.contains(r#"  <LanguageCode>spa</LanguageCode>"#));
+
+        // Change all possible values to test that output is updated
+        test_language.language_code = LanguageCode::WEL;
+        for language_relation in [
+            LanguageRelation::ORIGINAL,
+            LanguageRelation::TRANSLATED_INTO,
+        ] {
+            test_language.language_relation = language_relation;
+            let output = generate_test_output(&test_language);
+            assert!(output.contains(r#"  <LanguageRole>01</LanguageRole>"#));
+            assert!(output.contains(r#"  <LanguageCode>wel</LanguageCode>"#));
+        }
+    }
+
+    #[test]
+    fn test_onix3_oapen_issues() {
+        let mut test_issue = WorkIssues {
+            issue_ordinal: 1,
+            series: WorkIssuesSeries {
+                series_type: thoth_client::SeriesType::JOURNAL,
+                series_name: "Name of series".to_string(),
+                issn_print: "1234-5678".to_string(),
+                issn_digital: "8765-4321".to_string(),
+                series_url: None,
+            },
+        };
+
+        // Test standard output
+        let output = generate_test_output(&test_issue);
+        assert!(output.contains(r#"<Collection>"#));
+        assert!(output.contains(r#"  <CollectionType>10</CollectionType>"#));
+        assert!(output.contains(r#"  <TitleDetail>"#));
+        assert!(output.contains(r#"    <TitleType>01</TitleType>"#));
+        assert!(output.contains(r#"    <TitleElement>"#));
+        assert!(output.contains(r#"      <TitleElementLevel>02</TitleElementLevel>"#));
+        assert!(output.contains(r#"      <PartNumber>1</PartNumber>"#));
+        assert!(output.contains(r#"      <TitleText>Name of series</TitleText>"#));
+
+        // Change all possible values to test that output is updated
+        test_issue.issue_ordinal = 2;
+        test_issue.series.series_name = "Different series".to_string();
+        let output = generate_test_output(&test_issue);
+        assert!(output.contains(r#"<Collection>"#));
+        assert!(output.contains(r#"  <CollectionType>10</CollectionType>"#));
+        assert!(output.contains(r#"  <TitleDetail>"#));
+        assert!(output.contains(r#"    <TitleType>01</TitleType>"#));
+        assert!(output.contains(r#"    <TitleElement>"#));
+        assert!(output.contains(r#"      <TitleElementLevel>02</TitleElementLevel>"#));
+        assert!(output.contains(r#"      <PartNumber>2</PartNumber>"#));
+        assert!(output.contains(r#"      <TitleText>Different series</TitleText>"#));
+    }
+
+    #[test]
+    fn test_onix3_oapen_fundings() {
+        let mut test_funding = WorkFundings {
+            program: Some("Name of program".to_string()),
+            project_name: Some("Name of project".to_string()),
+            project_shortname: None,
+            grant_number: Some("Number of grant".to_string()),
+            jurisdiction: None,
+            funder: thoth_client::WorkFundingsFunder {
+                funder_name: "Name of funder".to_string(),
+                funder_doi: None,
+            },
+        };
+
+        // Test standard output
+        let output = generate_test_output(&test_funding);
+        assert!(output.contains(r#"<Publisher>"#));
+        assert!(output.contains(r#"  <PublishingRole>16</PublishingRole>"#));
+        assert!(output.contains(r#"  <PublisherName>Name of funder</PublisherName>"#));
+        assert!(output.contains(r#"  <Funding>"#));
+        assert!(output.contains(r#"    <FundingIdentifier>"#));
+        assert!(output.contains(r#"      <FundingIDType>01</FundingIDType>"#));
+        assert!(output.contains(r#"      <IDTypeName>programname</IDTypeName>"#));
+        assert!(output.contains(r#"      <IDValue>Name of program</IDValue>"#));
+        assert!(output.contains(r#"      <IDTypeName>projectname</IDTypeName>"#));
+        assert!(output.contains(r#"      <IDValue>Name of project</IDValue>"#));
+        assert!(output.contains(r#"      <IDTypeName>grantnumber</IDTypeName>"#));
+        assert!(output.contains(r#"      <IDValue>Number of grant</IDValue>"#));
+
+        // Change all possible values to test that output is updated
+
+        test_funding.funder.funder_name = "Different funder".to_string();
+        test_funding.program = None;
+        let output = generate_test_output(&test_funding);
+        assert!(output.contains(r#"<Publisher>"#));
+        assert!(output.contains(r#"  <PublishingRole>16</PublishingRole>"#));
+        assert!(output.contains(r#"  <PublisherName>Different funder</PublisherName>"#));
+        assert!(output.contains(r#"  <Funding>"#));
+        assert!(output.contains(r#"    <FundingIdentifier>"#));
+        assert!(output.contains(r#"      <FundingIDType>01</FundingIDType>"#));
+        // No program supplied
+        assert!(!output.contains(r#"      <IDTypeName>programname</IDTypeName>"#));
+        assert!(!output.contains(r#"      <IDValue>Name of program</IDValue>"#));
+        assert!(output.contains(r#"      <IDTypeName>projectname</IDTypeName>"#));
+        assert!(output.contains(r#"      <IDValue>Name of project</IDValue>"#));
+        assert!(output.contains(r#"      <IDTypeName>grantnumber</IDTypeName>"#));
+        assert!(output.contains(r#"      <IDValue>Number of grant</IDValue>"#));
+
+        test_funding.project_name = None;
+        let output = generate_test_output(&test_funding);
+        assert!(output.contains(r#"<Publisher>"#));
+        assert!(output.contains(r#"  <PublishingRole>16</PublishingRole>"#));
+        assert!(output.contains(r#"  <PublisherName>Different funder</PublisherName>"#));
+        assert!(output.contains(r#"  <Funding>"#));
+        assert!(output.contains(r#"    <FundingIdentifier>"#));
+        assert!(output.contains(r#"      <FundingIDType>01</FundingIDType>"#));
+        // No program supplied
+        assert!(!output.contains(r#"      <IDTypeName>programname</IDTypeName>"#));
+        assert!(!output.contains(r#"      <IDValue>Name of program</IDValue>"#));
+        // No project supplied
+        assert!(!output.contains(r#"      <IDTypeName>projectname</IDTypeName>"#));
+        assert!(!output.contains(r#"      <IDValue>Name of project</IDValue>"#));
+        assert!(output.contains(r#"      <IDTypeName>grantnumber</IDTypeName>"#));
+        assert!(output.contains(r#"      <IDValue>Number of grant</IDValue>"#));
+
+        test_funding.grant_number = None;
+        let output = generate_test_output(&test_funding);
+        assert!(output.contains(r#"<Publisher>"#));
+        assert!(output.contains(r#"  <PublishingRole>16</PublishingRole>"#));
+        assert!(output.contains(r#"  <PublisherName>Different funder</PublisherName>"#));
+        // No program, project or grant supplied, so Funding block is omitted completely
+        assert!(!output.contains(r#"  <Funding>"#));
+        assert!(!output.contains(r#"    <FundingIdentifier>"#));
+        assert!(!output.contains(r#"      <FundingIDType>01</FundingIDType>"#));
+        assert!(!output.contains(r#"      <IDTypeName>programname</IDTypeName>"#));
+        assert!(!output.contains(r#"      <IDValue>Name of program</IDValue>"#));
+        assert!(!output.contains(r#"      <IDTypeName>projectname</IDTypeName>"#));
+        assert!(!output.contains(r#"      <IDValue>Name of project</IDValue>"#));
+        assert!(!output.contains(r#"      <IDTypeName>grantnumber</IDTypeName>"#));
+        assert!(!output.contains(r#"      <IDValue>Number of grant</IDValue>"#));
+    }
+
+    #[test]
+    fn test_onix3_oapen_works() {
+        let mut test_work = Work {
+            work_id: Uuid::from_str("00000000-0000-0000-AAAA-000000000001").unwrap(),
+            work_status: WorkStatus::ACTIVE,
+            full_title: "Book Title: Book Subtitle".to_string(),
+            title: "Book Title".to_string(),
+            subtitle: Some("Book Subtitle".to_string()),
+            work_type: WorkType::MONOGRAPH,
+            edition: 1,
+            doi: Some("https://doi.org/10.00001/BOOK.0001".to_string()),
+            publication_date: Some(chrono::NaiveDate::from_ymd(1999, 12, 31)),
+            license: Some("https://creativecommons.org/licenses/by/4.0/".to_string()),
+            copyright_holder: "Author 1; Author 2".to_string(),
+            short_abstract: None,
+            long_abstract: Some("Lorem ipsum dolor sit amet".to_string()),
+            general_note: None,
+            place: Some("León, Spain".to_string()),
+            width: None,
+            height: None,
+            page_count: Some(334),
+            page_breakdown: None,
+            image_count: None,
+            table_count: None,
+            audio_count: None,
+            video_count: None,
+            landing_page: Some("https://www.book.com".to_string()),
+            toc: None,
+            lccn: None,
+            oclc: None,
+            cover_url: Some("https://www.book.com/cover".to_string()),
+            cover_caption: None,
+            imprint: WorkImprint {
+                imprint_name: "OA Editions Imprint".to_string(),
+                publisher: WorkImprintPublisher {
+                    publisher_name: "OA Editions".to_string(),
+                },
+            },
+            issues: vec![],
+            contributions: vec![],
+            languages: vec![],
+            publications: vec![WorkPublications {
+                publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
+                publication_type: PublicationType::PDF,
+                publication_url: Some("https://www.book.com/pdf".to_string()),
+                isbn: Some("978-1-00000-000-2".to_string()),
+                prices: vec![],
+            }],
+            subjects: vec![],
+            fundings: vec![],
+        };
+
+        // Test standard output
+        let output = generate_test_output(&test_work);
+        assert!(output.contains(r#"<Product>"#));
+        assert!(output.contains(
+            r#"  <RecordReference>urn:uuid:00000000-0000-0000-aaaa-000000000001</RecordReference>"#
+        ));
+        assert!(output.contains(r#"  <NotificationType>03</NotificationType>"#));
+        assert!(output.contains(r#"  <RecordSourceType>01</RecordSourceType>"#));
+        assert!(output.contains(r#"  <ProductIdentifier>"#));
+        assert!(output.contains(r#"    <ProductIDType>01</ProductIDType>"#));
+        assert!(output
+            .contains(r#"    <IDValue>urn:uuid:00000000-0000-0000-aaaa-000000000001</IDValue>"#));
+        assert!(output.contains(r#"    <ProductIDType>15</ProductIDType>"#));
+        assert!(output.contains(r#"    <IDValue>9781000000002</IDValue>"#));
+        assert!(output.contains(r#"    <ProductIDType>06</ProductIDType>"#));
+        assert!(output.contains(r#"    <IDValue>10.00001/BOOK.0001</IDValue>"#));
+        assert!(output.contains(r#"  <DescriptiveDetail>"#));
+        assert!(output.contains(r#"    <ProductComposition>00</ProductComposition>"#));
+        assert!(output.contains(r#"    <ProductForm>EB</ProductForm>"#));
+        assert!(output.contains(r#"    <ProductFormDetail>E107</ProductFormDetail>"#));
+        assert!(output.contains(r#"    <PrimaryContentType>10</PrimaryContentType>"#));
+        assert!(output.contains(r#"    <EpubLicense>"#));
+        assert!(
+            output.contains(r#"      <EpubLicenseName>Creative Commons License</EpubLicenseName>"#)
+        );
+        assert!(output.contains(r#"      <EpubLicenseExpression>"#));
+        assert!(
+            output.contains(r#"        <EpubLicenseExpressionType>02</EpubLicenseExpressionType>"#)
+        );
+        assert!(output.contains(r#"        <EpubLicenseExpressionLink>https://creativecommons.org/licenses/by/4.0/</EpubLicenseExpressionLink>"#));
+        assert!(output.contains(r#"    <TitleDetail>"#));
+        assert!(output.contains(r#"      <TitleType>01</TitleType>"#));
+        assert!(output.contains(r#"      <TitleElement>"#));
+        assert!(output.contains(r#"        <TitleElementLevel>01</TitleElementLevel>"#));
+        assert!(output.contains(r#"        <TitleText>Book Title</TitleText>"#));
+        assert!(output.contains(r#"        <Subtitle>Book Subtitle</Subtitle>"#));
+        assert!(output.contains(r#"    <Extent>"#));
+        assert!(output.contains(r#"      <ExtentType>00</ExtentType>"#));
+        assert!(output.contains(r#"      <ExtentValue>334</ExtentValue>"#));
+        assert!(output.contains(r#"      <ExtentUnit>03</ExtentUnit>"#));
+        assert!(output.contains(r#"    <Audience>"#));
+        assert!(output.contains(r#"      <AudienceCodeType>01</AudienceCodeType>"#));
+        assert!(output.contains(r#"      <AudienceCodeValue>06</AudienceCodeValue>"#));
+        assert!(output.contains(r#"  <CollateralDetail>"#));
+        assert!(output.contains(r#"    <TextContent>"#));
+        assert!(output.contains(r#"      <TextType>03</TextType>"#));
+        assert!(output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
+        assert!(output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
+        assert!(output.contains(r#"    <SupportingResource>"#));
+        assert!(output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
+        assert!(output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
+        assert!(output.contains(r#"      <ResourceVersion>"#));
+        assert!(output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
+        assert!(
+            output.contains(r#"        <ResourceLink>https://www.book.com/cover</ResourceLink>"#)
+        );
+        assert!(output.contains(r#"  <PublishingDetail>"#));
+        assert!(output.contains(r#"    <Imprint>"#));
+        assert!(output.contains(r#"      <ImprintName>OA Editions Imprint</ImprintName>"#));
+        assert!(output.contains(r#"    <Publisher>"#));
+        assert!(output.contains(r#"      <PublishingRole>01</PublishingRole>"#));
+        assert!(output.contains(r#"      <PublisherName>OA Editions</PublisherName>"#));
+        assert!(output.contains(r#"    <CityOfPublication>León, Spain</CityOfPublication>"#));
+        assert!(output.contains(r#"    <PublishingStatus>04</PublishingStatus>"#));
+        assert!(output.contains(r#"    <PublishingDate>"#));
+        assert!(output.contains(r#"      <PublishingDateRole>19</PublishingDateRole>"#));
+        assert!(output.contains(r#"      <Date dateformat="05">1999</Date>"#));
+        assert!(output.contains(r#"    <RelatedProduct>"#));
+        assert!(output.contains(r#"      <ProductRelationCode>06</ProductRelationCode>"#));
+        assert!(output.contains(r#"      <ProductIdentifier>"#));
+        assert!(output.contains(r#"        <ProductIDType>15</ProductIDType>"#));
+        assert!(output.contains(r#"        <IDValue>9781000000002</IDValue>"#));
+        assert!(output.contains(r#"  <ProductSupply>"#));
+        assert!(output.contains(r#"    <SupplyDetail>"#));
+        assert!(output.contains(r#"      <Supplier>"#));
+        assert!(output.contains(r#"        <SupplierRole>09</SupplierRole>"#));
+        assert!(output.contains(r#"        <SupplierName>OA Editions</SupplierName>"#));
+        assert!(output.contains(r#"        <Website>"#));
+        assert!(output.contains(r#"          <WebsiteRole>01</WebsiteRole>"#));
+        assert!(output.contains(
+            r#"          <WebsiteDescription>Publisher's website: web shop</WebsiteDescription>"#
+        ));
+        assert!(output.contains(r#"          <WebsiteLink>https://www.book.com</WebsiteLink>"#));
+        assert!(output.contains(r#"      <ProductAvailability>99</ProductAvailability>"#));
+        assert!(output.contains(r#"      <UnpricedItemType>04</UnpricedItemType>"#));
+        assert!(output.contains(r#"        <SupplierRole>09</SupplierRole>"#));
+        assert!(output.contains(r#"        <SupplierName>OA Editions</SupplierName>"#));
+        assert!(output.contains(r#"          <WebsiteRole>29</WebsiteRole>"#));
+        assert!(output.contains(r#"          <WebsiteDescription>Publisher's website: download the title</WebsiteDescription>"#));
+        assert!(output.contains(r#"          <WebsiteLink>https://www.book.com/pdf</WebsiteLink>"#));
+
+        // Remove some values to test non-output of optional blocks
+        test_work.doi = None;
+        test_work.license = None;
+        test_work.subtitle = None;
+        test_work.page_count = None;
+        test_work.long_abstract = None;
+        test_work.place = None;
+        test_work.publication_date = None;
+        test_work.landing_page = None;
+        let output = generate_test_output(&test_work);
+        // No DOI supplied
+        assert!(!output.contains(r#"    <ProductIDType>06</ProductIDType>"#));
+        assert!(!output.contains(r#"    <IDValue>10.00001/BOOK.0001</IDValue>"#));
+        // No licence supplied
+        assert!(!output.contains(r#"    <EpubLicense>"#));
+        assert!(!output
+            .contains(r#"      <EpubLicenseName>Creative Commons License</EpubLicenseName>"#));
+        assert!(!output.contains(r#"      <EpubLicenseExpression>"#));
+        assert!(!output
+            .contains(r#"        <EpubLicenseExpressionType>02</EpubLicenseExpressionType>"#));
+        assert!(!output.contains(r#"        <EpubLicenseExpressionLink>https://creativecommons.org/licenses/by/4.0/</EpubLicenseExpressionLink>"#));
+        // No subtitle supplied: work FullTitle is used instead of Title
+        assert!(!output.contains(r#"        <TitleText>Book Title</TitleText>"#));
+        assert!(!output.contains(r#"        <Subtitle>Book Subtitle</Subtitle>"#));
+        assert!(output.contains(r#"        <TitleText>Book Title: Book Subtitle</TitleText>"#));
+        // No page count supplied
+        assert!(!output.contains(r#"    <Extent>"#));
+        assert!(!output.contains(r#"      <ExtentType>00</ExtentType>"#));
+        assert!(!output.contains(r#"      <ExtentValue>334</ExtentValue>"#));
+        assert!(!output.contains(r#"      <ExtentUnit>03</ExtentUnit>"#));
+        // No long abstract supplied: CollateralDetail block only contains cover URL
+        assert!(output.contains(r#"  <CollateralDetail>"#));
+        assert!(output.contains(r#"    <SupportingResource>"#));
+        assert!(output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
+        assert!(output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
+        assert!(output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
+        assert!(output.contains(r#"      <ResourceVersion>"#));
+        assert!(output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
+        assert!(
+            output.contains(r#"        <ResourceLink>https://www.book.com/cover</ResourceLink>"#)
+        );
+        assert!(!output.contains(r#"    <TextContent>"#));
+        assert!(!output.contains(r#"      <TextType>03</TextType>"#));
+        assert!(!output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
+        // No place supplied
+        assert!(!output.contains(r#"    <CityOfPublication>León, Spain</CityOfPublication>"#));
+        // No publication date supplied
+        assert!(!output.contains(r#"    <PublishingDate>"#));
+        assert!(!output.contains(r#"      <PublishingDateRole>19</PublishingDateRole>"#));
+        assert!(!output.contains(r#"      <Date dateformat="05">1999</Date>"#));
+        // No landing page supplied: only one SupplyDetail block, linking to PDF download
+        assert!(!output.contains(r#"          <WebsiteRole>01</WebsiteRole>"#));
+        assert!(!output.contains(
+            r#"          <WebsiteDescription>Publisher's website: web shop</WebsiteDescription>"#
+        ));
+        assert!(!output.contains(r#"          <WebsiteLink>https://www.book.com</WebsiteLink>"#));
+
+        // Replace long abstract but remove cover URL
+        // Result: CollateralDetail block still present, but now only contains long abstract
+        test_work.long_abstract = Some("Lorem ipsum dolor sit amet".to_string());
+        test_work.cover_url = None;
+        let output = generate_test_output(&test_work);
+        assert!(output.contains(r#"  <CollateralDetail>"#));
+        assert!(output.contains(r#"    <TextContent>"#));
+        assert!(output.contains(r#"      <TextType>03</TextType>"#));
+        assert!(output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
+        assert!(output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
+        assert!(!output.contains(r#"    <SupportingResource>"#));
+        assert!(!output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
+        assert!(!output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
+        assert!(!output.contains(r#"      <ResourceVersion>"#));
+        assert!(!output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
+        assert!(!output
+            .contains(r#"        <ResourceLink>"https://www.book.com/cover"</ResourceLink>"#));
+
+        // Remove both cover URL and long abstract
+        // Result: No CollateralDetail block present at all
+        test_work.long_abstract = None;
+        let output = generate_test_output(&test_work);
+        assert!(!output.contains(r#"  <CollateralDetail>"#));
+        assert!(!output.contains(r#"    <TextContent>"#));
+        assert!(!output.contains(r#"      <TextType>03</TextType>"#));
+        assert!(!output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
+        assert!(!output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
+        assert!(!output.contains(r#"    <SupportingResource>"#));
+        assert!(!output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
+        assert!(!output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
+        assert!(!output.contains(r#"      <ResourceVersion>"#));
+        assert!(!output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
+        assert!(!output
+            .contains(r#"        <ResourceLink>"https://www.book.com/cover"</ResourceLink>"#));
+
+        // Remove the only publication, which is the PDF
+        // Result: error (can't generate OAPEN ONIX without PDF URL)
+        test_work.publications.clear();
+        // Can't use helper function for this as it assumes Ok rather than Err
+        let mut buffer = Vec::new();
+        let mut writer = xml::writer::EmitterConfig::new()
+            .perform_indent(true)
+            .create_writer(&mut buffer);
+        let wrapped_output = XmlElementBlock::<Onix3Oapen>::xml_element(&test_work, &mut writer)
+            .map(|_| buffer)
+            .and_then(|onix| {
+                String::from_utf8(onix)
+                    .map_err(|_| ThothError::InternalError("Could not parse XML".to_string()))
+            });
+        assert!(wrapped_output.is_err());
+        let output = wrapped_output.unwrap_err().to_string();
+        assert_eq!(
+            output,
+            "Could not generate onix_3.0::oapen: Missing PDF URL".to_string()
+        );
     }
 }

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -294,9 +294,9 @@ impl XmlElementBlock<Onix3ProjectMuse> for Work {
                                     w.write(XmlEvent::Characters("06")).map_err(|e| e.into())
                                 })?;
                                 write_element_block("ProductIdentifier", w, |w| {
-                                    // 06 ISBN
+                                    // 15 ISBN-13
                                     write_element_block("ProductIDType", w, |w| {
-                                        w.write(XmlEvent::Characters("06")).map_err(|e| e.into())
+                                        w.write(XmlEvent::Characters("15")).map_err(|e| e.into())
                                     })?;
                                     write_element_block("IDValue", w, |w| {
                                         w.write(XmlEvent::Characters(&isbn)).map_err(|e| e.into())
@@ -308,15 +308,21 @@ impl XmlElementBlock<Onix3ProjectMuse> for Work {
                     })?;
                 }
                 write_element_block("ProductSupply", w, |w| {
-                    let mut supplies: HashMap<String, String> = HashMap::new();
+                    let mut supplies: HashMap<String, (String, String)> = HashMap::new();
                     supplies.insert(
                         pdf_url.to_string(),
-                        "Publisher's website: download the title".to_string(),
+                        (
+                            "29".to_string(),
+                            "Publisher's website: download the title".to_string(),
+                        ),
                     );
                     if let Some(landing_page) = &self.landing_page {
                         supplies.insert(
                             landing_page.to_string(),
-                            "Publisher's website: web shop".to_string(),
+                            (
+                                "01".to_string(),
+                                "Publisher's website: web shop".to_string(),
+                            ),
                         );
                     }
                     for (url, description) in supplies.iter() {
@@ -324,7 +330,7 @@ impl XmlElementBlock<Onix3ProjectMuse> for Work {
                             write_element_block("Supplier", w, |w| {
                                 // 09 Publisher to end-customers
                                 write_element_block("SupplierRole", w, |w| {
-                                    w.write(XmlEvent::Characters("11")).map_err(|e| e.into())
+                                    w.write(XmlEvent::Characters("09")).map_err(|e| e.into())
                                 })?;
                                 write_element_block("SupplierName", w, |w| {
                                     w.write(XmlEvent::Characters(
@@ -335,10 +341,11 @@ impl XmlElementBlock<Onix3ProjectMuse> for Work {
                                 write_element_block("Website", w, |w| {
                                     // 01 Publisher’s corporate website
                                     write_element_block("WebsiteRole", w, |w| {
-                                        w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
+                                        w.write(XmlEvent::Characters(&description.0))
+                                            .map_err(|e| e.into())
                                     })?;
                                     write_element_block("WebsiteDescription", w, |w| {
-                                        w.write(XmlEvent::Characters(&description))
+                                        w.write(XmlEvent::Characters(&description.1))
                                             .map_err(|e| e.into())
                                     })?;
                                     write_element_block("WebsiteLink", w, |w| {

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -173,7 +173,9 @@ impl XmlElementBlock<Onix3ProjectMuse> for Work {
                             }
                         })
                     })?;
-                    XmlElementBlock::<Onix3ProjectMuse>::xml_element(&self.contributions, w).ok();
+                    for contribution in &self.contributions {
+                        XmlElementBlock::<Onix3ProjectMuse>::xml_element(contribution, w).ok();
+                    }
                     for language in &self.languages {
                         XmlElementBlock::<Onix3ProjectMuse>::xml_element(language, w).ok();
                     }
@@ -460,48 +462,42 @@ impl XmlElement<Onix3ProjectMuse> for ContributionType {
     }
 }
 
-// Replace with implementation for WorkContributions (without the vector)
-// when we implement contribution ordering
-impl XmlElementBlock<Onix3ProjectMuse> for Vec<WorkContributions> {
+impl XmlElementBlock<Onix3ProjectMuse> for WorkContributions {
     fn xml_element<W: Write>(&self, w: &mut EventWriter<W>) -> ThothResult<()> {
-        for (mut sequence_number, contribution) in self.iter().enumerate() {
-            sequence_number += 1;
-            write_element_block("Contributor", w, |w| {
-                write_element_block("SequenceNumber", w, |w| {
-                    w.write(XmlEvent::Characters(&sequence_number.to_string()))
+        write_element_block("Contributor", w, |w| {
+            write_element_block("SequenceNumber", w, |w| {
+                w.write(XmlEvent::Characters(&self.contribution_ordinal.to_string()))
+                    .map_err(|e| e.into())
+            })?;
+            XmlElement::<Onix3ProjectMuse>::xml_element(&self.contribution_type, w)?;
+
+            if let Some(orcid) = &self.contributor.orcid {
+                write_element_block("NameIdentifier", w, |w| {
+                    write_element_block("NameIDType", w, |w| {
+                        w.write(XmlEvent::Characters("21")).map_err(|e| e.into())
+                    })?;
+                    write_element_block("IDValue", w, |w| {
+                        w.write(XmlEvent::Characters(&orcid)).map_err(|e| e.into())
+                    })
+                })?;
+            }
+            if let Some(first_name) = &self.first_name {
+                write_element_block("NamesBeforeKey", w, |w| {
+                    w.write(XmlEvent::Characters(&first_name))
                         .map_err(|e| e.into())
                 })?;
-                XmlElement::<Onix3ProjectMuse>::xml_element(&contribution.contribution_type, w)?;
-
-                if let Some(orcid) = &contribution.contributor.orcid {
-                    write_element_block("NameIdentifier", w, |w| {
-                        write_element_block("NameIDType", w, |w| {
-                            w.write(XmlEvent::Characters("21")).map_err(|e| e.into())
-                        })?;
-                        write_element_block("IDValue", w, |w| {
-                            w.write(XmlEvent::Characters(&orcid)).map_err(|e| e.into())
-                        })
-                    })?;
-                }
-                if let Some(first_name) = &contribution.first_name {
-                    write_element_block("NamesBeforeKey", w, |w| {
-                        w.write(XmlEvent::Characters(&first_name))
-                            .map_err(|e| e.into())
-                    })?;
-                    write_element_block("KeyNames", w, |w| {
-                        w.write(XmlEvent::Characters(&contribution.last_name))
-                            .map_err(|e| e.into())
-                    })?;
-                } else {
-                    write_element_block("PersonName", w, |w| {
-                        w.write(XmlEvent::Characters(&contribution.full_name))
-                            .map_err(|e| e.into())
-                    })?;
-                }
-                Ok(())
-            })?;
-        }
-        Ok(())
+                write_element_block("KeyNames", w, |w| {
+                    w.write(XmlEvent::Characters(&self.last_name))
+                        .map_err(|e| e.into())
+                })?;
+            } else {
+                write_element_block("PersonName", w, |w| {
+                    w.write(XmlEvent::Characters(&self.full_name))
+                        .map_err(|e| e.into())
+                })?;
+            }
+            Ok(())
+        })
     }
 }
 


### PR DESCRIPTION
Fixes #48.

Based on our existing ONIX XML output (Project Muse flavour) in combination with comments on this output plus an example file from OAPEN. Example output following these changes sent to OAPEN and confirmed all OK.

Includes some testing which could be extended under #253.