### PR TITLE
Add Project MUSE ONIX output format tests (#253, part)

### DIFF
--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -602,21 +602,31 @@ mod tests {
         assert!(!output.contains(r#"  <KeyNames>1</KeyNames>"#));
         assert!(output.contains(r#"  <PersonName>Author 1</PersonName>"#));
 
-        // All roles except Author and Editor are output as Z01
-        for contribution_type in [
-            ContributionType::TRANSLATOR,
-            ContributionType::PHOTOGRAPHER,
-            ContributionType::ILUSTRATOR,
-            ContributionType::MUSIC_EDITOR,
-            ContributionType::FOREWORD_BY,
-            ContributionType::INTRODUCTION_BY,
-            ContributionType::AFTERWORD_BY,
-            ContributionType::PREFACE_BY,
-        ] {
-            test_contribution.contribution_type = contribution_type;
-            let output = generate_test_output(&test_contribution);
-            assert!(output.contains(r#"  <ContributorRole>Z01</ContributorRole>"#));
-        }
+        // Test all remaining contributor roles
+        test_contribution.contribution_type = ContributionType::TRANSLATOR;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>B06</ContributorRole>"#));
+        test_contribution.contribution_type = ContributionType::PHOTOGRAPHER;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>A13</ContributorRole>"#));
+        test_contribution.contribution_type = ContributionType::ILUSTRATOR;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>A12</ContributorRole>"#));
+        test_contribution.contribution_type = ContributionType::MUSIC_EDITOR;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>B25</ContributorRole>"#));
+        test_contribution.contribution_type = ContributionType::FOREWORD_BY;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>A23</ContributorRole>"#));
+        test_contribution.contribution_type = ContributionType::INTRODUCTION_BY;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>A24</ContributorRole>"#));
+        test_contribution.contribution_type = ContributionType::AFTERWORD_BY;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>A19</ContributorRole>"#));
+        test_contribution.contribution_type = ContributionType::PREFACE_BY;
+        let output = generate_test_output(&test_contribution);
+        assert!(output.contains(r#"  <ContributorRole>A15</ContributorRole>"#));
     }
 
     #[test]
@@ -676,10 +686,10 @@ mod tests {
             audio_count: None,
             video_count: None,
             landing_page: Some("https://www.book.com".to_string()),
-            toc: None,
+            toc: Some("1. Chapter 1".to_string()),
             lccn: None,
             oclc: None,
-            cover_url: Some("https://www.book.com/cover".to_string()),
+            cover_url: None,
             cover_caption: None,
             imprint: WorkImprint {
                 imprint_name: "OA Editions Imprint".to_string(),
@@ -741,22 +751,14 @@ mod tests {
         assert!(output.contains(r#"      <ExtentType>00</ExtentType>"#));
         assert!(output.contains(r#"      <ExtentValue>334</ExtentValue>"#));
         assert!(output.contains(r#"      <ExtentUnit>03</ExtentUnit>"#));
-        assert!(output.contains(r#"    <Audience>"#));
-        assert!(output.contains(r#"      <AudienceCodeType>01</AudienceCodeType>"#));
-        assert!(output.contains(r#"      <AudienceCodeValue>06</AudienceCodeValue>"#));
         assert!(output.contains(r#"  <CollateralDetail>"#));
         assert!(output.contains(r#"    <TextContent>"#));
         assert!(output.contains(r#"      <TextType>03</TextType>"#));
         assert!(output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
         assert!(output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
-        assert!(output.contains(r#"    <SupportingResource>"#));
-        assert!(output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
-        assert!(output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
-        assert!(output.contains(r#"      <ResourceVersion>"#));
-        assert!(output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
-        assert!(
-            output.contains(r#"        <ResourceLink>https://www.book.com/cover</ResourceLink>"#)
-        );
+        assert!(output.contains(r#"    <TextContent>"#));
+        assert!(output.contains(r#"      <TextType>04</TextType>"#));
+        assert!(output.contains(r#"      <Text>1. Chapter 1</Text>"#));
         assert!(output.contains(r#"  <PublishingDetail>"#));
         assert!(output.contains(r#"    <Imprint>"#));
         assert!(output.contains(r#"      <ImprintName>OA Editions Imprint</ImprintName>"#));
@@ -767,7 +769,7 @@ mod tests {
         assert!(output.contains(r#"    <PublishingStatus>04</PublishingStatus>"#));
         assert!(output.contains(r#"    <PublishingDate>"#));
         assert!(output.contains(r#"      <PublishingDateRole>19</PublishingDateRole>"#));
-        assert!(output.contains(r#"      <Date dateformat="05">1999</Date>"#));
+        assert!(output.contains(r#"      <Date dateformat="01">199912</Date>"#));
         assert!(output.contains(r#"    <RelatedProduct>"#));
         assert!(output.contains(r#"      <ProductRelationCode>06</ProductRelationCode>"#));
         assert!(output.contains(r#"      <ProductIdentifier>"#));
@@ -822,18 +824,12 @@ mod tests {
         assert!(!output.contains(r#"      <ExtentType>00</ExtentType>"#));
         assert!(!output.contains(r#"      <ExtentValue>334</ExtentValue>"#));
         assert!(!output.contains(r#"      <ExtentUnit>03</ExtentUnit>"#));
-        // No long abstract supplied: CollateralDetail block only contains cover URL
+        // No long abstract supplied: CollateralDetail block only contains TOC
         assert!(output.contains(r#"  <CollateralDetail>"#));
-        assert!(output.contains(r#"    <SupportingResource>"#));
-        assert!(output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
+        assert!(output.contains(r#"    <TextContent>"#));
+        assert!(output.contains(r#"      <TextType>04</TextType>"#));
         assert!(output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
-        assert!(output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
-        assert!(output.contains(r#"      <ResourceVersion>"#));
-        assert!(output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
-        assert!(
-            output.contains(r#"        <ResourceLink>https://www.book.com/cover</ResourceLink>"#)
-        );
-        assert!(!output.contains(r#"    <TextContent>"#));
+        assert!(output.contains(r#"      <Text>1. Chapter 1</Text>"#));
         assert!(!output.contains(r#"      <TextType>03</TextType>"#));
         assert!(!output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
         // No place supplied
@@ -841,7 +837,7 @@ mod tests {
         // No publication date supplied
         assert!(!output.contains(r#"    <PublishingDate>"#));
         assert!(!output.contains(r#"      <PublishingDateRole>19</PublishingDateRole>"#));
-        assert!(!output.contains(r#"      <Date dateformat="05">1999</Date>"#));
+        assert!(!output.contains(r#"      <Date dateformat="01">199912</Date>"#));
         // No landing page supplied: only one SupplyDetail block, linking to PDF download
         assert!(!output.contains(r#"          <WebsiteRole>01</WebsiteRole>"#));
         assert!(!output.contains(
@@ -849,25 +845,20 @@ mod tests {
         ));
         assert!(!output.contains(r#"          <WebsiteLink>https://www.book.com</WebsiteLink>"#));
 
-        // Replace long abstract but remove cover URL
+        // Replace long abstract but remove TOC
         // Result: CollateralDetail block still present, but now only contains long abstract
         test_work.long_abstract = Some("Lorem ipsum dolor sit amet".to_string());
-        test_work.cover_url = None;
+        test_work.toc = None;
         let output = generate_test_output(&test_work);
         assert!(output.contains(r#"  <CollateralDetail>"#));
         assert!(output.contains(r#"    <TextContent>"#));
         assert!(output.contains(r#"      <TextType>03</TextType>"#));
         assert!(output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
         assert!(output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
-        assert!(!output.contains(r#"    <SupportingResource>"#));
-        assert!(!output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
-        assert!(!output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
-        assert!(!output.contains(r#"      <ResourceVersion>"#));
-        assert!(!output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
-        assert!(!output
-            .contains(r#"        <ResourceLink>"https://www.book.com/cover"</ResourceLink>"#));
+        assert!(!output.contains(r#"      <TextType>04</TextType>"#));
+        assert!(!output.contains(r#"      <Text>1. Chapter 1</Text>"#));
 
-        // Remove both cover URL and long abstract
+        // Remove both TOC and long abstract
         // Result: No CollateralDetail block present at all
         test_work.long_abstract = None;
         let output = generate_test_output(&test_work);
@@ -876,13 +867,8 @@ mod tests {
         assert!(!output.contains(r#"      <TextType>03</TextType>"#));
         assert!(!output.contains(r#"      <ContentAudience>00</ContentAudience>"#));
         assert!(!output.contains(r#"      <Text language="eng">Lorem ipsum dolor sit amet</Text>"#));
-        assert!(!output.contains(r#"    <SupportingResource>"#));
-        assert!(!output.contains(r#"      <ResourceContentType>01</ResourceContentType>"#));
-        assert!(!output.contains(r#"      <ResourceMode>03</ResourceMode>"#));
-        assert!(!output.contains(r#"      <ResourceVersion>"#));
-        assert!(!output.contains(r#"        <ResourceForm>02</ResourceForm>"#));
-        assert!(!output
-            .contains(r#"        <ResourceLink>"https://www.book.com/cover"</ResourceLink>"#));
+        assert!(!output.contains(r#"      <TextType>04</TextType>"#));
+        assert!(!output.contains(r#"      <Text>1. Chapter 1</Text>"#));
 
         // Remove the only publication, which is the PDF
         // Result: error (can't generate OAPEN ONIX without PDF URL)

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -534,7 +534,8 @@ mod tests {
     use thoth_api::model::Orcid;
     use thoth_client::{
         ContributionType, LanguageCode, LanguageRelation, PublicationType,
-        WorkContributionsContributor, WorkImprint, WorkImprintPublisher, WorkStatus, WorkType,
+        WorkContributionsContributor, WorkImprint, WorkImprintPublisher, WorkStatus, WorkSubjects,
+        WorkType,
     };
     use uuid::Uuid;
 
@@ -707,7 +708,38 @@ mod tests {
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
             }],
-            subjects: vec![],
+            subjects: vec![
+                WorkSubjects {
+                    subject_code: "AAB".to_string(),
+                    subject_type: SubjectType::BIC,
+                    subject_ordinal: 1,
+                },
+                WorkSubjects {
+                    subject_code: "AAA000000".to_string(),
+                    subject_type: SubjectType::BISAC,
+                    subject_ordinal: 2,
+                },
+                WorkSubjects {
+                    subject_code: "JA85".to_string(),
+                    subject_type: SubjectType::LCC,
+                    subject_ordinal: 3,
+                },
+                WorkSubjects {
+                    subject_code: "JWA".to_string(),
+                    subject_type: SubjectType::THEMA,
+                    subject_ordinal: 4,
+                },
+                WorkSubjects {
+                    subject_code: "keyword1".to_string(),
+                    subject_type: SubjectType::KEYWORD,
+                    subject_ordinal: 5,
+                },
+                WorkSubjects {
+                    subject_code: "custom1".to_string(),
+                    subject_type: SubjectType::CUSTOM,
+                    subject_ordinal: 6,
+                },
+            ],
             fundings: vec![],
         };
 
@@ -751,6 +783,19 @@ mod tests {
         assert!(output.contains(r#"      <ExtentType>00</ExtentType>"#));
         assert!(output.contains(r#"      <ExtentValue>334</ExtentValue>"#));
         assert!(output.contains(r#"      <ExtentUnit>03</ExtentUnit>"#));
+        assert!(output.contains(r#"    <Subject>"#));
+        assert!(output.contains(r#"      <SubjectSchemeIdentifier>12</SubjectSchemeIdentifier>"#));
+        assert!(output.contains(r#"      <SubjectCode>AAB</SubjectCode>"#));
+        assert!(output.contains(r#"      <SubjectSchemeIdentifier>10</SubjectSchemeIdentifier>"#));
+        assert!(output.contains(r#"      <SubjectCode>AAA000000</SubjectCode>"#));
+        assert!(output.contains(r#"      <SubjectSchemeIdentifier>04</SubjectSchemeIdentifier>"#));
+        assert!(output.contains(r#"      <SubjectCode>JA85</SubjectCode>"#));
+        assert!(output.contains(r#"      <SubjectSchemeIdentifier>93</SubjectSchemeIdentifier>"#));
+        assert!(output.contains(r#"      <SubjectCode>JWA</SubjectCode>"#));
+        assert!(output.contains(r#"      <SubjectSchemeIdentifier>20</SubjectSchemeIdentifier>"#));
+        assert!(output.contains(r#"      <SubjectCode>keyword1</SubjectCode>"#));
+        assert!(output.contains(r#"      <SubjectSchemeIdentifier>B2</SubjectSchemeIdentifier>"#));
+        assert!(output.contains(r#"      <SubjectCode>custom1</SubjectCode>"#));
         assert!(output.contains(r#"  <CollateralDetail>"#));
         assert!(output.contains(r#"    <TextContent>"#));
         assert!(output.contains(r#"      <TextType>03</TextType>"#));
@@ -803,6 +848,7 @@ mod tests {
         test_work.place = None;
         test_work.publication_date = None;
         test_work.landing_page = None;
+        test_work.subjects.clear();
         let output = generate_test_output(&test_work);
         // No DOI supplied
         assert!(!output.contains(r#"    <ProductIDType>06</ProductIDType>"#));
@@ -844,6 +890,20 @@ mod tests {
             r#"          <WebsiteDescription>Publisher's website: web shop</WebsiteDescription>"#
         ));
         assert!(!output.contains(r#"          <WebsiteLink>https://www.book.com</WebsiteLink>"#));
+        // No subjects supplied
+        assert!(!output.contains(r#"    <Subject>"#));
+        assert!(!output.contains(r#"      <SubjectSchemeIdentifier>12</SubjectSchemeIdentifier>"#));
+        assert!(!output.contains(r#"      <SubjectCode>AAB</SubjectCode>"#));
+        assert!(!output.contains(r#"      <SubjectSchemeIdentifier>10</SubjectSchemeIdentifier>"#));
+        assert!(!output.contains(r#"      <SubjectCode>AAA000000</SubjectCode>"#));
+        assert!(!output.contains(r#"      <SubjectSchemeIdentifier>04</SubjectSchemeIdentifier>"#));
+        assert!(!output.contains(r#"      <SubjectCode>JA85</SubjectCode>"#));
+        assert!(!output.contains(r#"      <SubjectSchemeIdentifier>93</SubjectSchemeIdentifier>"#));
+        assert!(!output.contains(r#"      <SubjectCode>JWA</SubjectCode>"#));
+        assert!(!output.contains(r#"      <SubjectSchemeIdentifier>20</SubjectSchemeIdentifier>"#));
+        assert!(!output.contains(r#"      <SubjectCode>keyword1</SubjectCode>"#));
+        assert!(!output.contains(r#"      <SubjectSchemeIdentifier>B2</SubjectSchemeIdentifier>"#));
+        assert!(!output.contains(r#"      <SubjectCode>custom1</SubjectCode>"#));
 
         // Replace long abstract but remove TOC
         // Result: CollateralDetail block still present, but now only contains long abstract


### PR DESCRIPTION
Contributes to #253. Follows example of OAPEN ONIX output format tests.