### PR TITLE
Implement location table to store URLs and further information about publications (#297)

### DIFF
--- a/thoth-api/migrations/0.4.8/down.sql
+++ b/thoth-api/migrations/0.4.8/down.sql
@@ -3,8 +3,9 @@ ALTER TABLE publication
     ADD COLUMN publication_url TEXT CHECK (publication_url ~* '^[^:]*:\/\/(?:[^\/:]*:[^\/@]*@)?(?:[^\/:.]*\.)+([^:\/]+)');
 
 -- Migrate location URLs back into publication table as far as possible before dropping location table:
--- set the landing page of the canonical location (if any) as the main publication_url,
+-- set the landing_page or full_text_url of the canonical location as the main publication_url,
 -- then create duplicate publications to store all other location URLs (landing page/full text).
+-- Note this will create multiple identical publications if the same URL is re-used across location fields.
 UPDATE publication
     SET publication_url = location.landing_page
         FROM location

--- a/thoth-api/migrations/0.4.8/down.sql
+++ b/thoth-api/migrations/0.4.8/down.sql
@@ -1,5 +1,6 @@
 ALTER TABLE publication
-    DROP CONSTRAINT publication_publication_type_work_id_uniq;
+    DROP CONSTRAINT publication_publication_type_work_id_uniq,
+    ADD COLUMN publication_url TEXT CHECK (publication_url ~* '^[^:]*:\/\/(?:[^\/:]*:[^\/@]*@)?(?:[^\/:.]*\.)+([^:\/]+)');
 
 -- Migrate location URLs back into publication table as far as possible before dropping location table:
 -- set the landing page of the canonical location (if any) as the main publication_url,

--- a/thoth-api/migrations/0.4.8/down.sql
+++ b/thoth-api/migrations/0.4.8/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE location_history;
+DROP TRIGGER set_updated_at ON location;
+DROP TABLE location;
+DROP TYPE IF EXISTS location_platform;

--- a/thoth-api/migrations/0.4.8/down.sql
+++ b/thoth-api/migrations/0.4.8/down.sql
@@ -1,3 +1,24 @@
+ALTER TABLE publication
+    DROP CONSTRAINT publication_publication_type_work_id_uniq;
+
+-- Migrate location URLs back into publication table as far as possible before dropping location table:
+-- set the landing page of the canonical location (if any) as the main publication_url,
+-- then create duplicate publications to store all other location URLs (landing page/full text).
+UPDATE publication
+   SET publication_url = location.landing_page
+      FROM location
+      WHERE publication.publication_id = location.publication_id
+      AND location.canonical
+      AND location.full_text_url IS NULL;
+INSERT INTO publication(publication_type, work_id, publication_url)
+    SELECT publication.publication_type, publication.work_id, location.landing_page FROM publication, location
+    WHERE publication.publication_id = location.publication_id
+    AND NOT location.canonical;
+INSERT INTO publication(publication_type, work_id, publication_url)
+    SELECT publication.publication_type, publication.work_id, location.full_text_url FROM publication, location
+    WHERE publication.publication_id = location.publication_id
+    AND location.full_text_url IS NOT NULL;
+
 DROP TABLE location_history;
 DROP TRIGGER set_updated_at ON location;
 DROP TABLE location;

--- a/thoth-api/migrations/0.4.8/up.sql
+++ b/thoth-api/migrations/0.4.8/up.sql
@@ -1,7 +1,14 @@
 CREATE TYPE location_platform AS ENUM (
     'Project MUSE',
     'OAPEN',
+    'DOAB',
     'JSTOR',
+    'EBSCO Host',
+    'OCLC KB',
+    'ProQuest KB',
+    'ProQuest ExLibris',
+    'EBSCO KB',
+    'JISC KB',
     'Other'
 );
 

--- a/thoth-api/migrations/0.4.8/up.sql
+++ b/thoth-api/migrations/0.4.8/up.sql
@@ -37,8 +37,10 @@ CREATE TABLE location_history (
 INSERT INTO location(publication_id, landing_page)
     SELECT publication_id, publication_url FROM publication WHERE publication_url IS NOT NULL;
 
--- Only allow one publication of each type per work (existing data may breach this)
--- To check for records which breach this constraint:
--- `select * from publication a where (select count(*) from publication b where a.publication_type = b.publication_type and a.work_id = b.work_id) > 1 order by work_id, publication_type;`
 ALTER TABLE publication
-    ADD CONSTRAINT publication_publication_type_work_id_uniq UNIQUE (publication_type, work_id);
+    -- Only allow one publication of each type per work (existing data may breach this)
+    -- To check for records which breach this constraint:
+    -- `select * from publication a where (select count(*) from publication b where a.publication_type = b.publication_type and a.work_id = b.work_id) > 1 order by work_id, publication_type;`
+    ADD CONSTRAINT publication_publication_type_work_id_uniq UNIQUE (publication_type, work_id),
+    -- Remove publication_url column (all data should have been migrated to location table above)
+    DROP COLUMN publication_url;

--- a/thoth-api/migrations/0.4.8/up.sql
+++ b/thoth-api/migrations/0.4.8/up.sql
@@ -1,0 +1,29 @@
+CREATE TYPE location_platform AS ENUM (
+    'Project MUSE',
+    'OAPEN',
+    'JSTOR',
+    'Other'
+);
+
+CREATE TABLE location (
+    location_id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    publication_id      UUID NOT NULL REFERENCES publication(publication_id) ON DELETE CASCADE,
+    landing_page        TEXT NOT NULL CHECK (landing_page ~* '^[^:]*:\/\/(?:[^\/:]*:[^\/@]*@)?(?:[^\/:.]*\.)+([^:\/]+)'),
+    full_text_url       TEXT CHECK (full_text_url ~* '^[^:]*:\/\/(?:[^\/:]*:[^\/@]*@)?(?:[^\/:.]*\.)+([^:\/]+)'),
+    location_platform   location_platform NOT NULL DEFAULT 'Other',
+    canonical           BOOLEAN NOT NULL DEFAULT True,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+SELECT diesel_manage_updated_at('location');
+
+CREATE TABLE location_history (
+    location_history_id      UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    location_id              UUID NOT NULL REFERENCES location(location_id) ON DELETE CASCADE,
+    account_id               UUID NOT NULL REFERENCES account(account_id),
+    data                     JSONB NOT NULL,
+    timestamp                TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO location(publication_id, landing_page)
+    SELECT publication_id, publication_url FROM publication WHERE publication_url IS NOT NULL;

--- a/thoth-api/migrations/0.4.8/up.sql
+++ b/thoth-api/migrations/0.4.8/up.sql
@@ -13,7 +13,9 @@ CREATE TABLE location (
     location_platform   location_platform NOT NULL DEFAULT 'Other',
     canonical           BOOLEAN NOT NULL DEFAULT False,
     created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Location must contain at least one of landing_page or full_text_url
+    CONSTRAINT location_url_check CHECK (landing_page IS NOT NULL OR full_text_url IS NOT NULL)
 );
 SELECT diesel_manage_updated_at('location');
 

--- a/thoth-api/migrations/0.4.8/up.sql
+++ b/thoth-api/migrations/0.4.8/up.sql
@@ -17,6 +17,14 @@ CREATE TABLE location (
 );
 SELECT diesel_manage_updated_at('location');
 
+-- Only allow one canonical location per publication
+CREATE UNIQUE INDEX location_uniq_canonical_true_idx ON location(publication_id)
+    WHERE canonical;
+
+-- Only allow one instance of each platform (except 'Other') per publication
+CREATE UNIQUE INDEX location_uniq_platform_idx ON location(publication_id,location_platform)
+    WHERE NOT location_platform = 'Other';
+
 CREATE TABLE location_history (
     location_history_id      UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     location_id              UUID NOT NULL REFERENCES location(location_id) ON DELETE CASCADE,
@@ -25,5 +33,12 @@ CREATE TABLE location_history (
     timestamp                TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Create location entries for every existing publication_url (assume all are landing pages)
 INSERT INTO location(publication_id, landing_page)
     SELECT publication_id, publication_url FROM publication WHERE publication_url IS NOT NULL;
+
+-- Only allow one publication of each type per work (existing data may breach this)
+-- To check for records which breach this constraint:
+-- `select * from publication a where (select count(*) from publication b where a.publication_type = b.publication_type and a.work_id = b.work_id) > 1 order by work_id, publication_type;`
+ALTER TABLE publication
+    ADD CONSTRAINT publication_publication_type_work_id_uniq UNIQUE (publication_type, work_id);

--- a/thoth-api/migrations/0.4.8/up.sql
+++ b/thoth-api/migrations/0.4.8/up.sql
@@ -8,7 +8,7 @@ CREATE TYPE location_platform AS ENUM (
 CREATE TABLE location (
     location_id         UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     publication_id      UUID NOT NULL REFERENCES publication(publication_id) ON DELETE CASCADE,
-    landing_page        TEXT NOT NULL CHECK (landing_page ~* '^[^:]*:\/\/(?:[^\/:]*:[^\/@]*@)?(?:[^\/:.]*\.)+([^:\/]+)'),
+    landing_page        TEXT CHECK (landing_page ~* '^[^:]*:\/\/(?:[^\/:]*:[^\/@]*@)?(?:[^\/:.]*\.)+([^:\/]+)'),
     full_text_url       TEXT CHECK (full_text_url ~* '^[^:]*:\/\/(?:[^\/:]*:[^\/@]*@)?(?:[^\/:.]*\.)+([^:\/]+)'),
     location_platform   location_platform NOT NULL DEFAULT 'Other',
     canonical           BOOLEAN NOT NULL DEFAULT False,

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -2520,8 +2520,8 @@ impl Location {
         self.publication_id
     }
 
-    pub fn landing_page(&self) -> &String {
-        &self.landing_page
+    pub fn landing_page(&self) -> Option<&String> {
+        self.landing_page.as_ref()
     }
 
     pub fn full_text_url(&self) -> Option<&String> {

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1115,7 +1115,9 @@ impl MutationRoot {
                 data.publication_id,
             )?)?;
 
-        if !data.canonical {
+        if data.canonical {
+            data.canonical_record_complete(&context.db)?;
+        } else {
             data.can_be_non_canonical(&context.db)?;
         }
 
@@ -1357,6 +1359,10 @@ impl MutationRoot {
             // Updating an existing location would always violate this,
             // as it should always result in either zero or two canonical locations.
             return Err(ThothError::CanonicalLocationError.into());
+        }
+
+        if data.canonical {
+            data.canonical_record_complete(&context.db)?;
         }
 
         let account_id = context.token.jwt.as_ref().unwrap().account_id(&context.db);

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1056,6 +1056,10 @@ impl MutationRoot {
             .account_access
             .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
 
+        if !data.isbn.is_none() {
+            data.can_have_isbn(&context.db)?;
+        }
+
         Publication::create(&context.db, &data).map_err(|e| e.into())
     }
 
@@ -1150,6 +1154,11 @@ impl MutationRoot {
                 .can_edit(publisher_id_from_imprint_id(&context.db, data.imprint_id)?)?;
             work.can_update_imprint(&context.db)?;
         }
+
+        if data.work_type == WorkType::BookChapter {
+            work.can_be_chapter(&context.db)?;
+        }
+
         let account_id = context.token.jwt.as_ref().unwrap().account_id(&context.db);
         work.update_with_units(&context.db, data, &account_id, units)
             .map_err(|e| e.into())
@@ -1227,6 +1236,11 @@ impl MutationRoot {
                 .account_access
                 .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
         }
+
+        if !data.isbn.is_none() {
+            data.can_have_isbn(&context.db)?;
+        }
+
         let account_id = context.token.jwt.as_ref().unwrap().account_id(&context.db);
         publication
             .update(&context.db, &data, &account_id)

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -205,7 +205,7 @@ impl QueryRoot {
             offset(default = 0, description = "The number of items to skip"),
             filter(
                 default = "".to_string(),
-                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn and publication_url"
+                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn"
             ),
             order(
                 default = PublicationOrderBy::default(),
@@ -252,7 +252,7 @@ impl QueryRoot {
         arguments(
             filter(
                 default = "".to_string(),
-                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn and publication_url",
+                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn",
             ),
             publishers(
                 default = vec![],
@@ -1772,7 +1772,7 @@ impl Work {
             offset(default = 0, description = "The number of items to skip"),
             filter(
                 default = "".to_string(),
-                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn and publication_url"
+                description = "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn"
             ),
             order(
                 default = {
@@ -1948,10 +1948,6 @@ impl Publication {
 
     pub fn isbn(&self) -> Option<&Isbn> {
         self.isbn.as_ref()
-    }
-
-    pub fn publication_url(&self) -> Option<&String> {
-        self.publication_url.as_ref()
     }
 
     pub fn created_at(&self) -> Timestamp {

--- a/thoth-api/src/model/location/crud.rs
+++ b/thoth-api/src/model/location/crud.rs
@@ -1,0 +1,182 @@
+use super::{
+    Location, LocationField, LocationHistory, LocationPlatform, NewLocation, NewLocationHistory,
+    PatchLocation,
+};
+use crate::graphql::model::LocationOrderBy;
+use crate::graphql::utils::Direction;
+use crate::model::{Crud, DbInsert, HistoryEntry};
+use crate::schema::{location, location_history};
+use crate::{crud_methods, db_insert};
+use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use thoth_errors::{ThothError, ThothResult};
+use uuid::Uuid;
+
+impl Crud for Location {
+    type NewEntity = NewLocation;
+    type PatchEntity = PatchLocation;
+    type OrderByEntity = LocationOrderBy;
+    type FilterParameter1 = LocationPlatform;
+    type FilterParameter2 = ();
+
+    fn pk(&self) -> Uuid {
+        self.location_id
+    }
+
+    fn all(
+        db: &crate::db::PgPool,
+        limit: i32,
+        offset: i32,
+        _: Option<String>,
+        order: Self::OrderByEntity,
+        publishers: Vec<Uuid>,
+        parent_id_1: Option<Uuid>,
+        _: Option<Uuid>,
+        location_platform: Option<Self::FilterParameter1>,
+        _: Option<Self::FilterParameter2>,
+    ) -> ThothResult<Vec<Location>> {
+        use crate::schema::location::dsl;
+        let connection = db.get().unwrap();
+        let mut query =
+            dsl::location
+                .inner_join(crate::schema::publication::table.inner_join(
+                    crate::schema::work::table.inner_join(crate::schema::imprint::table),
+                ))
+                .select((
+                    dsl::location_id,
+                    dsl::publication_id,
+                    dsl::landing_page,
+                    dsl::full_text_url,
+                    dsl::location_platform,
+                    dsl::canonical,
+                    dsl::created_at,
+                    dsl::updated_at,
+                ))
+                .into_boxed();
+
+        match order.field {
+            LocationField::LocationId => match order.direction {
+                Direction::Asc => query = query.order(dsl::location_id.asc()),
+                Direction::Desc => query = query.order(dsl::location_id.desc()),
+            },
+            LocationField::PublicationId => match order.direction {
+                Direction::Asc => query = query.order(dsl::publication_id.asc()),
+                Direction::Desc => query = query.order(dsl::publication_id.desc()),
+            },
+            LocationField::LandingPage => match order.direction {
+                Direction::Asc => query = query.order(dsl::landing_page.asc()),
+                Direction::Desc => query = query.order(dsl::landing_page.desc()),
+            },
+            LocationField::FullTextUrl => match order.direction {
+                Direction::Asc => query = query.order(dsl::full_text_url.asc()),
+                Direction::Desc => query = query.order(dsl::full_text_url.desc()),
+            },
+            LocationField::LocationPlatform => match order.direction {
+                Direction::Asc => query = query.order(dsl::location_platform.asc()),
+                Direction::Desc => query = query.order(dsl::location_platform.desc()),
+            },
+            LocationField::Canonical => match order.direction {
+                Direction::Asc => query = query.order(dsl::canonical.asc()),
+                Direction::Desc => query = query.order(dsl::canonical.desc()),
+            },
+            LocationField::CreatedAt => match order.direction {
+                Direction::Asc => query = query.order(dsl::created_at.asc()),
+                Direction::Desc => query = query.order(dsl::created_at.desc()),
+            },
+            LocationField::UpdatedAt => match order.direction {
+                Direction::Asc => query = query.order(dsl::updated_at.asc()),
+                Direction::Desc => query = query.order(dsl::updated_at.desc()),
+            },
+        }
+        // This loop must appear before any other filter statements, as it takes advantage of
+        // the behaviour of `or_filter` being equal to `filter` when no other filters are present yet.
+        // Result needs to be `WHERE (x = $1 [OR x = $2...]) AND ([...])` - note bracketing.
+        for pub_id in publishers {
+            query = query.or_filter(crate::schema::imprint::publisher_id.eq(pub_id));
+        }
+        if let Some(pid) = parent_id_1 {
+            query = query.filter(dsl::publication_id.eq(pid));
+        }
+        if let Some(loc_platform) = location_platform {
+            query = query.filter(dsl::location_platform.eq(loc_platform));
+        }
+        match query
+            .limit(limit.into())
+            .offset(offset.into())
+            .load::<Location>(&connection)
+        {
+            Ok(t) => Ok(t),
+            Err(e) => Err(ThothError::from(e)),
+        }
+    }
+
+    fn count(
+        db: &crate::db::PgPool,
+        _: Option<String>,
+        _: Vec<Uuid>,
+        location_platform: Option<Self::FilterParameter1>,
+        _: Option<Self::FilterParameter2>,
+    ) -> ThothResult<i32> {
+        use crate::schema::location::dsl;
+        let connection = db.get().unwrap();
+        let mut query = dsl::location.into_boxed();
+        if let Some(loc_platform) = location_platform {
+            query = query.filter(dsl::location_platform.eq(loc_platform));
+        }
+        // `SELECT COUNT(*)` in postgres returns a BIGINT, which diesel parses as i64. Juniper does
+        // not implement i64 yet, only i32. The only sensible way, albeit shameful, to solve this
+        // is converting i64 to string and then parsing it as i32. This should work until we reach
+        // 2147483647 records - if you are fixing this bug, congratulations on book number 2147483647!
+        match query.count().get_result::<i64>(&connection) {
+            Ok(t) => Ok(t.to_string().parse::<i32>().unwrap()),
+            Err(e) => Err(ThothError::from(e)),
+        }
+    }
+
+    fn publisher_id(&self, db: &crate::db::PgPool) -> ThothResult<Uuid> {
+        crate::model::publication::Publication::from_id(db, &self.publication_id)?.publisher_id(db)
+    }
+
+    crud_methods!(location::table, location::dsl::location);
+}
+
+impl HistoryEntry for Location {
+    type NewHistoryEntity = NewLocationHistory;
+
+    fn new_history_entry(&self, account_id: &Uuid) -> Self::NewHistoryEntity {
+        Self::NewHistoryEntity {
+            location_id: self.location_id,
+            account_id: *account_id,
+            data: serde_json::Value::String(serde_json::to_string(&self).unwrap()),
+        }
+    }
+}
+
+impl DbInsert for NewLocationHistory {
+    type MainEntity = LocationHistory;
+
+    db_insert!(location_history::table);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_location_pk() {
+        let location: Location = Default::default();
+        assert_eq!(location.pk(), location.location_id);
+    }
+
+    #[test]
+    fn test_new_location_history_from_location() {
+        let location: Location = Default::default();
+        let account_id: Uuid = Default::default();
+        let new_location_history = location.new_history_entry(&account_id);
+        assert_eq!(new_location_history.location_id, location.location_id);
+        assert_eq!(new_location_history.account_id, account_id);
+        assert_eq!(
+            new_location_history.data,
+            serde_json::Value::String(serde_json::to_string(&location).unwrap())
+        );
+    }
+}

--- a/thoth-api/src/model/location/mod.rs
+++ b/thoth-api/src/model/location/mod.rs
@@ -49,7 +49,7 @@ pub enum LocationField {
 pub struct Location {
     pub location_id: Uuid,
     pub publication_id: Uuid,
-    pub landing_page: String,
+    pub landing_page: Option<String>,
     pub full_text_url: Option<String>,
     pub location_platform: LocationPlatform,
     pub canonical: bool,
@@ -64,7 +64,7 @@ pub struct Location {
 )]
 pub struct NewLocation {
     pub publication_id: Uuid,
-    pub landing_page: String,
+    pub landing_page: Option<String>,
     pub full_text_url: Option<String>,
     pub location_platform: LocationPlatform,
     pub canonical: bool,
@@ -79,7 +79,7 @@ pub struct NewLocation {
 pub struct PatchLocation {
     pub location_id: Uuid,
     pub publication_id: Uuid,
-    pub landing_page: String,
+    pub landing_page: Option<String>,
     pub full_text_url: Option<String>,
     pub location_platform: LocationPlatform,
     pub canonical: bool,

--- a/thoth-api/src/model/location/mod.rs
+++ b/thoth-api/src/model/location/mod.rs
@@ -1,0 +1,152 @@
+use serde::{Deserialize, Serialize};
+use strum::Display;
+use strum::EnumString;
+use uuid::Uuid;
+
+use crate::model::Timestamp;
+#[cfg(feature = "backend")]
+use crate::schema::location;
+#[cfg(feature = "backend")]
+use crate::schema::location_history;
+
+#[cfg_attr(feature = "backend", derive(DbEnum, juniper::GraphQLEnum))]
+#[cfg_attr(feature = "backend", DieselType = "Location_platform")]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, EnumString, Display)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum LocationPlatform {
+    #[cfg_attr(feature = "backend", db_rename = "Project MUSE")]
+    #[strum(serialize = "Project MUSE")]
+    ProjectMuse,
+    #[cfg_attr(feature = "backend", db_rename = "OAPEN")]
+    #[strum(serialize = "OAPEN")]
+    Oapen,
+    #[cfg_attr(feature = "backend", db_rename = "JSTOR")]
+    #[strum(serialize = "JSTOR")]
+    Jstor,
+    #[cfg_attr(feature = "backend", db_rename = "Other")]
+    Other,
+}
+
+#[cfg_attr(
+    feature = "backend",
+    derive(juniper::GraphQLEnum),
+    graphql(description = "Field to use when sorting locations list")
+)]
+pub enum LocationField {
+    LocationId,
+    PublicationId,
+    LandingPage,
+    FullTextUrl,
+    LocationPlatform,
+    Canonical,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[cfg_attr(feature = "backend", derive(Queryable))]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Location {
+    pub location_id: Uuid,
+    pub publication_id: Uuid,
+    pub landing_page: String,
+    pub full_text_url: Option<String>,
+    pub location_platform: LocationPlatform,
+    pub canonical: bool,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
+}
+
+#[cfg_attr(
+    feature = "backend",
+    derive(juniper::GraphQLInputObject, Insertable),
+    table_name = "location"
+)]
+pub struct NewLocation {
+    pub publication_id: Uuid,
+    pub landing_page: String,
+    pub full_text_url: Option<String>,
+    pub location_platform: LocationPlatform,
+    pub canonical: bool,
+}
+
+#[cfg_attr(
+    feature = "backend",
+    derive(juniper::GraphQLInputObject, AsChangeset),
+    changeset_options(treat_none_as_null = "true"),
+    table_name = "location"
+)]
+pub struct PatchLocation {
+    pub location_id: Uuid,
+    pub publication_id: Uuid,
+    pub landing_page: String,
+    pub full_text_url: Option<String>,
+    pub location_platform: LocationPlatform,
+    pub canonical: bool,
+}
+
+#[cfg_attr(feature = "backend", derive(Queryable))]
+pub struct LocationHistory {
+    pub location_history_id: Uuid,
+    pub location_id: Uuid,
+    pub account_id: Uuid,
+    pub data: serde_json::Value,
+    pub timestamp: Timestamp,
+}
+
+#[cfg_attr(
+    feature = "backend",
+    derive(Insertable),
+    table_name = "location_history"
+)]
+pub struct NewLocationHistory {
+    pub location_id: Uuid,
+    pub account_id: Uuid,
+    pub data: serde_json::Value,
+}
+
+impl Default for LocationPlatform {
+    fn default() -> LocationPlatform {
+        LocationPlatform::Other
+    }
+}
+
+#[test]
+fn test_locationplatform_default() {
+    let locationplatform: LocationPlatform = Default::default();
+    assert_eq!(locationplatform, LocationPlatform::Other);
+}
+
+#[test]
+fn test_locationplatform_display() {
+    assert_eq!(format!("{}", LocationPlatform::ProjectMuse), "Project MUSE");
+    assert_eq!(format!("{}", LocationPlatform::Oapen), "OAPEN");
+    assert_eq!(format!("{}", LocationPlatform::Jstor), "JSTOR");
+    assert_eq!(format!("{}", LocationPlatform::Other), "Other");
+}
+
+#[test]
+fn test_locationplatform_fromstr() {
+    use std::str::FromStr;
+    assert_eq!(
+        LocationPlatform::from_str("Project MUSE").unwrap(),
+        LocationPlatform::ProjectMuse
+    );
+    assert_eq!(
+        LocationPlatform::from_str("OAPEN").unwrap(),
+        LocationPlatform::Oapen
+    );
+    assert_eq!(
+        LocationPlatform::from_str("JSTOR").unwrap(),
+        LocationPlatform::Jstor
+    );
+    assert_eq!(
+        LocationPlatform::from_str("Other").unwrap(),
+        LocationPlatform::Other
+    );
+    assert!(LocationPlatform::from_str("Amazon").is_err());
+    assert!(LocationPlatform::from_str("Twitter").is_err());
+}
+
+#[cfg(feature = "backend")]
+pub mod crud;

--- a/thoth-api/src/model/location/mod.rs
+++ b/thoth-api/src/model/location/mod.rs
@@ -20,9 +20,30 @@ pub enum LocationPlatform {
     #[cfg_attr(feature = "backend", db_rename = "OAPEN")]
     #[strum(serialize = "OAPEN")]
     Oapen,
+    #[cfg_attr(feature = "backend", db_rename = "DOAB")]
+    #[strum(serialize = "DOAB")]
+    Doab,
     #[cfg_attr(feature = "backend", db_rename = "JSTOR")]
     #[strum(serialize = "JSTOR")]
     Jstor,
+    #[cfg_attr(feature = "backend", db_rename = "EBSCO Host")]
+    #[strum(serialize = "EBSCO Host")]
+    EbscoHost,
+    #[cfg_attr(feature = "backend", db_rename = "OCLC KB")]
+    #[strum(serialize = "OCLC KB")]
+    OclcKb,
+    #[cfg_attr(feature = "backend", db_rename = "ProQuest KB")]
+    #[strum(serialize = "ProQuest KB")]
+    ProquestKb,
+    #[cfg_attr(feature = "backend", db_rename = "ProQuest ExLibris")]
+    #[strum(serialize = "ProQuest ExLibris")]
+    ProquestExlibris,
+    #[cfg_attr(feature = "backend", db_rename = "EBSCO KB")]
+    #[strum(serialize = "EBSCO KB")]
+    EbscoKb,
+    #[cfg_attr(feature = "backend", db_rename = "JISC KB")]
+    #[strum(serialize = "JISC KB")]
+    JiscKb,
     #[cfg_attr(feature = "backend", db_rename = "Other")]
     Other,
 }
@@ -121,7 +142,17 @@ fn test_locationplatform_default() {
 fn test_locationplatform_display() {
     assert_eq!(format!("{}", LocationPlatform::ProjectMuse), "Project MUSE");
     assert_eq!(format!("{}", LocationPlatform::Oapen), "OAPEN");
+    assert_eq!(format!("{}", LocationPlatform::Doab), "DOAB");
     assert_eq!(format!("{}", LocationPlatform::Jstor), "JSTOR");
+    assert_eq!(format!("{}", LocationPlatform::EbscoHost), "EBSCO Host");
+    assert_eq!(format!("{}", LocationPlatform::OclcKb), "OCLC KB");
+    assert_eq!(format!("{}", LocationPlatform::ProquestKb), "ProQuest KB");
+    assert_eq!(
+        format!("{}", LocationPlatform::ProquestExlibris),
+        "ProQuest ExLibris"
+    );
+    assert_eq!(format!("{}", LocationPlatform::EbscoKb), "EBSCO KB");
+    assert_eq!(format!("{}", LocationPlatform::JiscKb), "JISC KB");
     assert_eq!(format!("{}", LocationPlatform::Other), "Other");
 }
 
@@ -137,8 +168,36 @@ fn test_locationplatform_fromstr() {
         LocationPlatform::Oapen
     );
     assert_eq!(
+        LocationPlatform::from_str("DOAB").unwrap(),
+        LocationPlatform::Doab
+    );
+    assert_eq!(
         LocationPlatform::from_str("JSTOR").unwrap(),
         LocationPlatform::Jstor
+    );
+    assert_eq!(
+        LocationPlatform::from_str("EBSCO Host").unwrap(),
+        LocationPlatform::EbscoHost
+    );
+    assert_eq!(
+        LocationPlatform::from_str("OCLC KB").unwrap(),
+        LocationPlatform::OclcKb
+    );
+    assert_eq!(
+        LocationPlatform::from_str("ProQuest KB").unwrap(),
+        LocationPlatform::ProquestKb
+    );
+    assert_eq!(
+        LocationPlatform::from_str("ProQuest ExLibris").unwrap(),
+        LocationPlatform::ProquestExlibris
+    );
+    assert_eq!(
+        LocationPlatform::from_str("EBSCO KB").unwrap(),
+        LocationPlatform::EbscoKb
+    );
+    assert_eq!(
+        LocationPlatform::from_str("JISC KB").unwrap(),
+        LocationPlatform::JiscKb
     );
     assert_eq!(
         LocationPlatform::from_str("Other").unwrap(),

--- a/thoth-api/src/model/mod.rs
+++ b/thoth-api/src/model/mod.rs
@@ -736,6 +736,7 @@ pub mod funding;
 pub mod imprint;
 pub mod issue;
 pub mod language;
+pub mod location;
 pub mod price;
 pub mod publication;
 pub mod publisher;

--- a/thoth-api/src/model/publication/crud.rs
+++ b/thoth-api/src/model/publication/crud.rs
@@ -6,9 +6,7 @@ use crate::graphql::utils::Direction;
 use crate::model::{Crud, DbInsert, HistoryEntry};
 use crate::schema::{publication, publication_history};
 use crate::{crud_methods, db_insert};
-use diesel::{
-    BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl,
-};
+use diesel::{ExpressionMethods, PgTextExpressionMethods, QueryDsl, RunQueryDsl};
 use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
@@ -44,7 +42,6 @@ impl Crud for Publication {
                 dsl::publication_type,
                 dsl::work_id,
                 dsl::isbn,
-                dsl::publication_url,
                 dsl::created_at,
                 dsl::updated_at,
             ))
@@ -66,10 +63,6 @@ impl Crud for Publication {
             PublicationField::Isbn => match order.direction {
                 Direction::Asc => query = query.order(dsl::isbn.asc()),
                 Direction::Desc => query = query.order(dsl::isbn.desc()),
-            },
-            PublicationField::PublicationUrl => match order.direction {
-                Direction::Asc => query = query.order(dsl::publication_url.asc()),
-                Direction::Desc => query = query.order(dsl::publication_url.desc()),
             },
             PublicationField::CreatedAt => match order.direction {
                 Direction::Asc => query = query.order(dsl::created_at.asc()),
@@ -93,13 +86,9 @@ impl Crud for Publication {
             query = query.filter(dsl::publication_type.eq(pub_type));
         }
         if let Some(filter) = filter {
-            // ISBN and URL fields are both nullable, so searching with an empty filter could fail
+            // ISBN field is nullable, so searching with an empty filter could fail
             if !filter.is_empty() {
-                query = query.filter(
-                    dsl::isbn
-                        .ilike(format!("%{}%", filter))
-                        .or(dsl::publication_url.ilike(format!("%{}%", filter))),
-                );
+                query = query.filter(dsl::isbn.ilike(format!("%{}%", filter)));
             }
         }
         match query
@@ -128,7 +117,6 @@ impl Crud for Publication {
                 dsl::publication_type,
                 dsl::work_id,
                 dsl::isbn,
-                dsl::publication_url,
                 dsl::created_at,
                 dsl::updated_at,
             ))
@@ -143,13 +131,9 @@ impl Crud for Publication {
             query = query.filter(dsl::publication_type.eq(pub_type));
         }
         if let Some(filter) = filter {
-            // ISBN and URL fields are both nullable, so searching with an empty filter could fail
+            // ISBN field is nullable, so searching with an empty filter could fail
             if !filter.is_empty() {
-                query = query.filter(
-                    dsl::isbn
-                        .ilike(format!("%{}%", filter))
-                        .or(dsl::publication_url.ilike(format!("%{}%", filter))),
-                );
+                query = query.filter(dsl::isbn.ilike(format!("%{}%", filter)));
             }
         }
 

--- a/thoth-api/src/model/publication/mod.rs
+++ b/thoth-api/src/model/publication/mod.rs
@@ -4,6 +4,7 @@ use strum::EnumString;
 use uuid::Uuid;
 
 use crate::graphql::utils::Direction;
+use crate::model::location::Location;
 use crate::model::price::Price;
 use crate::model::work::WorkWithRelations;
 use crate::model::Isbn;
@@ -82,6 +83,7 @@ pub struct PublicationWithRelations {
     pub publication_url: Option<String>,
     pub updated_at: Timestamp,
     pub prices: Option<Vec<Price>>,
+    pub locations: Option<Vec<Location>>,
     pub work: WorkWithRelations,
 }
 

--- a/thoth-api/src/model/publication/mod.rs
+++ b/thoth-api/src/model/publication/mod.rs
@@ -54,8 +54,6 @@ pub enum PublicationField {
     WorkId,
     #[strum(serialize = "ISBN")]
     Isbn,
-    #[strum(serialize = "URL")]
-    PublicationUrl,
     CreatedAt,
     UpdatedAt,
 }
@@ -68,7 +66,6 @@ pub struct Publication {
     pub publication_type: PublicationType,
     pub work_id: Uuid,
     pub isbn: Option<Isbn>,
-    pub publication_url: Option<String>,
     pub created_at: Timestamp,
     pub updated_at: Timestamp,
 }
@@ -80,7 +77,6 @@ pub struct PublicationWithRelations {
     pub publication_type: PublicationType,
     pub work_id: Uuid,
     pub isbn: Option<Isbn>,
-    pub publication_url: Option<String>,
     pub updated_at: Timestamp,
     pub prices: Option<Vec<Price>>,
     pub locations: Option<Vec<Location>>,
@@ -96,7 +92,6 @@ pub struct NewPublication {
     pub publication_type: PublicationType,
     pub work_id: Uuid,
     pub isbn: Option<Isbn>,
-    pub publication_url: Option<String>,
 }
 
 #[cfg_attr(
@@ -110,7 +105,6 @@ pub struct PatchPublication {
     pub publication_type: PublicationType,
     pub work_id: Uuid,
     pub isbn: Option<Isbn>,
-    pub publication_url: Option<String>,
 }
 
 #[cfg_attr(feature = "backend", derive(Queryable))]
@@ -185,7 +179,6 @@ fn test_publicationfield_display() {
     assert_eq!(format!("{}", PublicationField::PublicationType), "Type");
     assert_eq!(format!("{}", PublicationField::WorkId), "WorkID");
     assert_eq!(format!("{}", PublicationField::Isbn), "ISBN");
-    assert_eq!(format!("{}", PublicationField::PublicationUrl), "URL");
     assert_eq!(format!("{}", PublicationField::CreatedAt), "CreatedAt");
     assert_eq!(format!("{}", PublicationField::UpdatedAt), "UpdatedAt");
 }
@@ -244,10 +237,6 @@ fn test_publicationfield_fromstr() {
     assert_eq!(
         PublicationField::from_str("ISBN").unwrap(),
         PublicationField::Isbn
-    );
-    assert_eq!(
-        PublicationField::from_str("URL").unwrap(),
-        PublicationField::PublicationUrl
     );
     assert_eq!(
         PublicationField::from_str("CreatedAt").unwrap(),

--- a/thoth-api/src/model/work/crud.rs
+++ b/thoth-api/src/model/work/crud.rs
@@ -49,6 +49,27 @@ impl Work {
         }
     }
 
+    pub fn can_be_chapter(&self, db: &crate::db::PgPool) -> ThothResult<()> {
+        use crate::schema::publication::dsl;
+        let connection = db.get().unwrap();
+        let isbn_count = dsl::publication
+            .filter(dsl::work_id.eq(self.work_id))
+            .filter(dsl::isbn.is_not_null())
+            .count()
+            .get_result::<i64>(&connection)
+            .expect("Error loading publication ISBNs for work")
+            .to_string()
+            .parse::<i32>()
+            .unwrap();
+        // If a work has any publications with ISBNs,
+        // its type cannot be changed to Book Chapter.
+        if isbn_count == 0 {
+            Ok(())
+        } else {
+            Err(ThothError::ChapterIsbnError)
+        }
+    }
+
     pub fn update_with_units(
         &self,
         db: &crate::db::PgPool,

--- a/thoth-api/src/schema.rs
+++ b/thoth-api/src/schema.rs
@@ -271,7 +271,6 @@ table! {
         publication_type -> Publication_type,
         work_id -> Uuid,
         isbn -> Nullable<Text>,
-        publication_url -> Nullable<Text>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
     }

--- a/thoth-api/src/schema.rs
+++ b/thoth-api/src/schema.rs
@@ -210,6 +210,34 @@ table! {
 
 table! {
     use diesel::sql_types::*;
+    use crate::model::location::Location_platform;
+
+    location (location_id) {
+        location_id -> Uuid,
+        publication_id -> Uuid,
+        landing_page -> Text,
+        full_text_url -> Nullable<Text>,
+        location_platform -> Location_platform,
+        canonical -> Bool,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+
+    location_history (location_history_id) {
+        location_history_id -> Uuid,
+        location_id -> Uuid,
+        account_id -> Uuid,
+        data -> Jsonb,
+        timestamp -> Timestamptz,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
     use crate::model::price::Currency_code;
 
     price (price_id) {
@@ -430,6 +458,9 @@ joinable!(issue_history -> issue (issue_id));
 joinable!(language -> work (work_id));
 joinable!(language_history -> account (account_id));
 joinable!(language_history -> language (language_id));
+joinable!(location -> publication (publication_id));
+joinable!(location_history -> account (account_id));
+joinable!(location_history -> location (location_id));
 joinable!(price -> publication (publication_id));
 joinable!(price_history -> account (account_id));
 joinable!(price_history -> price (price_id));
@@ -466,6 +497,8 @@ allow_tables_to_appear_in_same_query!(
     issue_history,
     language,
     language_history,
+    location,
+    location_history,
     price,
     price_history,
     publication,

--- a/thoth-api/src/schema.rs
+++ b/thoth-api/src/schema.rs
@@ -215,7 +215,7 @@ table! {
     location (location_id) {
         location_id -> Uuid,
         publication_id -> Uuid,
-        landing_page -> Text,
+        landing_page -> Nullable<Text>,
         full_text_url -> Nullable<Text>,
         location_platform -> Location_platform,
         canonical -> Bool,

--- a/thoth-app/src/component/locations_form.rs
+++ b/thoth-app/src/component/locations_form.rs
@@ -237,7 +237,10 @@ impl Component for LocationsFormComponent {
                     .send_message(Msg::SetLocationDeleteState(FetchAction::Fetching));
                 false
             }
-            Msg::ChangeLandingPage(val) => self.new_location.landing_page.neq_assign(val.to_opt_string()),
+            Msg::ChangeLandingPage(val) => self
+                .new_location
+                .landing_page
+                .neq_assign(val.to_opt_string()),
             Msg::ChangeFullTextUrl(val) => self
                 .new_location
                 .full_text_url

--- a/thoth-app/src/component/locations_form.rs
+++ b/thoth-app/src/component/locations_form.rs
@@ -237,7 +237,7 @@ impl Component for LocationsFormComponent {
                     .send_message(Msg::SetLocationDeleteState(FetchAction::Fetching));
                 false
             }
-            Msg::ChangeLandingPage(val) => self.new_location.landing_page.neq_assign(val),
+            Msg::ChangeLandingPage(val) => self.new_location.landing_page.neq_assign(val.to_opt_string()),
             Msg::ChangeFullTextUrl(val) => self
                 .new_location
                 .full_text_url
@@ -297,7 +297,6 @@ impl Component for LocationsFormComponent {
                                     label="Landing Page"
                                     value=self.new_location.landing_page.clone()
                                     oninput=self.link.callback(|e: InputData| Msg::ChangeLandingPage(e.value))
-                                    required = true
                                 />
                                 <FormUrlInput
                                     label="Full Text URL"
@@ -397,7 +396,7 @@ impl LocationsFormComponent {
                     <div class="field" style="width: 8em;">
                         <label class="label">{ "Landing Page" }</label>
                         <div class="control is-expanded">
-                            {&l.landing_page}
+                            {&l.landing_page.clone().unwrap_or_else(|| "".to_string())}
                         </div>
                     </div>
                     <div class="field" style="width: 8em;">

--- a/thoth-app/src/component/locations_form.rs
+++ b/thoth-app/src/component/locations_form.rs
@@ -37,6 +37,8 @@ use crate::string::NO;
 use crate::string::REMOVE_BUTTON;
 use crate::string::YES;
 
+use super::ToOption;
+
 pub struct LocationsFormComponent {
     props: Props,
     data: LocationsFormData,
@@ -231,13 +233,10 @@ impl Component for LocationsFormComponent {
                 false
             }
             Msg::ChangeLandingPage(val) => self.new_location.landing_page.neq_assign(val),
-            Msg::ChangeFullTextUrl(val) => {
-                let value = match val.is_empty() {
-                    true => None,
-                    false => Some(val),
-                };
-                self.new_location.full_text_url.neq_assign(value)
-            }
+            Msg::ChangeFullTextUrl(val) => self
+                .new_location
+                .full_text_url
+                .neq_assign(val.to_opt_string()),
             Msg::ChangeLocationPlatform(code) => {
                 self.new_location.location_platform.neq_assign(code)
             }

--- a/thoth-app/src/component/locations_form.rs
+++ b/thoth-app/src/component/locations_form.rs
@@ -1,0 +1,427 @@
+use std::str::FromStr;
+use thoth_api::model::location::Location;
+use thoth_api::model::location::LocationPlatform;
+use uuid::Uuid;
+use yew::html;
+use yew::prelude::*;
+use yew::ComponentLink;
+use yewtil::fetch::Fetch;
+use yewtil::fetch::FetchAction;
+use yewtil::fetch::FetchState;
+use yewtil::future::LinkFuture;
+use yewtil::NeqAssign;
+
+use crate::agent::notification_bus::NotificationBus;
+use crate::agent::notification_bus::NotificationDispatcher;
+use crate::agent::notification_bus::NotificationStatus;
+use crate::agent::notification_bus::Request;
+use crate::component::utils::FormBooleanSelect;
+use crate::component::utils::FormLocationPlatformSelect;
+use crate::component::utils::FormUrlInput;
+use crate::models::location::create_location_mutation::CreateLocationRequest;
+use crate::models::location::create_location_mutation::CreateLocationRequestBody;
+use crate::models::location::create_location_mutation::PushActionCreateLocation;
+use crate::models::location::create_location_mutation::PushCreateLocation;
+use crate::models::location::create_location_mutation::Variables;
+use crate::models::location::delete_location_mutation::DeleteLocationRequest;
+use crate::models::location::delete_location_mutation::DeleteLocationRequestBody;
+use crate::models::location::delete_location_mutation::PushActionDeleteLocation;
+use crate::models::location::delete_location_mutation::PushDeleteLocation;
+use crate::models::location::delete_location_mutation::Variables as DeleteVariables;
+use crate::models::location::location_platforms_query::FetchActionLocationPlatforms;
+use crate::models::location::location_platforms_query::FetchLocationPlatforms;
+use crate::models::location::LocationPlatformValues;
+use crate::string::CANCEL_BUTTON;
+use crate::string::EMPTY_LOCATIONS;
+use crate::string::NO;
+use crate::string::REMOVE_BUTTON;
+use crate::string::YES;
+
+pub struct LocationsFormComponent {
+    props: Props,
+    data: LocationsFormData,
+    new_location: Location,
+    show_add_form: bool,
+    fetch_location_platforms: FetchLocationPlatforms,
+    push_location: PushCreateLocation,
+    delete_location: PushDeleteLocation,
+    link: ComponentLink<Self>,
+    notification_bus: NotificationDispatcher,
+}
+
+#[derive(Default)]
+struct LocationsFormData {
+    location_platforms: Vec<LocationPlatformValues>,
+}
+
+pub enum Msg {
+    ToggleAddFormDisplay(bool),
+    SetLocationPlatformsFetchState(FetchActionLocationPlatforms),
+    GetLocationPlatforms,
+    SetLocationPushState(PushActionCreateLocation),
+    CreateLocation,
+    SetLocationDeleteState(PushActionDeleteLocation),
+    DeleteLocation(Uuid),
+    ChangeLandingPage(String),
+    ChangeFullTextUrl(String),
+    ChangeLocationPlatform(LocationPlatform),
+    ChangeCanonical(bool),
+}
+
+#[derive(Clone, Properties, PartialEq)]
+pub struct Props {
+    pub locations: Option<Vec<Location>>,
+    pub publication_id: Uuid,
+    pub update_locations: Callback<Option<Vec<Location>>>,
+}
+
+impl Component for LocationsFormComponent {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        let data: LocationsFormData = Default::default();
+        let show_add_form = false;
+        let new_location: Location = Default::default();
+        let fetch_location_platforms = Default::default();
+        let push_location = Default::default();
+        let delete_location = Default::default();
+        let notification_bus = NotificationBus::dispatcher();
+
+        link.send_message(Msg::GetLocationPlatforms);
+
+        LocationsFormComponent {
+            props,
+            data,
+            new_location,
+            show_add_form,
+            fetch_location_platforms,
+            push_location,
+            delete_location,
+            link,
+            notification_bus,
+        }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::ToggleAddFormDisplay(value) => {
+                self.show_add_form = value;
+                true
+            }
+            Msg::SetLocationPlatformsFetchState(fetch_state) => {
+                self.fetch_location_platforms.apply(fetch_state);
+                self.data.location_platforms = match self.fetch_location_platforms.as_ref().state()
+                {
+                    FetchState::NotFetching(_) => vec![],
+                    FetchState::Fetching(_) => vec![],
+                    FetchState::Fetched(body) => body.data.location_platforms.enum_values.clone(),
+                    FetchState::Failed(_, _err) => vec![],
+                };
+                true
+            }
+            Msg::GetLocationPlatforms => {
+                self.link.send_future(
+                    self.fetch_location_platforms
+                        .fetch(Msg::SetLocationPlatformsFetchState),
+                );
+                self.link
+                    .send_message(Msg::SetLocationPlatformsFetchState(FetchAction::Fetching));
+                false
+            }
+            Msg::SetLocationPushState(fetch_state) => {
+                self.push_location.apply(fetch_state);
+                match self.push_location.as_ref().state() {
+                    FetchState::NotFetching(_) => false,
+                    FetchState::Fetching(_) => false,
+                    FetchState::Fetched(body) => match &body.data.create_location {
+                        Some(l) => {
+                            let location = l.clone();
+                            let mut locations: Vec<Location> =
+                                self.props.locations.clone().unwrap_or_default();
+                            locations.push(location);
+                            self.props.update_locations.emit(Some(locations));
+                            self.link.send_message(Msg::ToggleAddFormDisplay(false));
+                            true
+                        }
+                        None => {
+                            self.link.send_message(Msg::ToggleAddFormDisplay(false));
+                            self.notification_bus.send(Request::NotificationBusMsg((
+                                "Failed to save".to_string(),
+                                NotificationStatus::Danger,
+                            )));
+                            false
+                        }
+                    },
+                    FetchState::Failed(_, err) => {
+                        self.link.send_message(Msg::ToggleAddFormDisplay(false));
+                        self.notification_bus.send(Request::NotificationBusMsg((
+                            err.to_string(),
+                            NotificationStatus::Danger,
+                        )));
+                        false
+                    }
+                }
+            }
+            Msg::CreateLocation => {
+                let body = CreateLocationRequestBody {
+                    variables: Variables {
+                        publication_id: self.props.publication_id,
+                        landing_page: self.new_location.landing_page.clone(),
+                        full_text_url: self.new_location.full_text_url.clone(),
+                        location_platform: self.new_location.location_platform.clone(),
+                        canonical: self.new_location.canonical,
+                    },
+                    ..Default::default()
+                };
+                let request = CreateLocationRequest { body };
+                self.push_location = Fetch::new(request);
+                self.link
+                    .send_future(self.push_location.fetch(Msg::SetLocationPushState));
+                self.link
+                    .send_message(Msg::SetLocationPushState(FetchAction::Fetching));
+                false
+            }
+            Msg::SetLocationDeleteState(fetch_state) => {
+                self.delete_location.apply(fetch_state);
+                match self.delete_location.as_ref().state() {
+                    FetchState::NotFetching(_) => false,
+                    FetchState::Fetching(_) => false,
+                    FetchState::Fetched(body) => match &body.data.delete_location {
+                        Some(location) => {
+                            let to_keep: Vec<Location> = self
+                                .props
+                                .locations
+                                .clone()
+                                .unwrap_or_default()
+                                .into_iter()
+                                .filter(|l| l.location_id != location.location_id)
+                                .collect();
+                            self.props.update_locations.emit(Some(to_keep));
+                            true
+                        }
+                        None => {
+                            self.notification_bus.send(Request::NotificationBusMsg((
+                                "Failed to save".to_string(),
+                                NotificationStatus::Danger,
+                            )));
+                            false
+                        }
+                    },
+                    FetchState::Failed(_, err) => {
+                        self.notification_bus.send(Request::NotificationBusMsg((
+                            err.to_string(),
+                            NotificationStatus::Danger,
+                        )));
+                        false
+                    }
+                }
+            }
+            Msg::DeleteLocation(location_id) => {
+                let body = DeleteLocationRequestBody {
+                    variables: DeleteVariables { location_id },
+                    ..Default::default()
+                };
+                let request = DeleteLocationRequest { body };
+                self.delete_location = Fetch::new(request);
+                self.link
+                    .send_future(self.delete_location.fetch(Msg::SetLocationDeleteState));
+                self.link
+                    .send_message(Msg::SetLocationDeleteState(FetchAction::Fetching));
+                false
+            }
+            Msg::ChangeLandingPage(val) => self.new_location.landing_page.neq_assign(val),
+            Msg::ChangeFullTextUrl(val) => {
+                let value = match val.is_empty() {
+                    true => None,
+                    false => Some(val),
+                };
+                self.new_location.full_text_url.neq_assign(value)
+            }
+            Msg::ChangeLocationPlatform(code) => {
+                self.new_location.location_platform.neq_assign(code)
+            }
+            Msg::ChangeCanonical(val) => self.new_location.canonical.neq_assign(val),
+        }
+    }
+
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props.neq_assign(props)
+    }
+
+    fn view(&self) -> Html {
+        let locations = self.props.locations.clone().unwrap_or_default();
+        let open_modal = self.link.callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::ToggleAddFormDisplay(true)
+        });
+        let close_modal = self.link.callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::ToggleAddFormDisplay(false)
+        });
+        html! {
+            <nav class="panel">
+                <p class="panel-heading">
+                    { "Locations" }
+                </p>
+                <div class="panel-block">
+                    <button
+                        class="button is-link is-outlined is-success is-fullwidth"
+                        onclick=open_modal
+                    >
+                        { "Add Location" }
+                    </button>
+                </div>
+                <div class=self.add_form_status()>
+                    <div class="modal-background" onclick=&close_modal></div>
+                    <div class="modal-card">
+                        <header class="modal-card-head">
+                            <p class="modal-card-title">{ "New Location" }</p>
+                            <button
+                                class="delete"
+                                aria-label="close"
+                                onclick=&close_modal
+                            ></button>
+                        </header>
+                        <section class="modal-card-body">
+                            <form id="locations-form" onsubmit=self.link.callback(|e: FocusEvent| {
+                                e.prevent_default();
+                                Msg::CreateLocation
+                            })
+                            >
+                                <FormUrlInput
+                                    label="Landing Page"
+                                    value=self.new_location.landing_page.clone()
+                                    oninput=self.link.callback(|e: InputData| Msg::ChangeLandingPage(e.value))
+                                    required = true
+                                />
+                                <FormUrlInput
+                                    label="Full Text URL"
+                                    value=self.new_location.full_text_url.clone().unwrap_or_else(|| "".to_string())
+                                    oninput=self.link.callback(|e: InputData| Msg::ChangeFullTextUrl(e.value))
+                                />
+                                <FormLocationPlatformSelect
+                                    label = "Location Platform"
+                                    value=self.new_location.location_platform.clone()
+                                    data=self.data.location_platforms.clone()
+                                    onchange=self.link.callback(|event| match event {
+                                        ChangeData::Select(elem) => {
+                                            let value = elem.value();
+                                            Msg::ChangeLocationPlatform(
+                                                LocationPlatform::from_str(&value).unwrap()
+                                            )
+                                        }
+                                        _ => unreachable!(),
+                                    })
+                                    required = true
+                                />
+                                <FormBooleanSelect
+                                    label = "Canonical"
+                                    value=self.new_location.canonical
+                                    onchange=self.link.callback(|event| match event {
+                                        ChangeData::Select(elem) => {
+                                            let value = elem.value();
+                                            let boolean = value == "true";
+                                            Msg::ChangeCanonical(boolean)
+                                        }
+                                        _ => unreachable!(),
+                                    })
+                                    required = true
+                                />
+                            </form>
+                        </section>
+                        <footer class="modal-card-foot">
+                            <button
+                                class="button is-success"
+                                type="submit"
+                                form="locations-form"
+                            >
+                                { "Add Location" }
+                            </button>
+                            <button
+                                class="button"
+                                onclick=&close_modal
+                            >
+                                { CANCEL_BUTTON }
+                            </button>
+                        </footer>
+                    </div>
+                </div>
+                {
+                    if !locations.is_empty() {
+                        html!{{for locations.iter().map(|l| self.render_location(l))}}
+                    } else {
+                        html! {
+                            <div class="notification is-warning is-light">
+                                { EMPTY_LOCATIONS }
+                            </div>
+                        }
+                    }
+                }
+            </nav>
+        }
+    }
+}
+
+impl LocationsFormComponent {
+    fn add_form_status(&self) -> String {
+        match self.show_add_form {
+            true => "modal is-active".to_string(),
+            false => "modal".to_string(),
+        }
+    }
+
+    fn render_location(&self, l: &Location) -> Html {
+        let location_id = l.location_id;
+        html! {
+            <div class="panel-block field is-horizontal">
+                <span class="panel-icon">
+                    <i class="fas fa-file-invoice-dollar" aria-hidden="true"></i>
+                </span>
+                <div class="field-body">
+                    <div class="field" style="width: 8em;">
+                        <label class="label">{ "Landing Page" }</label>
+                        <div class="control is-expanded">
+                            {&l.landing_page}
+                        </div>
+                    </div>
+                    <div class="field" style="width: 8em;">
+                        <label class="label">{ "Full Text URL" }</label>
+                        <div class="control is-expanded">
+                            {&l.full_text_url.clone().unwrap_or_else(|| "".to_string())}
+                        </div>
+                    </div>
+                    <div class="field" style="width: 8em;">
+                        <label class="label">{ "Platform" }</label>
+                        <div class="control is-expanded">
+                            {&l.location_platform}
+                        </div>
+                    </div>
+                    <div class="field" style="width: 8em;">
+                        <label class="label">{ "Canonical" }</label>
+                        <div class="control is-expanded">
+                            {
+                                match l.canonical {
+                                    true => { YES },
+                                    false => { NO }
+                                }
+                            }
+                        </div>
+                    </div>
+
+                    <div class="field">
+                        <label class="label"></label>
+                        <div class="control is-expanded">
+                            <a
+                                class="button is-danger"
+                                onclick=self.link.callback(move |_| Msg::DeleteLocation(location_id))
+                            >
+                                { REMOVE_BUTTON }
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    }
+}

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -364,6 +364,7 @@ pub mod imprint;
 pub mod imprints;
 pub mod issues_form;
 pub mod languages_form;
+pub mod locations_form;
 pub mod login;
 pub mod menu;
 pub mod navbar;

--- a/thoth-app/src/component/publication.rs
+++ b/thoth-app/src/component/publication.rs
@@ -1,4 +1,5 @@
 use thoth_api::account::model::AccountDetails;
+use thoth_api::model::location::Location;
 use thoth_api::model::price::Price;
 use thoth_api::model::publication::PublicationWithRelations;
 use uuid::Uuid;
@@ -19,6 +20,7 @@ use crate::agent::notification_bus::NotificationDispatcher;
 use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
 use crate::component::delete_dialogue::ConfirmDeleteComponent;
+use crate::component::locations_form::LocationsFormComponent;
 use crate::component::prices_form::PricesFormComponent;
 use crate::component::utils::Loader;
 use crate::models::publication::delete_publication_mutation::DeletePublicationRequest;
@@ -49,6 +51,7 @@ pub enum Msg {
     GetPublication,
     SetPublicationDeleteState(PushActionDeletePublication),
     DeletePublication,
+    UpdateLocations(Option<Vec<Location>>),
     UpdatePrices(Option<Vec<Price>>),
     ChangeRoute(AppRoute),
 }
@@ -190,6 +193,7 @@ impl Component for PublicationComponent {
                     .send_message(Msg::SetPublicationDeleteState(FetchAction::Fetching));
                 false
             }
+            Msg::UpdateLocations(locations) => self.publication.locations.neq_assign(locations),
             Msg::UpdatePrices(prices) => self.publication.prices.neq_assign(prices),
             Msg::ChangeRoute(r) => {
                 let route = Route::from(r);
@@ -259,9 +263,15 @@ impl Component for PublicationComponent {
 
                         <article class="message is-info">
                             <div class="message-body">
-                                { "Prices below are saved automatically upon change." }
+                                { "Relations below are saved automatically upon change." }
                             </div>
                         </article>
+
+                        <LocationsFormComponent
+                            locations=self.publication.locations.clone()
+                            publication_id=self.publication.publication_id
+                            update_locations=self.link.callback(Msg::UpdateLocations)
+                        />
 
                         <PricesFormComponent
                             prices=self.publication.prices.clone()

--- a/thoth-app/src/component/publication.rs
+++ b/thoth-app/src/component/publication.rs
@@ -250,13 +250,6 @@ impl Component for PublicationComponent {
                                     {&self.publication.isbn.as_ref().map(|s| s.to_string()).unwrap_or_else(|| "".to_string())}
                                 </div>
                             </div>
-
-                            <div class="field">
-                                <label class="label">{ "Publication URL" }</label>
-                                <div class="control is-expanded">
-                                    {&self.publication.publication_url.clone().unwrap_or_else(|| "".to_string())}
-                                </div>
-                            </div>
                         </form>
 
                         <hr/>

--- a/thoth-app/src/component/publication.rs
+++ b/thoth-app/src/component/publication.rs
@@ -35,6 +35,7 @@ use crate::models::publication::publication_query::PublicationRequestBody;
 use crate::models::publication::publication_query::Variables;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
+use crate::string::RELATIONS_INFO;
 
 pub struct PublicationComponent {
     publication: PublicationWithRelations,
@@ -256,7 +257,7 @@ impl Component for PublicationComponent {
 
                         <article class="message is-info">
                             <div class="message-body">
-                                { "Relations below are saved automatically upon change." }
+                                { RELATIONS_INFO }
                             </div>
                         </article>
 

--- a/thoth-app/src/component/publications.rs
+++ b/thoth-app/src/component/publications.rs
@@ -26,7 +26,6 @@ pagination_component! {
         "Publisher".to_string(),
         PublicationField::PublicationType.to_string(),
         PublicationField::Isbn.to_string(),
-        PublicationField::PublicationUrl.to_string(),
         PublicationField::UpdatedAt.to_string(),
     ],
     PublicationOrderBy,

--- a/thoth-app/src/component/publications_form.rs
+++ b/thoth-app/src/component/publications_form.rs
@@ -22,7 +22,6 @@ use crate::agent::notification_bus::NotificationStatus;
 use crate::agent::notification_bus::Request;
 use crate::component::utils::FormPublicationTypeSelect;
 use crate::component::utils::FormTextInputExtended;
-use crate::component::utils::FormUrlInput;
 use crate::models::publication::create_publication_mutation::CreatePublicationRequest;
 use crate::models::publication::create_publication_mutation::CreatePublicationRequestBody;
 use crate::models::publication::create_publication_mutation::PushActionCreatePublication;
@@ -74,7 +73,6 @@ pub enum Msg {
     DeletePublication(Uuid),
     ChangePublicationType(PublicationType),
     ChangeIsbn(String),
-    ChangeUrl(String),
     ChangeRoute(AppRoute),
     DoNothing,
 }
@@ -198,7 +196,6 @@ impl Component for PublicationsFormComponent {
                         work_id: self.props.work_id,
                         publication_type: self.new_publication.publication_type.clone(),
                         isbn: self.new_publication.isbn.clone(),
-                        publication_url: self.new_publication.publication_url.clone(),
                     },
                     ..Default::default()
                 };
@@ -284,13 +281,6 @@ impl Component for PublicationsFormComponent {
                     false
                 }
             }
-            Msg::ChangeUrl(value) => {
-                let url = match value.trim().is_empty() {
-                    true => None,
-                    false => Some(value.trim().to_owned()),
-                };
-                self.new_publication.publication_url.neq_assign(url)
-            }
             Msg::ChangeRoute(r) => {
                 let route = Route::from(r);
                 self.router.send(RouteRequest::ChangeRoute(route));
@@ -365,11 +355,6 @@ impl Component for PublicationsFormComponent {
                                     tooltip=self.isbn_warning.clone()
                                     oninput=self.link.callback(|e: InputData| Msg::ChangeIsbn(e.value))
                                 />
-                                <FormUrlInput
-                                    label = "URL"
-                                    value=self.new_publication.publication_url.clone().unwrap_or_else(|| "".to_string()).clone()
-                                    oninput=self.link.callback(|e: InputData| Msg::ChangeUrl(e.value))
-                                />
                             </form>
                         </section>
                         <footer class="modal-card-foot">
@@ -435,13 +420,6 @@ impl PublicationsFormComponent {
                         <label class="label">{ "ISBN" }</label>
                         <div class="control is-expanded">
                             {&p.isbn.as_ref().map(|s| s.to_string()).unwrap_or_else(|| "".to_string())}
-                        </div>
-                    </div>
-
-                    <div class="field" style="width: 8em;">
-                        <label class="label">{ "URL" }</label>
-                        <div class="control is-expanded">
-                            {&p.publication_url.clone().unwrap_or_else(|| "".to_string())}
                         </div>
                     </div>
 

--- a/thoth-app/src/component/publications_form.rs
+++ b/thoth-app/src/component/publications_form.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 use thoth_api::model::publication::Publication;
 use thoth_api::model::publication::PublicationType;
+use thoth_api::model::work::WorkType;
 use thoth_api::model::Isbn;
 use thoth_errors::ThothError;
 use uuid::Uuid;
@@ -80,6 +81,7 @@ pub enum Msg {
 pub struct Props {
     pub publications: Option<Vec<Publication>>,
     pub work_id: Uuid,
+    pub work_type: WorkType,
     pub update_publications: Callback<Option<Vec<Publication>>>,
 }
 
@@ -302,6 +304,8 @@ impl Component for PublicationsFormComponent {
             e.prevent_default();
             Msg::ToggleAddFormDisplay(false)
         });
+        // ISBNs cannot be added for publications whose work type is Book Chapter.
+        let isbn_deactivated = self.props.work_type == WorkType::BookChapter;
         html! {
             <nav class="panel">
                 <p class="panel-heading">
@@ -352,6 +356,7 @@ impl Component for PublicationsFormComponent {
                                     value=self.isbn.clone()
                                     tooltip=self.isbn_warning.clone()
                                     oninput=self.link.callback(|e: InputData| Msg::ChangeIsbn(e.value))
+                                    deactivated=isbn_deactivated
                                 />
                             </form>
                         </section>

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -181,6 +181,7 @@ pub struct PureNumberInput {
 pub struct PureWorkTypeSelect {
     pub label: String,
     pub data: Vec<WorkTypeValues>,
+    // Subset of `data` list which should be deactivated, if any
     #[prop_or_default]
     pub deactivate: Vec<WorkType>,
     pub value: WorkType,
@@ -768,23 +769,12 @@ impl PureComponent for PurePublisherSelect {
 
 impl PureWorkTypeSelect {
     fn render_worktype(&self, w: &WorkTypeValues, deactivate: &[WorkType]) -> VNode {
-        // It should not be possible for the selected option to require deactivation.
-        if deactivate.contains(&w.name) {
-            html! {
-                <option value={w.name.to_string()} disabled=true>
-                    {&w.name}
-                </option>
-            }
-        } else if w.name == self.value {
-            html! {
-                <option value={w.name.to_string()} selected=true>
-                    {&w.name}
-                </option>
-            }
-        } else {
-            html! {
-                <option value={w.name.to_string()}>{&w.name}</option>
-            }
+        let deactivated = deactivate.contains(&w.name);
+        let selected = w.name == self.value;
+        html! {
+            <option value={w.name.to_string()} selected={selected} disabled={deactivated}>
+                {&w.name}
+            </option>
         }
     }
 }

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -92,6 +92,7 @@ pub struct PureTextarea {
 
 // Variant of PureTextInput which supports tooltips,
 // prepended static buttons, or both together.
+// Also supports deactivating the input.
 #[derive(Clone, PartialEq, Properties)]
 pub struct PureTextInputExtended {
     pub label: String,
@@ -108,6 +109,8 @@ pub struct PureTextInputExtended {
     pub onblur: Callback<FocusEvent>,
     #[prop_or(false)]
     pub required: bool,
+    #[prop_or(false)]
+    pub deactivated: bool,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -178,6 +181,8 @@ pub struct PureNumberInput {
 pub struct PureWorkTypeSelect {
     pub label: String,
     pub data: Vec<WorkTypeValues>,
+    #[prop_or_default]
+    pub deactivate: Vec<WorkType>,
     pub value: WorkType,
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
@@ -399,6 +404,7 @@ impl PureComponent for PureTextInputExtended {
                         onfocus=self.onfocus.clone()
                         onblur=self.onblur.clone()
                         required={ self.required }
+                        disabled={ self.deactivated }
                     />
                 </div>
             </div>
@@ -492,7 +498,7 @@ impl PureComponent for PureWorkTypeSelect {
                 <div class="control is-expanded">
                     <div class="select is-fullwidth">
                     <select required=self.required onchange=&self.onchange>
-                        { for self.data.iter().map(|i| self.render_worktype(i)) }
+                        { for self.data.iter().map(|i| self.render_worktype(i, &self.deactivate)) }
                     </select>
                     </div>
                 </div>
@@ -761,8 +767,15 @@ impl PureComponent for PurePublisherSelect {
 }
 
 impl PureWorkTypeSelect {
-    fn render_worktype(&self, w: &WorkTypeValues) -> VNode {
-        if w.name == self.value {
+    fn render_worktype(&self, w: &WorkTypeValues, deactivate: &[WorkType]) -> VNode {
+        // It should not be possible for the selected option to require deactivation.
+        if deactivate.contains(&w.name) {
+            html! {
+                <option value={w.name.to_string()} disabled=true>
+                    {&w.name}
+                </option>
+            }
+        } else if w.name == self.value {
             html! {
                 <option value={w.name.to_string()} selected=true>
                     {&w.name}

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -2,6 +2,7 @@ use thoth_api::model::contribution::ContributionType;
 use thoth_api::model::imprint::ImprintWithPublisher;
 use thoth_api::model::language::LanguageCode;
 use thoth_api::model::language::LanguageRelation;
+use thoth_api::model::location::LocationPlatform;
 use thoth_api::model::price::CurrencyCode;
 use thoth_api::model::publication::PublicationType;
 use thoth_api::model::publisher::Publisher;
@@ -25,6 +26,7 @@ use yewtil::PureComponent;
 use crate::models::contribution::ContributionTypeValues;
 use crate::models::language::LanguageCodeValues;
 use crate::models::language::LanguageRelationValues;
+use crate::models::location::LocationPlatformValues;
 use crate::models::price::CurrencyCodeValues;
 use crate::models::publication::PublicationTypeValues;
 use crate::models::series::SeriesTypeValues;
@@ -53,6 +55,7 @@ pub type FormSubjectTypeSelect = Pure<PureSubjectTypeSelect>;
 pub type FormLanguageCodeSelect = Pure<PureLanguageCodeSelect>;
 pub type FormLanguageRelationSelect = Pure<PureLanguageRelationSelect>;
 pub type FormCurrencyCodeSelect = Pure<PureCurrencyCodeSelect>;
+pub type FormLocationPlatformSelect = Pure<PureLocationPlatformSelect>;
 pub type FormLengthUnitSelect = Pure<PureLengthUnitSelect>;
 pub type FormBooleanSelect = Pure<PureBooleanSelect>;
 pub type FormImprintSelect = Pure<PureImprintSelect>;
@@ -250,6 +253,16 @@ pub struct PureCurrencyCodeSelect {
     pub label: String,
     pub data: Vec<CurrencyCodeValues>,
     pub value: CurrencyCode,
+    pub onchange: Callback<ChangeData>,
+    #[prop_or(false)]
+    pub required: bool,
+}
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct PureLocationPlatformSelect {
+    pub label: String,
+    pub data: Vec<LocationPlatformValues>,
+    pub value: LocationPlatform,
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
     pub required: bool,
@@ -642,6 +655,26 @@ impl PureComponent for PureCurrencyCodeSelect {
     }
 }
 
+impl PureComponent for PureLocationPlatformSelect {
+    fn render(&self) -> VNode {
+        html! {
+            <div class="field">
+                <label class="label">{ &self.label }</label>
+                <div class="control is-expanded">
+                    <div class="select">
+                    <select
+                        required=self.required
+                        onchange=&self.onchange
+                    >
+                        { for self.data.iter().map(|l| self.render_locationplatform(l)) }
+                    </select>
+                    </div>
+                </div>
+            </div>
+        }
+    }
+}
+
 impl PureComponent for PureLengthUnitSelect {
     fn render(&self) -> VNode {
         html! {
@@ -863,6 +896,22 @@ impl PureCurrencyCodeSelect {
         } else {
             html! {
                 <option value={c.name.to_string()}>{&c.name}</option>
+            }
+        }
+    }
+}
+
+impl PureLocationPlatformSelect {
+    fn render_locationplatform(&self, l: &LocationPlatformValues) -> VNode {
+        if l.name == self.value {
+            html! {
+                <option value={l.name.to_string()} selected=true>
+                    {&l.name}
+                </option>
+            }
+        } else {
+            html! {
+                <option value={l.name.to_string()}>{&l.name}</option>
             }
         }
     }

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -68,6 +68,7 @@ use crate::models::work::WorkStatusValues;
 use crate::models::work::WorkTypeValues;
 use crate::route::AdminRoute;
 use crate::route::AppRoute;
+use crate::string::RELATIONS_INFO;
 use crate::string::SAVE_BUTTON;
 
 use super::ToOption;
@@ -811,7 +812,7 @@ impl Component for WorkComponent {
 
                         <article class="message is-info">
                             <div class="message-body">
-                                { "Relations below are saved automatically upon change." }
+                                { RELATIONS_INFO }
                             </div>
                         </article>
 

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -79,6 +79,8 @@ pub struct WorkComponent {
     doi_warning: String,
     // Track imprint stored in database, as distinct from imprint selected in dropdown
     imprint_id: Uuid,
+    // Track work_type stored in database, as distinct from work_type selected in dropdown
+    work_type: WorkType,
     data: WorkFormData,
     fetch_work: FetchWork,
     push_work: PushUpdateWork,
@@ -164,6 +166,7 @@ impl Component for WorkComponent {
         let doi = Default::default();
         let doi_warning = Default::default();
         let imprint_id = work.imprint.imprint_id;
+        let work_type = work.work_type.clone();
         let data: WorkFormData = Default::default();
         let router = RouteAgentDispatcher::new();
 
@@ -174,6 +177,7 @@ impl Component for WorkComponent {
             doi,
             doi_warning,
             imprint_id,
+            work_type,
             data,
             fetch_work,
             push_work,
@@ -200,6 +204,7 @@ impl Component for WorkComponent {
                         // Initialise user-entered DOI variable to match DOI in database
                         self.doi = self.work.doi.clone().unwrap_or_default().to_string();
                         self.imprint_id = self.work.imprint.imprint_id;
+                        self.work_type = self.work.work_type.clone();
                         self.data.imprints = body.data.imprints.to_owned();
                         self.data.length_units = body.data.length_units.enum_values.to_owned();
                         self.data.work_types = body.data.work_types.enum_values.to_owned();
@@ -251,6 +256,7 @@ impl Component for WorkComponent {
                             self.doi = self.work.doi.clone().unwrap_or_default().to_string();
                             self.doi_warning.clear();
                             self.imprint_id = self.work.imprint.imprint_id;
+                            self.work_type = self.work.work_type.clone();
                             if self.props.units_selection == LengthUnit::In {
                                 // User-entered dimensions may have been rounded on save due to
                                 // conversion to mm - update display with database values
@@ -527,6 +533,19 @@ impl Component for WorkComponent {
                     true => self.data.imprints.clone(),
                     false => vec![self.work.imprint.clone()],
                 };
+                // FormWorkTypeSelect: while the work has any publications with ISBNs,
+                // the work type cannot be changed to Book Chapter.
+                let deactivated_types = match self
+                    .work
+                    .publications
+                    .as_ref()
+                    .unwrap_or(&vec![])
+                    .iter()
+                    .any(|p| p.isbn.is_some())
+                {
+                    true => vec![WorkType::BookChapter],
+                    false => vec![],
+                };
                 // Restrict the number of decimal places the user can enter for width/height values
                 // based on currently selected units.
                 let step = match self.props.units_selection {
@@ -559,6 +578,7 @@ impl Component for WorkComponent {
                                         label = "Work Type"
                                         value=self.work.work_type.clone()
                                         data=self.data.work_types.clone()
+                                        deactivate=deactivated_types.clone()
                                         onchange=self.link.callback(|event| match event {
                                             ChangeData::Select(elem) => {
                                                 let value = elem.value();
@@ -803,6 +823,7 @@ impl Component for WorkComponent {
                         <PublicationsFormComponent
                             publications=self.work.publications.clone()
                             work_id=self.work.work_id
+                            work_type=self.work_type.clone()
                             update_publications=self.link.callback(Msg::UpdatePublications)
                         />
                         <LanguagesFormComponent

--- a/thoth-app/src/models/location/create_location_mutation.rs
+++ b/thoth-app/src/models/location/create_location_mutation.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 const CREATE_LOCATION_MUTATION: &str = "
     mutation CreateLocation(
         $publicationId: Uuid!,
-        $landingPage: String!,
+        $landingPage: String,
         $fullTextUrl: String,
         $locationPlatform: LocationPlatform!,
         $canonical: Boolean!
@@ -46,7 +46,7 @@ graphql_query_builder! {
 #[serde(rename_all = "camelCase")]
 pub struct Variables {
     pub publication_id: Uuid,
-    pub landing_page: String,
+    pub landing_page: Option<String>,
     pub full_text_url: Option<String>,
     pub location_platform: LocationPlatform,
     pub canonical: bool,

--- a/thoth-app/src/models/location/create_location_mutation.rs
+++ b/thoth-app/src/models/location/create_location_mutation.rs
@@ -1,0 +1,59 @@
+use serde::Deserialize;
+use serde::Serialize;
+use thoth_api::model::location::Location;
+use thoth_api::model::location::LocationPlatform;
+use uuid::Uuid;
+
+const CREATE_LOCATION_MUTATION: &str = "
+    mutation CreateLocation(
+        $publicationId: Uuid!,
+        $landingPage: String!,
+        $fullTextUrl: String,
+        $locationPlatform: LocationPlatform!,
+        $canonical: Boolean!
+    ) {
+        createLocation(data: {
+            publicationId: $publicationId
+            landingPage: $landingPage
+            fullTextUrl: $fullTextUrl
+            locationPlatform: $locationPlatform
+            canonical: $canonical
+        }){
+            locationId
+            publicationId
+            landingPage
+            fullTextUrl
+            locationPlatform
+            canonical
+            createdAt
+            updatedAt
+        }
+    }
+";
+
+graphql_query_builder! {
+    CreateLocationRequest,
+    CreateLocationRequestBody,
+    Variables,
+    CREATE_LOCATION_MUTATION,
+    CreateLocationResponseBody,
+    CreateLocationResponseData,
+    PushCreateLocation,
+    PushActionCreateLocation
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Variables {
+    pub publication_id: Uuid,
+    pub landing_page: String,
+    pub full_text_url: Option<String>,
+    pub location_platform: LocationPlatform,
+    pub canonical: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateLocationResponseData {
+    pub create_location: Option<Location>,
+}

--- a/thoth-app/src/models/location/delete_location_mutation.rs
+++ b/thoth-app/src/models/location/delete_location_mutation.rs
@@ -12,7 +12,6 @@ const DELETE_LOCATION_MUTATION: &str = "
         ){
             locationId
             publicationId
-            landingPage
             locationPlatform
             canonical
             createdAt

--- a/thoth-app/src/models/location/delete_location_mutation.rs
+++ b/thoth-app/src/models/location/delete_location_mutation.rs
@@ -1,0 +1,45 @@
+use serde::Deserialize;
+use serde::Serialize;
+use thoth_api::model::location::Location;
+use uuid::Uuid;
+
+const DELETE_LOCATION_MUTATION: &str = "
+    mutation DeleteLocation(
+        $locationId: Uuid!
+    ) {
+        deleteLocation(
+            locationId: $locationId
+        ){
+            locationId
+            publicationId
+            landingPage
+            locationPlatform
+            canonical
+            createdAt
+            updatedAt
+        }
+    }
+";
+
+graphql_query_builder! {
+    DeleteLocationRequest,
+    DeleteLocationRequestBody,
+    Variables,
+    DELETE_LOCATION_MUTATION,
+    DeleteLocationResponseBody,
+    DeleteLocationResponseData,
+    PushDeleteLocation,
+    PushActionDeleteLocation
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Variables {
+    pub location_id: Uuid,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteLocationResponseData {
+    pub delete_location: Option<Location>,
+}

--- a/thoth-app/src/models/location/location_platforms_query.rs
+++ b/thoth-app/src/models/location/location_platforms_query.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::LocationPlatformDefinition;
+
+const LOCATION_PLATFORMS_QUERY: &str = "
+    {
+        location_platforms: __type(name: \"LocationPlatform\") {
+            enumValues {
+                name
+            }
+        }
+    }
+";
+
+graphql_query_builder! {
+    LocationPlatformsRequest,
+    LocationPlatformsRequestBody,
+    Variables,
+    LOCATION_PLATFORMS_QUERY,
+    LocationPlatformsResponseBody,
+    LocationPlatformsResponseData,
+    FetchLocationPlatforms,
+    FetchActionLocationPlatforms
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Variables {}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct LocationPlatformsResponseData {
+    pub location_platforms: LocationPlatformDefinition,
+}

--- a/thoth-app/src/models/location/mod.rs
+++ b/thoth-app/src/models/location/mod.rs
@@ -1,0 +1,19 @@
+use serde::Deserialize;
+use serde::Serialize;
+use thoth_api::model::location::LocationPlatform;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationPlatformDefinition {
+    pub enum_values: Vec<LocationPlatformValues>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationPlatformValues {
+    pub name: LocationPlatform,
+}
+
+pub mod create_location_mutation;
+pub mod delete_location_mutation;
+pub mod location_platforms_query;

--- a/thoth-app/src/models/mod.rs
+++ b/thoth-app/src/models/mod.rs
@@ -144,6 +144,7 @@ pub mod funding;
 pub mod imprint;
 pub mod issue;
 pub mod language;
+pub mod location;
 pub mod price;
 pub mod publication;
 pub mod publisher;

--- a/thoth-app/src/models/price/currency_codes_query.rs
+++ b/thoth-app/src/models/price/currency_codes_query.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use super::CurrencyCodeDefinition;
 
-const LANGUAGE_CODES_QUERY: &str = "
+const CURRENCY_CODES_QUERY: &str = "
     {
         currency_codes: __type(name: \"CurrencyCode\") {
             enumValues {
@@ -17,7 +17,7 @@ graphql_query_builder! {
     CurrencyCodesRequest,
     CurrencyCodesRequestBody,
     Variables,
-    LANGUAGE_CODES_QUERY,
+    CURRENCY_CODES_QUERY,
     CurrencyCodesResponseBody,
     CurrencyCodesResponseData,
     FetchCurrencyCodes,

--- a/thoth-app/src/models/publication/create_publication_mutation.rs
+++ b/thoth-app/src/models/publication/create_publication_mutation.rs
@@ -10,19 +10,16 @@ const CREATE_PUBLICATION_MUTATION: &str = "
         $publicationType: PublicationType!,
         $workId: Uuid!,
         $isbn: Isbn,
-        $publicationUrl: String,
     ) {
         createPublication(data: {
             publicationType: $publicationType
             workId: $workId
             isbn: $isbn
-            publicationUrl: $publicationUrl
         }){
             publicationId
             publicationType
             workId
             isbn
-            publicationUrl
             createdAt
             updatedAt
         }
@@ -46,7 +43,6 @@ pub struct Variables {
     pub publication_type: PublicationType,
     pub work_id: Uuid,
     pub isbn: Option<Isbn>,
-    pub publication_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/thoth-app/src/models/publication/mod.rs
+++ b/thoth-app/src/models/publication/mod.rs
@@ -49,10 +49,6 @@ impl MetadataTable for PublicationWithRelations {
             .as_ref()
             .map(|s| s.to_string())
             .unwrap_or_else(|| "".to_string());
-        let publication_url = &self
-            .publication_url
-            .clone()
-            .unwrap_or_else(|| "".to_string());
         html! {
             <tr
                 class="row"
@@ -64,7 +60,6 @@ impl MetadataTable for PublicationWithRelations {
                 <td>{&self.work.publisher()}</td>
                 <td>{&self.publication_type}</td>
                 <td>{isbn}</td>
-                <td>{publication_url}</td>
                 <td>{&self.updated_at}</td>
             </tr>
         }

--- a/thoth-app/src/models/publication/publication_query.rs
+++ b/thoth-app/src/models/publication/publication_query.rs
@@ -20,6 +20,16 @@ pub const PUBLICATION_QUERY: &str = "
                 createdAt
                 updatedAt
             }
+            locations {
+                locationId
+                publicationId
+                landingPage
+                fullTextUrl
+                locationPlatform
+                canonical
+                createdAt
+                updatedAt
+            }
             work {
                 workId
                 workType

--- a/thoth-app/src/models/publication/publication_query.rs
+++ b/thoth-app/src/models/publication/publication_query.rs
@@ -10,7 +10,6 @@ pub const PUBLICATION_QUERY: &str = "
             publicationType
             workId
             isbn
-            publicationUrl
             updatedAt
             prices {
                 priceId

--- a/thoth-app/src/models/publication/publications_query.rs
+++ b/thoth-app/src/models/publication/publications_query.rs
@@ -10,7 +10,6 @@ pub const PUBLICATIONS_QUERY: &str = "
             publicationType
             workId
             isbn
-            publicationUrl
             updatedAt
             work {
                 workId

--- a/thoth-app/src/models/work/work_query.rs
+++ b/thoth-app/src/models/work/work_query.rs
@@ -62,7 +62,6 @@ pub const WORK_QUERY: &str = "
                 publicationType
                 workId
                 isbn
-                publicationUrl
                 createdAt
                 updatedAt
             }

--- a/thoth-app/src/string.rs
+++ b/thoth-app/src/string.rs
@@ -30,6 +30,7 @@ strings! {
     EMPTY_CONTRIBUTIONS => "This work does not have any contributions. Search contributors above to add its contributions.",
     EMPTY_ISSUES => "This work is not part of a series. Search above to add a new series issue.",
     EMPTY_LANGUAGES => "This work does not have any languages. Search above to add a new language.",
+    EMPTY_LOCATIONS => "This publication does not have any location information. Click above to add locations.",
     EMPTY_PUBLICATIONS => "This work does not have any publications. Click above to add associated publications",
     EMPTY_SUBJECTS => "This work does not have any subjects. Click above to add associated subjects",
     EMPTY_FUNDINGS => "This work does not have any funding. Click above to add associated funding",

--- a/thoth-app/src/string.rs
+++ b/thoth-app/src/string.rs
@@ -45,4 +45,5 @@ strings! {
     STORAGE_ERROR => "local storage is disabled",
     PERMISSIONS_ERROR => "This account is not permitted to access any data",
     NEW_VERSION_PROMPT => "A new version of Thoth is available. Refresh your browser to update.",
+    RELATIONS_INFO => "Relations below are saved automatically upon change.",
 }

--- a/thoth-app/src/string.rs
+++ b/thoth-app/src/string.rs
@@ -41,7 +41,7 @@ strings! {
     SEARCH_PUBLISHERS => "Search by publisher name or short name",
     SEARCH_IMPRINTS => "Search by imprint name or URL",
     SEARCH_CONTRIBUTORS => "Search by name or ORCID",
-    SEARCH_PUBLICATIONS => "Search by ISBN or URL",
+    SEARCH_PUBLICATIONS => "Search by ISBN",
     STORAGE_ERROR => "local storage is disabled",
     PERMISSIONS_ERROR => "This account is not permitted to access any data",
     NEW_VERSION_PROMPT => "A new version of Thoth is available. Refresh your browser to update.",

--- a/thoth-client/assets/queries.graphql
+++ b/thoth-client/assets/queries.graphql
@@ -70,7 +70,6 @@ fragment Work on Work {
     publications {
         publicationId
         publicationType
-        publicationUrl
         isbn
         prices {
             currencyCode

--- a/thoth-client/assets/queries.graphql
+++ b/thoth-client/assets/queries.graphql
@@ -76,6 +76,12 @@ fragment Work on Work {
             currencyCode
             unitPrice
         }
+        locations {
+            landingPage
+            fullTextUrl
+            locationPlatform
+            canonical
+        }
     }
     subjects {
         subjectCode

--- a/thoth-client/assets/schema.json
+++ b/thoth-client/assets/schema.json
@@ -5410,7 +5410,49 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "DOAB"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "JSTOR"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "EBSCO_HOST"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "OCLC_KB"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PROQUEST_KB"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PROQUEST_EXLIBRIS"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "EBSCO_KB"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "JISC_KB"
             },
             {
               "deprecationReason": null,

--- a/thoth-client/assets/schema.json
+++ b/thoth-client/assets/schema.json
@@ -5398,42 +5398,38 @@
           "possibleTypes": null
         },
         {
-          "description": "Field and order to use when sorting subjects list",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
+          "description": null,
+          "enumValues": [
             {
-              "defaultValue": null,
+              "deprecationReason": null,
               "description": null,
-              "name": "field",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "SubjectField",
-                  "ofType": null
-                }
-              }
+              "isDeprecated": false,
+              "name": "PROJECT_MUSE"
             },
             {
-              "defaultValue": null,
+              "deprecationReason": null,
               "description": null,
-              "name": "direction",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "Direction",
-                  "ofType": null
-                }
-              }
+              "isDeprecated": false,
+              "name": "OAPEN"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "JSTOR"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "OTHER"
             }
           ],
+          "fields": null,
+          "inputFields": null,
           "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "SubjectOrderBy",
+          "kind": "ENUM",
+          "name": "LocationPlatform",
           "possibleTypes": null
         },
         {
@@ -6007,7 +6003,7 @@
           "possibleTypes": null
         },
         {
-          "description": "Field and order to use when sorting seriess list",
+          "description": "Field and order to use when sorting subjects list",
           "enumValues": null,
           "fields": null,
           "inputFields": [
@@ -6020,7 +6016,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "SeriesField",
+                  "name": "SubjectField",
                   "ofType": null
                 }
               }
@@ -6042,7 +6038,7 @@
           ],
           "interfaces": null,
           "kind": "INPUT_OBJECT",
-          "name": "SeriesOrderBy",
+          "name": "SubjectOrderBy",
           "possibleTypes": null
         },
         {
@@ -6132,30 +6128,20 @@
           "possibleTypes": null
         },
         {
-          "description": null,
+          "description": "Field and order to use when sorting seriess list",
           "enumValues": null,
           "fields": null,
           "inputFields": [
             {
               "defaultValue": null,
               "description": null,
-              "name": "firstName",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "lastName",
+              "name": "field",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
+                  "kind": "ENUM",
+                  "name": "SeriesField",
                   "ofType": null
                 }
               }
@@ -6163,41 +6149,21 @@
             {
               "defaultValue": null,
               "description": null,
-              "name": "fullName",
+              "name": "direction",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
+                  "kind": "ENUM",
+                  "name": "Direction",
                   "ofType": null
                 }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "orcid",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Orcid",
-                "ofType": null
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "website",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               }
             }
           ],
           "interfaces": null,
           "kind": "INPUT_OBJECT",
-          "name": "NewContributor",
+          "name": "SeriesOrderBy",
           "possibleTypes": null
         },
         {
@@ -6374,6 +6340,71 @@
               }
             },
             {
+              "args": [
+                {
+                  "defaultValue": "100",
+                  "description": "The number of items to return",
+                  "name": "limit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": "0",
+                  "description": "The number of items to skip",
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": "{field: \"LOCATION_PLATFORM\", direction: \"ASC\"}",
+                  "description": "The order in which to sort the results",
+                  "name": "order",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LocationOrderBy",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "A specific platform to filter by",
+                  "name": "locationPlatform",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "LocationPlatform",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Get locations linked to this publication",
+              "isDeprecated": false,
+              "name": "locations",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Location",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
               "args": [],
               "deprecationReason": null,
               "description": null,
@@ -6404,6 +6435,75 @@
           "interfaces": null,
           "kind": "SCALAR",
           "name": "Uuid",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "firstName",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "lastName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "fullName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "orcid",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Orcid",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "website",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "NewContributor",
           "possibleTypes": null
         },
         {
@@ -6520,79 +6620,6 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "PatchImprint",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "publicationId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Uuid",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "publicationType",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "PublicationType",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "workId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Uuid",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "isbn",
-              "type": {
-                "kind": "SCALAR",
-                "name": "Isbn",
-                "ofType": null
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "publicationUrl",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "PatchPublication",
           "possibleTypes": null
         },
         {
@@ -6713,6 +6740,79 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "NewImprint",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "publicationId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Uuid",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "publicationType",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PublicationType",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "workId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Uuid",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "isbn",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Isbn",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "publicationUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "PatchPublication",
           "possibleTypes": null
         },
         {
@@ -6885,113 +6985,6 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "PatchIssue",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "description",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "args",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "__InputValue",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "type",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isDeprecated",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "deprecationReason",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "__Field",
           "possibleTypes": null
         },
         {
@@ -7465,30 +7458,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "locations",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "ENUM",
-                      "name": "__DirectiveLocation",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "args",
               "type": {
                 "kind": "NON_NULL",
@@ -7510,10 +7479,26 @@
             },
             {
               "args": [],
-              "deprecationReason": "Use the locations array instead",
+              "deprecationReason": null,
               "description": null,
-              "isDeprecated": true,
-              "name": "onOperation",
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -7526,41 +7511,21 @@
             },
             {
               "args": [],
-              "deprecationReason": "Use the locations array instead",
+              "deprecationReason": null,
               "description": null,
-              "isDeprecated": true,
-              "name": "onFragment",
+              "isDeprecated": false,
+              "name": "deprecationReason",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": "Use the locations array instead",
-              "description": null,
-              "isDeprecated": true,
-              "name": "onField",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             }
           ],
           "inputFields": null,
           "interfaces": [],
           "kind": "OBJECT",
-          "name": "__Directive",
+          "name": "__Field",
           "possibleTypes": null
         },
         {
@@ -7731,6 +7696,141 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "PatchPrice",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "locations",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "args",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use the locations array instead",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onOperation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use the locations array instead",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onFragment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use the locations array instead",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onField",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "__Directive",
           "possibleTypes": null
         },
         {
@@ -8543,6 +8643,37 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "NewLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createLocation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Location",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "data",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "NewPrice",
                       "ofType": null
                     }
@@ -8960,6 +9091,37 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "PatchLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "updateLocation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Location",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "data",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "PatchPrice",
                       "ofType": null
                     }
@@ -9348,6 +9510,37 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "Funding",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "locationId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Uuid",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deleteLocation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Location",
                   "ofType": null
                 }
               }
@@ -9778,6 +9971,83 @@
         {
           "description": null,
           "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "publicationId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Uuid",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "landingPage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "fullTextUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "locationPlatform",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "LocationPlatform",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "canonical",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "NewLocation",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
           "fields": [
             {
               "args": [],
@@ -10199,6 +10469,97 @@
         },
         {
           "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "locationId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Uuid",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "publicationId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Uuid",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "landingPage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "fullTextUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "locationPlatform",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "LocationPlatform",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "canonical",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "PatchLocation",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
           "enumValues": [
             {
               "deprecationReason": null,
@@ -10318,6 +10679,196 @@
           "possibleTypes": null
         },
         {
+          "description": "A location, such as a web shop or distribution platform, where a publication can be acquired or viewed.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "locationId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Uuid",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "publicationId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Uuid",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "landingPage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fullTextUrl",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "locationPlatform",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "LocationPlatform",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "canonical",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Timestamp",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "updatedAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Timestamp",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "publication",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Publication",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Location",
+          "possibleTypes": null
+        },
+        {
+          "description": "Field and order to use when sorting imprints list",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "field",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ImprintField",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "direction",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Direction",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "ImprintOrderBy",
+          "possibleTypes": null
+        },
+        {
           "description": null,
           "enumValues": [
             {
@@ -10362,92 +10913,6 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "SubjectType",
-          "possibleTypes": null
-        },
-        {
-          "description": "Field and order to use when sorting imprints list",
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "field",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "ImprintField",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "direction",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "Direction",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "ImprintOrderBy",
-          "possibleTypes": null
-        },
-        {
-          "description": "Field to use when sorting publishers list",
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "PUBLISHER_ID"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "PUBLISHER_NAME"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "PUBLISHER_SHORTNAME"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "PUBLISHER_URL"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "CREATED_AT"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "UPDATED_AT"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "PublisherField",
           "possibleTypes": null
         },
         {
@@ -11448,7 +11913,7 @@
                 },
                 {
                   "defaultValue": "\"\"",
-                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on full_name and orcid",
+                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on full_name, last_name and orcid",
                   "name": "filter",
                   "type": {
                     "kind": "SCALAR",
@@ -11524,7 +11989,7 @@
               "args": [
                 {
                   "defaultValue": "\"\"",
-                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on full_name and orcid",
+                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on full_name, last_name and orcid",
                   "name": "filter",
                   "type": {
                     "kind": "SCALAR",
@@ -12171,6 +12636,147 @@
                   }
                 },
                 {
+                  "defaultValue": "{field: \"LOCATION_PLATFORM\", direction: \"ASC\"}",
+                  "description": "The order in which to sort the results",
+                  "name": "order",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LocationOrderBy",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": "[]",
+                  "description": "If set, only shows results connected to publishers with these IDs",
+                  "name": "publishers",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Uuid",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "A specific platform to filter by",
+                  "name": "locationPlatform",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "LocationPlatform",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Query the full list of locations",
+              "isDeprecated": false,
+              "name": "locations",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Location",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "locationId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Uuid",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Query a single location using its id",
+              "isDeprecated": false,
+              "name": "location",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Location",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "locationPlatform",
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "LocationPlatform",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Get the total number of locations associated to works",
+              "isDeprecated": false,
+              "name": "locationCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "100",
+                  "description": "The number of items to return",
+                  "name": "limit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": "0",
+                  "description": "The number of items to skip",
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
                   "defaultValue": "{field: \"CURRENCY_CODE\", direction: \"ASC\"}",
                   "description": "The order in which to sort the results",
                   "name": "order",
@@ -12416,22 +13022,18 @@
             {
               "args": [
                 {
-                  "defaultValue": null,
-                  "description": null,
+                  "defaultValue": "\"\"",
+                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on subject_code",
                   "name": "filter",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   }
                 },
                 {
                   "defaultValue": null,
-                  "description": null,
+                  "description": "A specific type to filter by",
                   "name": "subjectType",
                   "type": {
                     "kind": "ENUM",
@@ -12715,6 +13317,53 @@
           "possibleTypes": null
         },
         {
+          "description": "Field to use when sorting publishers list",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PUBLISHER_ID"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PUBLISHER_NAME"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PUBLISHER_SHORTNAME"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PUBLISHER_URL"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "CREATED_AT"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "UPDATED_AT"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "PublisherField",
+          "possibleTypes": null
+        },
+        {
           "description": "Field to use when sorting series list",
           "enumValues": [
             {
@@ -12883,6 +13532,65 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "__InputValue",
+          "possibleTypes": null
+        },
+        {
+          "description": "Field to use when sorting locations list",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "LOCATION_ID"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PUBLICATION_ID"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "LANDING_PAGE"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "FULL_TEXT_URL"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "LOCATION_PLATFORM"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "CANONICAL"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "CREATED_AT"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "UPDATED_AT"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "LocationField",
           "possibleTypes": null
         },
         {
@@ -14193,6 +14901,45 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "__EnumValue",
+          "possibleTypes": null
+        },
+        {
+          "description": "Field and order to use when sorting locations list",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "field",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "LocationField",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "direction",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Direction",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "LocationOrderBy",
           "possibleTypes": null
         },
         {

--- a/thoth-client/assets/schema.json
+++ b/thoth-client/assets/schema.json
@@ -9964,13 +9964,9 @@
               "description": null,
               "name": "landingPage",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             {
@@ -10477,13 +10473,9 @@
               "description": null,
               "name": "landingPage",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             {
@@ -10693,13 +10685,9 @@
               "isDeprecated": false,
               "name": "landingPage",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             {

--- a/thoth-client/assets/schema.json
+++ b/thoth-client/assets/schema.json
@@ -256,12 +256,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "PUBLICATION_URL"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "CREATED_AT"
             },
             {
@@ -6235,18 +6229,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "publicationUrl",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "createdAt",
               "type": {
                 "kind": "NON_NULL",
@@ -6796,16 +6778,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Isbn",
-                "ofType": null
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "publicationUrl",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             }
@@ -11416,7 +11388,7 @@
                 },
                 {
                   "defaultValue": "\"\"",
-                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn and publication_url",
+                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn",
                   "name": "filter",
                   "type": {
                     "kind": "SCALAR",
@@ -11520,7 +11492,7 @@
               "args": [
                 {
                   "defaultValue": "\"\"",
-                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn and publication_url",
+                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn",
                   "name": "filter",
                   "type": {
                     "kind": "SCALAR",
@@ -14422,7 +14394,7 @@
                 },
                 {
                   "defaultValue": "\"\"",
-                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn and publication_url",
+                  "description": "A query string to search. This argument is a test, do not rely on it. At present it simply searches for case insensitive literals on isbn",
                   "name": "filter",
                   "type": {
                     "kind": "SCALAR",
@@ -14817,16 +14789,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Isbn",
-                "ofType": null
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "publicationUrl",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             }

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -53,6 +53,8 @@ pub enum ThothError {
     DoiEmptyError,
     #[fail(display = "Cannot parse ISBN: no value provided")]
     IsbnEmptyError,
+    #[fail(display = "Works of type Book Chapter cannot have ISBNs in their Publications.")]
+    ChapterIsbnError,
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -55,6 +55,8 @@ pub enum ThothError {
     IsbnEmptyError,
     #[fail(display = "Works of type Book Chapter cannot have ISBNs in their Publications.")]
     ChapterIsbnError,
+    #[fail(display = "Each Publication must have exactly one canonical Location.")]
+    CanonicalLocationError,
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -57,6 +57,10 @@ pub enum ThothError {
     ChapterIsbnError,
     #[fail(display = "Each Publication must have exactly one canonical Location.")]
     CanonicalLocationError,
+    #[fail(
+        display = "Canonical Locations for digital Publications must have both a Landing Page and a Full Text URL."
+    )]
+    LocationUrlError,
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::io::Write;
 use thoth_client::{
     SubjectType, Work, WorkContributions, WorkFundings, WorkIssues, WorkLanguages,
-    WorkPublications, WorkPublicationsPrices, WorkSubjects,
+    WorkPublications, WorkPublicationsLocations, WorkPublicationsPrices, WorkSubjects,
 };
 use thoth_errors::ThothResult;
 
@@ -56,7 +56,9 @@ struct CsvThothRow {
         rename = "contributions [(type, first_name, last_name, full_name, institution, orcid)]"
     )]
     contributions: String,
-    #[serde(rename = "publications [(type, isbn, url, [(ISO_4217_currency, price)])]")]
+    #[serde(
+        rename = "publications [(type, isbn, [(ISO_4217_currency, price)], [(landing_page, full_text, platform, is_canonical)])]"
+    )]
     publications: String,
     #[serde(rename = "series [(type, name, issn_print, issn_digital, url, issue)]")]
     series: String,
@@ -226,14 +228,11 @@ impl CsvCell<CsvThoth> for Vec<String> {
 impl CsvCell<CsvThoth> for WorkPublications {
     fn csv_cell(&self) -> String {
         format!(
-            "(\"{:?}\", \"{}\", \"{}\", {})",
+            "(\"{:?}\", \"{}\", {}, {})",
             self.publication_type,
             self.isbn
                 .as_ref()
                 .map(|i| i.to_string())
-                .unwrap_or_else(|| "".to_string()),
-            self.publication_url
-                .clone()
                 .unwrap_or_else(|| "".to_string()),
             CsvCell::<CsvThoth>::csv_cell(
                 &self
@@ -241,7 +240,14 @@ impl CsvCell<CsvThoth> for WorkPublications {
                     .iter()
                     .map(|p| CsvCell::<CsvThoth>::csv_cell(p))
                     .collect::<Vec<String>>(),
-            )
+            ),
+            CsvCell::<CsvThoth>::csv_cell(
+                &self
+                    .locations
+                    .iter()
+                    .map(|l| CsvCell::<CsvThoth>::csv_cell(l))
+                    .collect::<Vec<String>>(),
+            ),
         )
     }
 }
@@ -267,6 +273,18 @@ impl CsvCell<CsvThoth> for WorkContributions {
 impl CsvCell<CsvThoth> for WorkPublicationsPrices {
     fn csv_cell(&self) -> String {
         format!("(\"{:?}\", \"{}\")", self.currency_code, self.unit_price,)
+    }
+}
+
+impl CsvCell<CsvThoth> for WorkPublicationsLocations {
+    fn csv_cell(&self) -> String {
+        format!(
+            "(\"{}\", \"{}\", \"{:?}\", \"{}\")",
+            self.landing_page,
+            self.full_text_url.clone().unwrap_or_else(|| "".to_string()),
+            self.location_platform,
+            self.canonical,
+        )
     }
 }
 
@@ -331,9 +349,10 @@ mod tests {
     use thoth_api::model::Isbn;
     use thoth_api::model::Orcid;
     use thoth_client::{
-        ContributionType, CurrencyCode, LanguageCode, LanguageRelation, PublicationType,
-        SeriesType, WorkContributionsContributor, WorkFundingsFunder, WorkImprint,
-        WorkImprintPublisher, WorkIssuesSeries, WorkStatus, WorkType,
+        ContributionType, CurrencyCode, LanguageCode, LanguageRelation, LocationPlatform,
+        PublicationType, SeriesType, WorkContributionsContributor, WorkFundingsFunder, WorkImprint,
+        WorkImprintPublisher, WorkIssuesSeries, WorkPublicationsLocations, WorkPublicationsPrices,
+        WorkStatus, WorkType,
     };
     use uuid::Uuid;
 
@@ -444,6 +463,20 @@ mod tests {
                             unit_price: 31.95,
                         },
                     ],
+                    locations: vec![
+                        WorkPublicationsLocations {
+                            landing_page: "https://www.book.com/paperback".to_string(),
+                            full_text_url: None,
+                            location_platform: LocationPlatform::OTHER,
+                            canonical: true,
+                        },
+                        WorkPublicationsLocations {
+                            landing_page: "https://www.jstor.com/paperback".to_string(),
+                            full_text_url: None,
+                            location_platform: LocationPlatform::JSTOR,
+                            canonical: false,
+                        },
+                    ],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-CCCC-000000000003").unwrap(),
@@ -464,6 +497,7 @@ mod tests {
                             unit_price: 40.95,
                         },
                     ],
+                    locations: vec![],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
@@ -471,6 +505,12 @@ mod tests {
                     publication_url: Some("https://www.book.com/pdf".to_string()),
                     isbn: Some(Isbn::from_str("978-1-56619-909-4").unwrap()),
                     prices: vec![],
+                    locations: vec![WorkPublicationsLocations {
+                        landing_page: "https://www.book.com/pdf_landing".to_string(),
+                        full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
+                        location_platform: LocationPlatform::OTHER,
+                        canonical: true,
+                    }],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-EEEE-000000000005").unwrap(),
@@ -478,6 +518,12 @@ mod tests {
                     publication_url: Some("https://www.book.com/html".to_string()),
                     isbn: None,
                     prices: vec![],
+                    locations: vec![WorkPublicationsLocations {
+                        landing_page: "https://www.book.com/html_landing".to_string(),
+                        full_text_url: Some("https://www.book.com/html_fulltext".to_string()),
+                        location_platform: LocationPlatform::OTHER,
+                        canonical: true,
+                    }],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-FFFF-000000000006").unwrap(),
@@ -485,6 +531,7 @@ mod tests {
                     publication_url: Some("https://www.book.com/xml".to_string()),
                     isbn: Some(Isbn::from_str("978-92-95055-02-5").unwrap()),
                     prices: vec![],
+                    locations: vec![],
                 },
             ],
             subjects: vec![
@@ -548,8 +595,8 @@ mod tests {
         };
     }
 
-    const TEST_RESULT: &str = r#""publisher","imprint","work_type","work_status","title","subtitle","edition","doi","publication_date","publication_place","license","copyright_holder","landing_page","width (mm)","width (cm)","width (in)","height (mm)","height (cm)","height (in)","page_count","page_breakdown","image_count","table_count","audio_count","video_count","lccn","oclc","short_abstract","long_abstract","general_note","toc","cover_url","cover_caption","contributions [(type, first_name, last_name, full_name, institution, orcid)]","publications [(type, isbn, url, [(ISO_4217_currency, price)])]","series [(type, name, issn_print, issn_digital, url, issue)]","languages [(relation, ISO_639-3/B_language, is_main)]","BIC [code]","THEMA [code]","BISAC [code]","LCC [code]","custom_categories [category]","keywords [keyword]","funding [(funder, funder_doi, program, project, grant, jurisdiction)]"
-"OA Editions","OA Editions Imprint","MONOGRAPH","ACTIVE","Book Title","Book Subtitle","1","10.00001/BOOK.0001","1999-12-31","León, Spain","http://creativecommons.org/licenses/by/4.0/","Author 1; Author 2","https://www.book.com","156.0","15.6","6.14","234.0","23.4","9.21","334","x+334","15","20","25","30","123456789","987654321","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vel libero eleifend, ultrices purus vitae, suscipit ligula. Aliquam ornare quam et nulla vestibulum, id euismod tellus malesuada. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vel libero eleifend, ultrices purus vitae, suscipit ligula. Aliquam ornare quam et nulla vestibulum, id euismod tellus malesuada. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam ornare bibendum ex nec dapibus. Proin porta risus elementum odio feugiat tempus. Etiam eu felis ac metus viverra ornare. In consectetur neque sed feugiat ornare. Mauris at purus fringilla orci tincidunt pulvinar sed a massa. Nullam vestibulum posuere augue, sit amet tincidunt nisl pulvinar ac.","This is a general note","1. Chapter 1","https://www.book.com/cover","This is a cover caption","[(""AUTHOR"", ""Author"", ""1"", ""Author 1"", """", ""0000-0002-0000-0001""),(""AUTHOR"", ""Author"", ""2"", ""Author 2"", """", """")]","[(""PAPERBACK"", ""978-3-16-148410-0"", ""https://www.book.com/paperback"", [(""EUR"", ""25.95""),(""GBP"", ""22.95""),(""USD"", ""31.95"")]),(""HARDBACK"", ""978-1-4028-9462-6"", ""https://www.book.com/hardback"", [(""EUR"", ""36.95""),(""GBP"", ""32.95""),(""USD"", ""40.95"")]),(""PDF"", ""978-1-56619-909-4"", ""https://www.book.com/pdf"", ),(""HTML"", """", ""https://www.book.com/html"", ),(""XML"", ""978-92-95055-02-5"", ""https://www.book.com/xml"", )]","[(""JOURNAL"", ""Name of series"", ""1234-5678"", ""8765-4321"", ""https://www.series.com"", ""1"")]","[(""ORIGINAL"", ""SPA"", ""true"")]","[""AAA"",""AAB""]","[""JWA""]","[""AAA000000"",""AAA000001""]","[""JA85""]","[""Category1""]","[""keyword1"",""keyword2""]","[(""Name of funder"", ""10.00001/FUNDER.0001"", ""Name of program"", ""Name of project"", ""Number of grant"", ""Funding jurisdiction"")]"
+    const TEST_RESULT: &str = r#""publisher","imprint","work_type","work_status","title","subtitle","edition","doi","publication_date","publication_place","license","copyright_holder","landing_page","width (mm)","width (cm)","width (in)","height (mm)","height (cm)","height (in)","page_count","page_breakdown","image_count","table_count","audio_count","video_count","lccn","oclc","short_abstract","long_abstract","general_note","toc","cover_url","cover_caption","contributions [(type, first_name, last_name, full_name, institution, orcid)]","publications [(type, isbn, [(ISO_4217_currency, price)], [(landing_page, full_text, platform, is_canonical)])]","series [(type, name, issn_print, issn_digital, url, issue)]","languages [(relation, ISO_639-3/B_language, is_main)]","BIC [code]","THEMA [code]","BISAC [code]","LCC [code]","custom_categories [category]","keywords [keyword]","funding [(funder, funder_doi, program, project, grant, jurisdiction)]"
+"OA Editions","OA Editions Imprint","MONOGRAPH","ACTIVE","Book Title","Book Subtitle","1","10.00001/BOOK.0001","1999-12-31","León, Spain","http://creativecommons.org/licenses/by/4.0/","Author 1; Author 2","https://www.book.com","156.0","15.6","6.14","234.0","23.4","9.21","334","x+334","15","20","25","30","123456789","987654321","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vel libero eleifend, ultrices purus vitae, suscipit ligula. Aliquam ornare quam et nulla vestibulum, id euismod tellus malesuada. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vel libero eleifend, ultrices purus vitae, suscipit ligula. Aliquam ornare quam et nulla vestibulum, id euismod tellus malesuada. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam ornare bibendum ex nec dapibus. Proin porta risus elementum odio feugiat tempus. Etiam eu felis ac metus viverra ornare. In consectetur neque sed feugiat ornare. Mauris at purus fringilla orci tincidunt pulvinar sed a massa. Nullam vestibulum posuere augue, sit amet tincidunt nisl pulvinar ac.","This is a general note","1. Chapter 1","https://www.book.com/cover","This is a cover caption","[(""AUTHOR"", ""Author"", ""1"", ""Author 1"", """", ""0000-0002-0000-0001""),(""AUTHOR"", ""Author"", ""2"", ""Author 2"", """", """")]","[(""PAPERBACK"", ""978-3-16-148410-0"", [(""EUR"", ""25.95""),(""GBP"", ""22.95""),(""USD"", ""31.95"")], [(""https://www.book.com/paperback"", """", ""OTHER"", ""true""),(""https://www.jstor.com/paperback"", """", ""JSTOR"", ""false"")]),(""HARDBACK"", ""978-1-4028-9462-6"", [(""EUR"", ""36.95""),(""GBP"", ""32.95""),(""USD"", ""40.95"")], ),(""PDF"", ""978-1-56619-909-4"", , [(""https://www.book.com/pdf_landing"", ""https://www.book.com/pdf_fulltext"", ""OTHER"", ""true"")]),(""HTML"", """", , [(""https://www.book.com/html_landing"", ""https://www.book.com/html_fulltext"", ""OTHER"", ""true"")]),(""XML"", ""978-92-95055-02-5"", , )]","[(""JOURNAL"", ""Name of series"", ""1234-5678"", ""8765-4321"", ""https://www.series.com"", ""1"")]","[(""ORIGINAL"", ""SPA"", ""true"")]","[""AAA"",""AAB""]","[""JWA""]","[""AAA000000"",""AAA000001""]","[""JA85""]","[""Category1""]","[""keyword1"",""keyword2""]","[(""Name of funder"", ""10.00001/FUNDER.0001"", ""Name of program"", ""Name of project"", ""Number of grant"", ""Funding jurisdiction"")]"
 "#;
 
     #[test]
@@ -583,16 +630,22 @@ mod tests {
                 currency_code: CurrencyCode::EUR,
                 unit_price: 25.95,
             }],
+            locations: vec![WorkPublicationsLocations {
+                landing_page: "https://www.book.com/paperback".to_string(),
+                full_text_url: None,
+                location_platform: LocationPlatform::PROJECT_MUSE,
+                canonical: true,
+            }],
         };
         assert_eq!(CsvCell::<CsvThoth>::csv_cell(&publication),
-            r#"("PAPERBACK", "978-3-16-148410-0", "https://www.book.com/paperback", [("EUR", "25.95")])"#.to_string());
+            r#"("PAPERBACK", "978-3-16-148410-0", [("EUR", "25.95")], [("https://www.book.com/paperback", "", "PROJECT_MUSE", "true")])"#.to_string());
         publication.publication_type = PublicationType::HARDBACK;
         publication.isbn = None;
-        publication.publication_url = None;
         publication.prices.clear();
+        publication.locations.clear();
         assert_eq!(
             CsvCell::<CsvThoth>::csv_cell(&publication),
-            r#"("HARDBACK", "", "", )"#.to_string()
+            r#"("HARDBACK", "", , )"#.to_string()
         );
     }
 
@@ -641,6 +694,27 @@ mod tests {
         assert_eq!(
             CsvCell::<CsvThoth>::csv_cell(&price),
             r#"("USD", "31.95")"#.to_string()
+        );
+    }
+
+    #[test]
+    fn test_csv_thoth_locations() {
+        let mut location = WorkPublicationsLocations {
+            landing_page: "https://www.book.com/pdf_landing".to_string(),
+            full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
+            location_platform: LocationPlatform::OTHER,
+            canonical: true,
+        };
+        assert_eq!(
+            CsvCell::<CsvThoth>::csv_cell(&location),
+            r#"("https://www.book.com/pdf_landing", "https://www.book.com/pdf_fulltext", "OTHER", "true")"#.to_string()
+        );
+        location.full_text_url = None;
+        location.location_platform = LocationPlatform::JSTOR;
+        location.canonical = false;
+        assert_eq!(
+            CsvCell::<CsvThoth>::csv_cell(&location),
+            r#"("https://www.book.com/pdf_landing", "", "JSTOR", "false")"#.to_string()
         );
     }
 

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -447,7 +447,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-BBBB-000000000002").unwrap(),
                     publication_type: PublicationType::PAPERBACK,
-                    publication_url: Some("https://www.book.com/paperback".to_string()),
                     isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                     prices: vec![
                         WorkPublicationsPrices {
@@ -481,7 +480,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-CCCC-000000000003").unwrap(),
                     publication_type: PublicationType::HARDBACK,
-                    publication_url: Some("https://www.book.com/hardback".to_string()),
                     isbn: Some(Isbn::from_str("978-1-4028-9462-6").unwrap()),
                     prices: vec![
                         WorkPublicationsPrices {
@@ -502,7 +500,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
                     publication_type: PublicationType::PDF,
-                    publication_url: Some("https://www.book.com/pdf".to_string()),
                     isbn: Some(Isbn::from_str("978-1-56619-909-4").unwrap()),
                     prices: vec![],
                     locations: vec![WorkPublicationsLocations {
@@ -515,7 +512,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-EEEE-000000000005").unwrap(),
                     publication_type: PublicationType::HTML,
-                    publication_url: Some("https://www.book.com/html".to_string()),
                     isbn: None,
                     prices: vec![],
                     locations: vec![WorkPublicationsLocations {
@@ -528,7 +524,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-FFFF-000000000006").unwrap(),
                     publication_type: PublicationType::XML,
-                    publication_url: Some("https://www.book.com/xml".to_string()),
                     isbn: Some(Isbn::from_str("978-92-95055-02-5").unwrap()),
                     prices: vec![],
                     locations: vec![],
@@ -624,7 +619,6 @@ mod tests {
         let mut publication = WorkPublications {
             publication_id: Uuid::from_str("00000000-0000-0000-BBBB-000000000002").unwrap(),
             publication_type: PublicationType::PAPERBACK,
-            publication_url: Some("https://www.book.com/paperback".to_string()),
             isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
             prices: vec![WorkPublicationsPrices {
                 currency_code: CurrencyCode::EUR,

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -280,7 +280,7 @@ impl CsvCell<CsvThoth> for WorkPublicationsLocations {
     fn csv_cell(&self) -> String {
         format!(
             "(\"{}\", \"{}\", \"{:?}\", \"{}\")",
-            self.landing_page,
+            self.landing_page.clone().unwrap_or_else(|| "".to_string()),
             self.full_text_url.clone().unwrap_or_else(|| "".to_string()),
             self.location_platform,
             self.canonical,
@@ -464,13 +464,13 @@ mod tests {
                     ],
                     locations: vec![
                         WorkPublicationsLocations {
-                            landing_page: "https://www.book.com/paperback".to_string(),
+                            landing_page: Some("https://www.book.com/paperback".to_string()),
                             full_text_url: None,
                             location_platform: LocationPlatform::OTHER,
                             canonical: true,
                         },
                         WorkPublicationsLocations {
-                            landing_page: "https://www.jstor.com/paperback".to_string(),
+                            landing_page: Some("https://www.jstor.com/paperback".to_string()),
                             full_text_url: None,
                             location_platform: LocationPlatform::JSTOR,
                             canonical: false,
@@ -503,7 +503,7 @@ mod tests {
                     isbn: Some(Isbn::from_str("978-1-56619-909-4").unwrap()),
                     prices: vec![],
                     locations: vec![WorkPublicationsLocations {
-                        landing_page: "https://www.book.com/pdf_landing".to_string(),
+                        landing_page: Some("https://www.book.com/pdf_landing".to_string()),
                         full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
                         location_platform: LocationPlatform::OTHER,
                         canonical: true,
@@ -515,7 +515,7 @@ mod tests {
                     isbn: None,
                     prices: vec![],
                     locations: vec![WorkPublicationsLocations {
-                        landing_page: "https://www.book.com/html_landing".to_string(),
+                        landing_page: Some("https://www.book.com/html_landing".to_string()),
                         full_text_url: Some("https://www.book.com/html_fulltext".to_string()),
                         location_platform: LocationPlatform::OTHER,
                         canonical: true,
@@ -625,7 +625,7 @@ mod tests {
                 unit_price: 25.95,
             }],
             locations: vec![WorkPublicationsLocations {
-                landing_page: "https://www.book.com/paperback".to_string(),
+                landing_page: Some("https://www.book.com/paperback".to_string()),
                 full_text_url: None,
                 location_platform: LocationPlatform::PROJECT_MUSE,
                 canonical: true,
@@ -694,7 +694,7 @@ mod tests {
     #[test]
     fn test_csv_thoth_locations() {
         let mut location = WorkPublicationsLocations {
-            landing_page: "https://www.book.com/pdf_landing".to_string(),
+            landing_page: Some("https://www.book.com/pdf_landing".to_string()),
             full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
             location_platform: LocationPlatform::OTHER,
             canonical: true,

--- a/thoth-export-server/src/csv/kbart_oclc.rs
+++ b/thoth-export-server/src/csv/kbart_oclc.rs
@@ -339,7 +339,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
                     publication_type: PublicationType::PDF,
-                    publication_url: Some("https://www.book.com/pdf".to_string()),
                     isbn: Some(Isbn::from_str("978-1-56619-909-4").unwrap()),
                     prices: vec![],
                     locations: vec![],
@@ -347,7 +346,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-CCCC-000000000003").unwrap(),
                     publication_type: PublicationType::HARDBACK,
-                    publication_url: Some("https://www.book.com/hardback".to_string()),
                     isbn: Some(Isbn::from_str("978-1-4028-9462-6").unwrap()),
                     prices: vec![],
                     locations: vec![],
@@ -355,7 +353,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-BBBB-000000000002").unwrap(),
                     publication_type: PublicationType::PAPERBACK,
-                    publication_url: Some("https://www.book.com/paperback".to_string()),
                     isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                     prices: vec![],
                     locations: vec![],
@@ -363,7 +360,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-EEEE-000000000005").unwrap(),
                     publication_type: PublicationType::HTML,
-                    publication_url: Some("https://www.book.com/html".to_string()),
                     isbn: None,
                     prices: vec![],
                     locations: vec![],
@@ -371,7 +367,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-FFFF-000000000006").unwrap(),
                     publication_type: PublicationType::XML,
-                    publication_url: Some("https://www.book.com/xml".to_string()),
                     isbn: Some(Isbn::from_str("978-92-95055-02-5").unwrap()),
                     prices: vec![],
                     locations: vec![],

--- a/thoth-export-server/src/csv/kbart_oclc.rs
+++ b/thoth-export-server/src/csv/kbart_oclc.rs
@@ -342,6 +342,7 @@ mod tests {
                     publication_url: Some("https://www.book.com/pdf".to_string()),
                     isbn: Some(Isbn::from_str("978-1-56619-909-4").unwrap()),
                     prices: vec![],
+                    locations: vec![],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-CCCC-000000000003").unwrap(),
@@ -349,6 +350,7 @@ mod tests {
                     publication_url: Some("https://www.book.com/hardback".to_string()),
                     isbn: Some(Isbn::from_str("978-1-4028-9462-6").unwrap()),
                     prices: vec![],
+                    locations: vec![],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-BBBB-000000000002").unwrap(),
@@ -356,6 +358,7 @@ mod tests {
                     publication_url: Some("https://www.book.com/paperback".to_string()),
                     isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                     prices: vec![],
+                    locations: vec![],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-EEEE-000000000005").unwrap(),
@@ -363,6 +366,7 @@ mod tests {
                     publication_url: Some("https://www.book.com/html".to_string()),
                     isbn: None,
                     prices: vec![],
+                    locations: vec![],
                 },
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-FFFF-000000000006").unwrap(),
@@ -370,6 +374,7 @@ mod tests {
                     publication_url: Some("https://www.book.com/xml".to_string()),
                     isbn: Some(Isbn::from_str("978-92-95055-02-5").unwrap()),
                     prices: vec![],
+                    locations: vec![],
                 },
             ],
             subjects: vec![],

--- a/thoth-export-server/src/xml/onix21_ebsco_host.rs
+++ b/thoth-export-server/src/xml/onix21_ebsco_host.rs
@@ -896,7 +896,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-AAAA-000000000001").unwrap(),
                     publication_type: PublicationType::EPUB,
-                    publication_url: Some("https://www.book.com/epub".to_string()),
                     isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                     prices: vec![],
                     locations: vec![WorkPublicationsLocations {
@@ -909,7 +908,6 @@ mod tests {
                 WorkPublications {
                     publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
                     publication_type: PublicationType::PDF,
-                    publication_url: Some("https://www.book.com/pdf".to_string()),
                     isbn: Some(Isbn::from_str("978-1-56619-909-4").unwrap()),
                     prices: vec![
                         WorkPublicationsPrices {

--- a/thoth-export-server/src/xml/onix21_ebsco_host.rs
+++ b/thoth-export-server/src/xml/onix21_ebsco_host.rs
@@ -899,7 +899,7 @@ mod tests {
                     isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                     prices: vec![],
                     locations: vec![WorkPublicationsLocations {
-                        landing_page: "https://www.book.com/epub_landing".to_string(),
+                        landing_page: Some("https://www.book.com/epub_landing".to_string()),
                         full_text_url: Some("https://www.book.com/epub_fulltext".to_string()),
                         location_platform: LocationPlatform::OTHER,
                         canonical: true,
@@ -924,7 +924,7 @@ mod tests {
                         },
                     ],
                     locations: vec![WorkPublicationsLocations {
-                        landing_page: "https://www.book.com/pdf_landing".to_string(),
+                        landing_page: Some("https://www.book.com/pdf_landing".to_string()),
                         full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
                         location_platform: LocationPlatform::OTHER,
                         canonical: true,

--- a/thoth-export-server/src/xml/onix3_jstor.rs
+++ b/thoth-export-server/src/xml/onix3_jstor.rs
@@ -729,7 +729,7 @@ mod tests {
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
                 locations: vec![WorkPublicationsLocations {
-                    landing_page: "https://www.book.com/pdf_landing".to_string(),
+                    landing_page: Some("https://www.book.com/pdf_landing".to_string()),
                     full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
                     location_platform: LocationPlatform::OTHER,
                     canonical: true,

--- a/thoth-export-server/src/xml/onix3_jstor.rs
+++ b/thoth-export-server/src/xml/onix3_jstor.rs
@@ -726,7 +726,6 @@ mod tests {
             publications: vec![WorkPublications {
                 publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
                 publication_type: PublicationType::PDF,
-                publication_url: Some("https://www.book.com/pdf".to_string()),
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
                 locations: vec![WorkPublicationsLocations {

--- a/thoth-export-server/src/xml/onix3_jstor.rs
+++ b/thoth-export-server/src/xml/onix3_jstor.rs
@@ -64,8 +64,9 @@ impl XmlElementBlock<Onix3Jstor> for Work {
         if let Some(pdf_url) = self
             .publications
             .iter()
-            .find(|p| p.publication_type.eq(&PublicationType::PDF))
-            .and_then(|p| p.publication_url.as_ref())
+            .find(|p| p.publication_type.eq(&PublicationType::PDF) && !p.locations.is_empty())
+            .and_then(|p| p.locations.iter().find(|l| l.canonical))
+            .and_then(|l| l.full_text_url.as_ref())
         {
             write_element_block("Product", w, |w| {
                 write_element_block("RecordReference", w, |w| {
@@ -544,9 +545,9 @@ mod tests {
     use thoth_api::model::Isbn;
     use thoth_api::model::Orcid;
     use thoth_client::{
-        ContributionType, LanguageCode, LanguageRelation, PublicationType,
+        ContributionType, LanguageCode, LanguageRelation, LocationPlatform, PublicationType,
         WorkContributionsContributor, WorkFundings, WorkImprint, WorkImprintPublisher, WorkIssues,
-        WorkIssuesSeries, WorkStatus, WorkSubjects, WorkType,
+        WorkIssuesSeries, WorkPublicationsLocations, WorkStatus, WorkSubjects, WorkType,
     };
     use uuid::Uuid;
 
@@ -728,6 +729,12 @@ mod tests {
                 publication_url: Some("https://www.book.com/pdf".to_string()),
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
+                locations: vec![WorkPublicationsLocations {
+                    landing_page: "https://www.book.com/pdf_landing".to_string(),
+                    full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
+                    location_platform: LocationPlatform::OTHER,
+                    canonical: true,
+                }],
             }],
             subjects: vec![
                 WorkSubjects {
@@ -871,7 +878,8 @@ mod tests {
         assert!(output.contains(r#"        <SupplierName>OA Editions</SupplierName>"#));
         assert!(output.contains(r#"          <WebsiteRole>29</WebsiteRole>"#));
         assert!(output.contains(r#"          <WebsiteDescription>Publisher's website: download the title</WebsiteDescription>"#));
-        assert!(output.contains(r#"          <WebsiteLink>https://www.book.com/pdf</WebsiteLink>"#));
+        assert!(output
+            .contains(r#"          <WebsiteLink>https://www.book.com/pdf_fulltext</WebsiteLink>"#));
 
         // Test that OAPEN-only blocks are not output in JSTOR format
         assert!(!output.contains(r#"    <Audience>"#));

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -64,8 +64,9 @@ impl XmlElementBlock<Onix3Oapen> for Work {
         if let Some(pdf_url) = self
             .publications
             .iter()
-            .find(|p| p.publication_type.eq(&PublicationType::PDF))
-            .and_then(|p| p.publication_url.as_ref())
+            .find(|p| p.publication_type.eq(&PublicationType::PDF) && !p.locations.is_empty())
+            .and_then(|p| p.locations.iter().find(|l| l.canonical))
+            .and_then(|l| l.full_text_url.as_ref())
         {
             write_element_block("Product", w, |w| {
                 write_element_block("RecordReference", w, |w| {
@@ -654,9 +655,9 @@ mod tests {
     use thoth_api::model::Isbn;
     use thoth_api::model::Orcid;
     use thoth_client::{
-        ContributionType, LanguageCode, LanguageRelation, PublicationType,
+        ContributionType, LanguageCode, LanguageRelation, LocationPlatform, PublicationType,
         WorkContributionsContributor, WorkImprint, WorkImprintPublisher, WorkIssuesSeries,
-        WorkStatus, WorkType,
+        WorkPublicationsLocations, WorkStatus, WorkType,
     };
     use uuid::Uuid;
 
@@ -992,6 +993,12 @@ mod tests {
                 publication_url: Some("https://www.book.com/pdf".to_string()),
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
+                locations: vec![WorkPublicationsLocations {
+                    landing_page: "https://www.book.com/pdf_landing".to_string(),
+                    full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
+                    location_platform: LocationPlatform::OTHER,
+                    canonical: true,
+                }],
             }],
             subjects: vec![],
             fundings: vec![],
@@ -1086,7 +1093,8 @@ mod tests {
         assert!(output.contains(r#"        <SupplierName>OA Editions</SupplierName>"#));
         assert!(output.contains(r#"          <WebsiteRole>29</WebsiteRole>"#));
         assert!(output.contains(r#"          <WebsiteDescription>Publisher's website: download the title</WebsiteDescription>"#));
-        assert!(output.contains(r#"          <WebsiteLink>https://www.book.com/pdf</WebsiteLink>"#));
+        assert!(output
+            .contains(r#"          <WebsiteLink>https://www.book.com/pdf_fulltext</WebsiteLink>"#));
 
         // Remove some values to test non-output of optional blocks
         test_work.doi = None;

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -990,7 +990,6 @@ mod tests {
             publications: vec![WorkPublications {
                 publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
                 publication_type: PublicationType::PDF,
-                publication_url: Some("https://www.book.com/pdf".to_string()),
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
                 locations: vec![WorkPublicationsLocations {

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -993,7 +993,7 @@ mod tests {
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
                 locations: vec![WorkPublicationsLocations {
-                    landing_page: "https://www.book.com/pdf_landing".to_string(),
+                    landing_page: Some("https://www.book.com/pdf_landing".to_string()),
                     full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
                     location_platform: LocationPlatform::OTHER,
                     canonical: true,

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -64,8 +64,9 @@ impl XmlElementBlock<Onix3ProjectMuse> for Work {
         if let Some(pdf_url) = self
             .publications
             .iter()
-            .find(|p| p.publication_type.eq(&PublicationType::PDF))
-            .and_then(|p| p.publication_url.as_ref())
+            .find(|p| p.publication_type.eq(&PublicationType::PDF) && !p.locations.is_empty())
+            .and_then(|p| p.locations.iter().find(|l| l.canonical))
+            .and_then(|l| l.full_text_url.as_ref())
         {
             write_element_block("Product", w, |w| {
                 write_element_block("RecordReference", w, |w| {
@@ -533,9 +534,9 @@ mod tests {
     use thoth_api::model::Isbn;
     use thoth_api::model::Orcid;
     use thoth_client::{
-        ContributionType, LanguageCode, LanguageRelation, PublicationType,
+        ContributionType, LanguageCode, LanguageRelation, LocationPlatform, PublicationType,
         WorkContributionsContributor, WorkFundings, WorkImprint, WorkImprintPublisher, WorkIssues,
-        WorkIssuesSeries, WorkStatus, WorkSubjects, WorkType,
+        WorkIssuesSeries, WorkPublicationsLocations, WorkStatus, WorkSubjects, WorkType,
     };
     use uuid::Uuid;
 
@@ -717,6 +718,12 @@ mod tests {
                 publication_url: Some("https://www.book.com/pdf".to_string()),
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
+                locations: vec![WorkPublicationsLocations {
+                    landing_page: "https://www.book.com/pdf_landing".to_string(),
+                    full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
+                    location_platform: LocationPlatform::OTHER,
+                    canonical: true,
+                }],
             }],
             subjects: vec![
                 WorkSubjects {
@@ -857,7 +864,8 @@ mod tests {
         assert!(output.contains(r#"        <SupplierName>OA Editions</SupplierName>"#));
         assert!(output.contains(r#"          <WebsiteRole>29</WebsiteRole>"#));
         assert!(output.contains(r#"          <WebsiteDescription>Publisher's website: download the title</WebsiteDescription>"#));
-        assert!(output.contains(r#"          <WebsiteLink>https://www.book.com/pdf</WebsiteLink>"#));
+        assert!(output
+            .contains(r#"          <WebsiteLink>https://www.book.com/pdf_fulltext</WebsiteLink>"#));
 
         // Test that OAPEN-only blocks are not output in Project MUSE format
         assert!(!output.contains(r#"    <Audience>"#));

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -746,7 +746,7 @@ mod tests {
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
                 locations: vec![WorkPublicationsLocations {
-                    landing_page: "https://www.book.com/pdf_landing".to_string(),
+                    landing_page: Some("https://www.book.com/pdf_landing".to_string()),
                     full_text_url: Some("https://www.book.com/pdf_fulltext".to_string()),
                     location_platform: LocationPlatform::OTHER,
                     canonical: true,

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -715,7 +715,6 @@ mod tests {
             publications: vec![WorkPublications {
                 publication_id: Uuid::from_str("00000000-0000-0000-DDDD-000000000004").unwrap(),
                 publication_type: PublicationType::PDF,
-                publication_url: Some("https://www.book.com/pdf".to_string()),
                 isbn: Some(Isbn::from_str("978-3-16-148410-0").unwrap()),
                 prices: vec![],
                 locations: vec![WorkPublicationsLocations {


### PR DESCRIPTION
Fixes #297.

Summary:
- Each work may now only have one publication of each type.
- Publications may no longer have an `isbn` if their work is of type Book Chapter.
- Publications no longer have `publication_url` fields: instead this information is stored in child location objects.
- Location objects have fields `landing_page`, `full_text_url`, `location_platform` and `canonical`.
  - If a publication has locations, exactly one must be marked as `canonical` - this indicates the "file of record" (usually the publisher's hosted version) for the publication type.
  - Each location must have at least one of `landing_page` and `full_text_url`. Canonical locations for digital publications must have both (canonical `full_text_url` is used for distribution).
  - Each publication can have at most one location for each named `location_platform` (distribution channel), except 'Other'.

Automatic data migration:
- Manual data inspection and pre-/post-migration cleanup is advised as this is a complex migration.
- On upward migration, all existing `publication_url`s are converted to new (canonical, 'Other') location `landing_page`s. Migration cannot be carried out if any work has multiple publications of the same type.
- On downward migration, all `location_platform` and `canonical` data is lost. All `landing_page`s and `full_text_url`s are converted back to `publication_url`s associated with the appropriate work and publication type.
  - The existing publication's `publication_url` is set to the `landing_page` (or `full_text_url` if not found) of the canonical location.
  - Additional publications are created to hold all remaining location URLs (which may result in duplicate publications if e.g. several locations use the same `landing_page`).

Currently, all columns of the location table are displayed in the app and editable when adding a new location. Later on, we may be able to implement automatic distribution, whereby successfully submitting a publication to a new platform would automatically create a location entry with the new URL. At this point we may want to make the `location_platform` field non-editable, or hide it altogether.

Additional restrictions on ISBNs for Book Chapters are implemented in the app by retaining the relevant fields/columns/dropdown options but deactivating them. An alternative would be to conditionally remove them altogether (but beware similar issues to https://github.com/jgthms/bulma/issues/3390 if attempting to alter dropdown list data on the fly).