### PR TITLE
Add workflow dispatch triger to docker action

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'release/**'
+  workflow_dispatch:
 
 jobs:
   build_docker_image:


### PR DESCRIPTION
Allow running the "build docker image" github action manually, using [`workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)