### PR TITLE
Fix new Clippy lints (non-minimal bools, single-char strings) under rustc 1.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
   - [#341](https://github.com/thoth-pub/thoth/issues/341) - Add weight to publication
 
+### Changed
+  - Tidied verbose bools and single-character strings to comply with [`rustc 1.59.0`](https://github.com/rust-lang/rust/releases/tag/1.59.0)
+
 ## [[0.7.2]](https://github.com/thoth-pub/thoth/releases/tag/v0.7.2) - 2022-02-08
 ### Changed
   - [#339](https://github.com/thoth-pub/thoth/pull/339) - Update publication types to include AZW3, DOCX and FictionBook

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1480,7 +1480,7 @@ impl MutationRoot {
             .account_access
             .can_edit(work.publisher_id(&context.db)?)?;
 
-        if !(data.imprint_id == work.imprint_id) {
+        if data.imprint_id != work.imprint_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_imprint_id(&context.db, data.imprint_id)?)?;
@@ -1501,7 +1501,7 @@ impl MutationRoot {
         let publisher = Publisher::from_id(&context.db, &data.publisher_id).unwrap();
         context.account_access.can_edit(publisher.publisher_id)?;
 
-        if !(data.publisher_id == publisher.publisher_id) {
+        if data.publisher_id != publisher.publisher_id {
             context.account_access.can_edit(data.publisher_id)?;
         }
         let account_id = context.token.jwt.as_ref().unwrap().account_id(&context.db);
@@ -1517,7 +1517,7 @@ impl MutationRoot {
             .account_access
             .can_edit(imprint.publisher_id(&context.db)?)?;
 
-        if !(data.publisher_id == imprint.publisher_id) {
+        if data.publisher_id != imprint.publisher_id {
             context.account_access.can_edit(data.publisher_id)?;
         }
         let account_id = context.token.jwt.as_ref().unwrap().account_id(&context.db);
@@ -1545,7 +1545,7 @@ impl MutationRoot {
             .account_access
             .can_edit(contribution.publisher_id(&context.db)?)?;
 
-        if !(data.work_id == contribution.work_id) {
+        if data.work_id != contribution.work_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
@@ -1563,7 +1563,7 @@ impl MutationRoot {
             .account_access
             .can_edit(publication.publisher_id(&context.db)?)?;
 
-        if !(data.work_id == publication.work_id) {
+        if data.work_id != publication.work_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
@@ -1584,7 +1584,7 @@ impl MutationRoot {
             .account_access
             .can_edit(series.publisher_id(&context.db)?)?;
 
-        if !(data.imprint_id == series.imprint_id) {
+        if data.imprint_id != series.imprint_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_imprint_id(&context.db, data.imprint_id)?)?;
@@ -1604,7 +1604,7 @@ impl MutationRoot {
 
         data.imprints_match(&context.db)?;
 
-        if !(data.work_id == issue.work_id) {
+        if data.work_id != issue.work_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
@@ -1622,7 +1622,7 @@ impl MutationRoot {
             .account_access
             .can_edit(language.publisher_id(&context.db)?)?;
 
-        if !(data.work_id == language.work_id) {
+        if data.work_id != language.work_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
@@ -1650,7 +1650,7 @@ impl MutationRoot {
             .account_access
             .can_edit(funding.publisher_id(&context.db)?)?;
 
-        if !(data.work_id == funding.work_id) {
+        if data.work_id != funding.work_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
@@ -1669,7 +1669,7 @@ impl MutationRoot {
             .account_access
             .can_edit(location.publisher_id(&context.db)?)?;
 
-        if !(data.publication_id == location.publication_id) {
+        if data.publication_id != location.publication_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_publication_id(
@@ -1678,7 +1678,7 @@ impl MutationRoot {
                 )?)?;
         }
 
-        if !(data.canonical == location.canonical) {
+        if data.canonical != location.canonical {
             // Each publication must have exactly one canonical location.
             // Updating an existing location would always violate this,
             // as it should always result in either zero or two canonical locations.
@@ -1702,7 +1702,7 @@ impl MutationRoot {
             .account_access
             .can_edit(price.publisher_id(&context.db)?)?;
 
-        if !(data.publication_id == price.publication_id) {
+        if data.publication_id != price.publication_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_publication_id(
@@ -1724,7 +1724,7 @@ impl MutationRoot {
             .account_access
             .can_edit(subject.publisher_id(&context.db)?)?;
 
-        if !(data.work_id == subject.work_id) {
+        if data.work_id != subject.work_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_work_id(&context.db, data.work_id)?)?;
@@ -1745,7 +1745,7 @@ impl MutationRoot {
             .account_access
             .can_edit(affiliation.publisher_id(&context.db)?)?;
 
-        if !(data.contribution_id == affiliation.contribution_id) {
+        if data.contribution_id != affiliation.contribution_id {
             context
                 .account_access
                 .can_edit(publisher_id_from_contribution_id(
@@ -1777,13 +1777,13 @@ impl MutationRoot {
             work_relation.related_work_id,
         )?)?;
 
-        if !(data.relator_work_id == work_relation.relator_work_id) {
+        if data.relator_work_id != work_relation.relator_work_id {
             context.account_access.can_edit(publisher_id_from_work_id(
                 &context.db,
                 data.relator_work_id,
             )?)?;
         }
-        if !(data.related_work_id == work_relation.related_work_id) {
+        if data.related_work_id != work_relation.related_work_id {
             context.account_access.can_edit(publisher_id_from_work_id(
                 &context.db,
                 data.related_work_id,

--- a/thoth-export-server/src/csv/kbart_oclc.rs
+++ b/thoth-export-server/src/csv/kbart_oclc.rs
@@ -50,7 +50,7 @@ impl CsvSpecification for KbartOclc {
                 for work in works.iter() {
                     // Do not include Chapters in full publisher metadata record
                     // (assumes that a publisher will always have more than one work)
-                    if !(work.work_type == WorkType::BOOK_CHAPTER) {
+                    if work.work_type != WorkType::BOOK_CHAPTER {
                         CsvRow::<KbartOclc>::csv_row(work, w).ok();
                     }
                 }

--- a/thoth-export-server/src/xml/onix21_ebsco_host.rs
+++ b/thoth-export-server/src/xml/onix21_ebsco_host.rs
@@ -42,7 +42,7 @@ impl XmlSpecification for Onix21EbscoHost {
                     for work in works.iter() {
                         // Do not include Chapters in full publisher metadata record
                         // (assumes that a publisher will always have more than one work)
-                        if !(work.work_type == WorkType::BOOK_CHAPTER) {
+                        if work.work_type != WorkType::BOOK_CHAPTER {
                             XmlElementBlock::<Onix21EbscoHost>::xml_element(work, w).ok();
                         }
                     }
@@ -431,15 +431,15 @@ fn get_publications_data(publications: &[WorkPublications]) -> (String, Vec<Stri
 
     for publication in publications {
         if let Some(isbn) = &publication.isbn.as_ref().map(|i| i.to_string()) {
-            isbns.push(isbn.replace("-", ""));
+            isbns.push(isbn.replace('-', ""));
             // The default product ISBN is the PDF's
             if publication.publication_type.eq(&PublicationType::PDF) {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
             // Books that don't have a PDF ISBN will use the paperback's
             if publication.publication_type.eq(&PublicationType::PAPERBACK) && main_isbn.is_empty()
             {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
         }
     }

--- a/thoth-export-server/src/xml/onix3_jstor.rs
+++ b/thoth-export-server/src/xml/onix3_jstor.rs
@@ -49,7 +49,7 @@ impl XmlSpecification for Onix3Jstor {
                     for work in works.iter() {
                         // Do not include Chapters in full publisher metadata record
                         // (assumes that a publisher will always have more than one work)
-                        if !(work.work_type == WorkType::BOOK_CHAPTER) {
+                        if work.work_type != WorkType::BOOK_CHAPTER {
                             XmlElementBlock::<Onix3Jstor>::xml_element(work, w).ok();
                         }
                     }
@@ -395,15 +395,15 @@ fn get_publications_data(publications: &[WorkPublications]) -> (String, Vec<Stri
 
     for publication in publications {
         if let Some(isbn) = &publication.isbn.as_ref().map(|i| i.to_string()) {
-            isbns.push(isbn.replace("-", ""));
+            isbns.push(isbn.replace('-', ""));
             // The default product ISBN is the PDF's
             if publication.publication_type.eq(&PublicationType::PDF) {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
             // Books that don't have a PDF ISBN will use the paperback's
             if publication.publication_type.eq(&PublicationType::PAPERBACK) && main_isbn.is_empty()
             {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
         }
     }

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -49,7 +49,7 @@ impl XmlSpecification for Onix3Oapen {
                     for work in works.iter() {
                         // Do not include Chapters in full publisher metadata record
                         // (assumes that a publisher will always have more than one work)
-                        if !(work.work_type == WorkType::BOOK_CHAPTER) {
+                        if work.work_type != WorkType::BOOK_CHAPTER {
                             XmlElementBlock::<Onix3Oapen>::xml_element(work, w).ok();
                         }
                     }
@@ -405,15 +405,15 @@ fn get_publications_data(publications: &[WorkPublications]) -> (String, Vec<Stri
 
     for publication in publications {
         if let Some(isbn) = &publication.isbn.as_ref().map(|i| i.to_string()) {
-            isbns.push(isbn.replace("-", ""));
+            isbns.push(isbn.replace('-', ""));
             // The default product ISBN is the PDF's
             if publication.publication_type.eq(&PublicationType::PDF) {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
             // Books that don't have a PDF ISBN will use the paperback's
             if publication.publication_type.eq(&PublicationType::PAPERBACK) && main_isbn.is_empty()
             {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
         }
     }

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -49,7 +49,7 @@ impl XmlSpecification for Onix3ProjectMuse {
                     for work in works.iter() {
                         // Do not include Chapters in full publisher metadata record
                         // (assumes that a publisher will always have more than one work)
-                        if !(work.work_type == WorkType::BOOK_CHAPTER) {
+                        if work.work_type != WorkType::BOOK_CHAPTER {
                             XmlElementBlock::<Onix3ProjectMuse>::xml_element(work, w).ok();
                         }
                     }
@@ -412,15 +412,15 @@ fn get_publications_data(publications: &[WorkPublications]) -> (String, Vec<Stri
 
     for publication in publications {
         if let Some(isbn) = &publication.isbn.as_ref().map(|i| i.to_string()) {
-            isbns.push(isbn.replace("-", ""));
+            isbns.push(isbn.replace('-', ""));
             // The default product ISBN is the PDF's
             if publication.publication_type.eq(&PublicationType::PDF) {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
             // Books that don't have a PDF ISBN will use the paperback's
             if publication.publication_type.eq(&PublicationType::PAPERBACK) && main_isbn.is_empty()
             {
-                main_isbn = isbn.replace("-", "");
+                main_isbn = isbn.replace('-', "");
             }
         }
     }


### PR DESCRIPTION
Note that this introduces a Clippy warning `warning: the following packages contain code that will be rejected by a future version of Rust: time-macros-impl v0.1.1`. This package is included indirectly in Thoth as a dependency of various Actix packages, so we will need to await a fix from them.