### PR TITLE
Implement BibTeX output (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  - [#104](https://github.com/thoth-pub/thoth/issues/104) - Implement BibTeX specification
+
+### Changed
+  - Removed unnecessary title branching logic from KBART/ONIX output formats
 
 ## [[0.8.0]](https://github.com/thoth-pub/thoth/releases/tag/v0.8.0) - 2022-03-01
 ### Added

--- a/thoth-app/src/models/work/mod.rs
+++ b/thoth-app/src/models/work/mod.rs
@@ -124,6 +124,7 @@ pub trait DisplayWork {
     fn onix_ebsco_host_endpoint(&self) -> String;
     fn csv_endpoint(&self) -> String;
     fn kbart_endpoint(&self) -> String;
+    fn bibtex_endpoint(&self) -> String;
     fn cover_alt_text(&self) -> String;
     fn license_icons(&self) -> Html;
     fn status_tag(&self) -> Html;
@@ -169,6 +170,13 @@ impl DisplayWork for WorkWithRelations {
     fn kbart_endpoint(&self) -> String {
         format!(
             "{}/specifications/kbart::oclc/work/{}",
+            THOTH_EXPORT_API, &self.work_id
+        )
+    }
+
+    fn bibtex_endpoint(&self) -> String {
+        format!(
+            "{}/specifications/bibtex::crossref/work/{}",
             THOTH_EXPORT_API, &self.work_id
         )
     }
@@ -397,6 +405,12 @@ impl DisplayWork for WorkWithRelations {
                                                 class="dropdown-item"
                                             >
                                             {"KBART"}
+                                            </a>
+                                            <a
+                                                href={self.bibtex_endpoint()}
+                                                class="dropdown-item"
+                                            >
+                                            {"BibTeX"}
                                             </a>
                                         </div>
                                     </div>

--- a/thoth-app/src/models/work/mod.rs
+++ b/thoth-app/src/models/work/mod.rs
@@ -176,7 +176,7 @@ impl DisplayWork for WorkWithRelations {
 
     fn bibtex_endpoint(&self) -> String {
         format!(
-            "{}/specifications/bibtex::crossref/work/{}",
+            "{}/specifications/bibtex::thoth/work/{}",
             THOTH_EXPORT_API, &self.work_id
         )
     }

--- a/thoth-export-server/src/bibtex/bibtex_crossref.rs
+++ b/thoth-export-server/src/bibtex/bibtex_crossref.rs
@@ -76,57 +76,57 @@ impl fmt::Display for BibtexCrossrefEntry {
             citekey = format!("{}-{}-{}", self.year, self.month, self.day);
         }
         writeln!(f, "@{}{{{},", self.entry_type, citekey)?;
-        writeln!(f, "\ttitle\t\t= {{{}}},", self.title)?;
+        write!(f, "\ttitle\t\t= {{{}}}", self.title)?;
         if let Some(shorttitle) = &self.shorttitle {
-            writeln!(f, "\tshorttitle\t= {{{shorttitle}}},")?;
+            write!(f, ",\n\tshorttitle\t= {{{shorttitle}}}")?;
         }
         if let Some(author) = &self.author {
-            writeln!(f, "\tauthor\t\t= {{{author}}},")?;
+            write!(f, ",\n\tauthor\t\t= {{{author}}}")?;
         }
         if let Some(editor) = &self.editor {
-            writeln!(f, "\teditor\t\t= {{{editor}}},")?;
+            write!(f, ",\n\teditor\t\t= {{{editor}}}")?;
         }
-        writeln!(f, "\tyear\t\t= {},", self.year)?;
-        writeln!(f, "\tmonth\t\t= {},", self.month)?;
-        writeln!(f, "\tday\t\t\t= {},", self.day)?;
-        writeln!(f, "\tpublisher\t= {{{}}},", self.publisher)?;
+        write!(f, ",\n\tyear\t\t= {}", self.year)?;
+        write!(f, ",\n\tmonth\t\t= {}", self.month)?;
+        write!(f, ",\n\tday\t\t\t= {}", self.day)?;
+        write!(f, ",\n\tpublisher\t= {{{}}}", self.publisher)?;
         if let Some(address) = &self.address {
-            writeln!(f, "\taddress\t\t= {{{address}}},")?;
+            write!(f, ",\n\taddress\t\t= {{{address}}}")?;
         }
         if let Some(series) = &self.series {
-            writeln!(f, "\tseries\t\t= {{{series}}},")?;
+            write!(f, ",\n\tseries\t\t= {{{series}}}")?;
         }
         if let Some(volume) = &self.volume {
-            writeln!(f, "\tvolume\t\t= {volume},")?;
+            write!(f, ",\n\tvolume\t\t= {volume}")?;
         }
         if let Some(booktitle) = &self.booktitle {
-            writeln!(f, "\tbooktitle\t= {{{booktitle}}},")?;
+            write!(f, ",\n\tbooktitle\t= {{{booktitle}}}")?;
         }
         if let Some(chapter) = &self.chapter {
-            writeln!(f, "\tchapter\t\t= {chapter},")?;
+            write!(f, ",\n\tchapter\t\t= {chapter}")?;
         }
         if let Some(pages) = &self.pages {
-            writeln!(f, "\tpages\t\t= {{{pages}}},")?;
+            write!(f, ",\n\tpages\t\t= {{{pages}}}")?;
         }
         if let Some(doi) = &self.doi {
-            writeln!(f, "\tdoi\t\t\t= {{{doi}}},")?;
+            write!(f, ",\n\tdoi\t\t\t= {{{doi}}}")?;
         }
         if let Some(isbn) = &self.isbn {
-            writeln!(f, "\tisbn\t\t= {{{isbn}}},")?;
+            write!(f, ",\n\tisbn\t\t= {{{isbn}}}")?;
         }
         if let Some(issn) = &self.issn {
-            writeln!(f, "\tissn\t\t= {{{issn}}},")?;
+            write!(f, ",\n\tissn\t\t= {{{issn}}}")?;
         }
         if let Some(url) = &self.url {
-            writeln!(f, "\turl\t\t\t= {{{url}}},")?;
+            write!(f, ",\n\turl\t\t\t= {{{url}}}")?;
         }
         if let Some(copyright) = &self.copyright {
-            writeln!(f, "\tcopyright\t= {{{copyright}}},")?;
+            write!(f, ",\n\tcopyright\t= {{{copyright}}}")?;
         }
         if let Some(long_abstract) = &self.long_abstract {
-            writeln!(f, "\tabstract\t= {{{long_abstract}}}")?;
+            write!(f, ",\n\tabstract\t= {{{long_abstract}}}")?;
         }
-        writeln!(f, "}}")
+        writeln!(f, "\n}}")
     }
 }
 
@@ -520,7 +520,7 @@ mod tests {
 \tpublisher\t= {OA Editions},
 \tbooktitle\t= {Related work title},
 \tchapter\t\t= 7,
-\tpages\t\t= {10--20},
+\tpages\t\t= {10--20}
 }
 "
         .to_string();

--- a/thoth-export-server/src/bibtex/bibtex_crossref.rs
+++ b/thoth-export-server/src/bibtex/bibtex_crossref.rs
@@ -1,11 +1,10 @@
-use csv::Writer;
 use serde::Serialize;
 use std::convert::TryFrom;
 use std::io::Write;
 use thoth_client::{ContributionType, PublicationType, Work, WorkType};
 use thoth_errors::{ThothError, ThothResult};
 
-use super::{BibtexEntry, BibtexSpecification};
+use super::{BibtexEntry, BibtexSpecification, BibtexWriter};
 
 pub(crate) struct BibtexCrossref;
 
@@ -32,7 +31,7 @@ struct BibtexCrossrefEntry {
 }
 
 impl BibtexSpecification for BibtexCrossref {
-    fn handle_event<W: Write>(w: &mut Writer<W>, works: &[Work]) -> ThothResult<()> {
+    fn handle_event<W: Write>(w: &mut BibtexWriter<W>, works: &[Work]) -> ThothResult<()> {
         match works.len() {
             0 => Err(ThothError::IncompleteMetadataRecord(
                 "kbart::oclc".to_string(),
@@ -54,9 +53,9 @@ impl BibtexSpecification for BibtexCrossref {
 }
 
 impl BibtexEntry<BibtexCrossref> for Work {
-    fn bibtex_entry<W: Write>(&self, w: &mut Writer<W>) -> ThothResult<()> {
-        w.serialize(BibtexCrossrefEntry::try_from(self.clone())?)
-            .map_err(|e| e.into())
+    fn bibtex_entry<W: Write>(&self, w: &mut BibtexWriter<W>) -> ThothResult<()> {
+        write!(w, "{:?}", BibtexCrossrefEntry::try_from(self.clone())?);
+        Ok(())
     }
 }
 

--- a/thoth-export-server/src/bibtex/bibtex_crossref.rs
+++ b/thoth-export-server/src/bibtex/bibtex_crossref.rs
@@ -1,0 +1,154 @@
+use csv::Writer;
+use serde::Serialize;
+use std::convert::TryFrom;
+use std::io::Write;
+use thoth_client::{ContributionType, PublicationType, Work, WorkType};
+use thoth_errors::{ThothError, ThothResult};
+
+use super::{BibtexEntry, BibtexSpecification};
+
+pub(crate) struct BibtexCrossref;
+
+#[derive(Debug, Serialize)]
+struct BibtexCrossrefEntry {
+    title: String,
+    shorttitle: Option<String>,
+    author: Option<String>,
+    editor: Option<String>,
+    year: i64,
+    month: i64,
+    day: i64,
+    publisher: String,
+    address: Option<String>,
+    series: Option<String>,
+    volume: Option<i64>,
+    pages: Option<String>,
+    doi: Option<String>,
+    isbn: Option<String>,
+    issn: Option<String>,
+    url: Option<String>,
+    copyright: Option<String>,
+    long_abstract: Option<String>,
+}
+
+impl BibtexSpecification for BibtexCrossref {
+    fn handle_event<W: Write>(w: &mut Writer<W>, works: &[Work]) -> ThothResult<()> {
+        match works.len() {
+            0 => Err(ThothError::IncompleteMetadataRecord(
+                "kbart::oclc".to_string(),
+                "Not enough data".to_string(),
+            )),
+            1 => BibtexEntry::<BibtexCrossref>::bibtex_entry(works.first().unwrap(), w),
+            _ => {
+                for work in works.iter() {
+                    // Do not include Chapters in full publisher metadata record
+                    // (assumes that a publisher will always have more than one work)
+                    if work.work_type != WorkType::BOOK_CHAPTER {
+                        BibtexEntry::<BibtexCrossref>::bibtex_entry(work, w).ok();
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl BibtexEntry<BibtexCrossref> for Work {
+    fn bibtex_entry<W: Write>(&self, w: &mut Writer<W>) -> ThothResult<()> {
+        w.serialize(BibtexCrossrefEntry::try_from(self.clone())?)
+            .map_err(|e| e.into())
+    }
+}
+
+impl TryFrom<Work> for BibtexCrossrefEntry {
+    type Error = ThothError;
+
+    fn try_from(work: Work) -> ThothResult<Self> {
+        let mut author_list = vec![];
+        let mut editor_list = vec![];
+        let mut contributions = work.contributions;
+        contributions.sort_by(|a, b| a.contribution_ordinal.cmp(&b.contribution_ordinal));
+        for contribution in contributions {
+            if contribution.main_contribution {
+                if work.work_type == WorkType::EDITED_BOOK {
+                    if contribution.contribution_type == ContributionType::EDITOR {
+                        editor_list.push(contribution.full_name);
+                    }
+                } else if contribution.contribution_type == ContributionType::AUTHOR {
+                    author_list.push(contribution.full_name);
+                }
+            }
+        }
+        // BibTeX book records must contain either author or editor
+        if author_list.is_empty() && editor_list.is_empty() {
+            Err(ThothError::IncompleteMetadataRecord(
+                "bibtex::crossref".to_string(),
+                "Missing Author/Editor Details".to_string(),
+            ))
+        // Publication year is mandatory for books in BibTeX
+        } else if work.publication_date.is_none() {
+            Err(ThothError::IncompleteMetadataRecord(
+                "bibtex::crossref".to_string(),
+                "Missing Publication Date".to_string(),
+            ))
+        } else {
+            let mut isbn = None;
+            for publication in work.publications {
+                if publication.publication_type == PublicationType::PDF
+                    && publication.isbn.is_some()
+                {
+                    isbn = publication.isbn.as_ref().map(|i| i.to_string());
+                }
+            }
+            let author = match author_list.is_empty() {
+                true => None,
+                false => Some(author_list.join(" and ")),
+            };
+            let editor = match editor_list.is_empty() {
+                true => None,
+                false => Some(editor_list.join(" and ")),
+            };
+            let mut title = work.full_title;
+            let mut shorttitle = None;
+            if let Some(subtitle) = work.subtitle {
+                title = format!("{}: {}", work.title, subtitle);
+                shorttitle = Some(work.title);
+            }
+            Ok(BibtexCrossrefEntry {
+                title,
+                shorttitle,
+                author,
+                editor,
+                year: work
+                    .publication_date
+                    .map(|date| chrono::Datelike::year(&date).into())
+                    .unwrap(),
+                month: work
+                    .publication_date
+                    .map(|date| chrono::Datelike::month(&date).into())
+                    .unwrap(),
+                day: work
+                    .publication_date
+                    .map(|date| chrono::Datelike::day(&date).into())
+                    .unwrap(),
+                publisher: work.imprint.publisher.publisher_name,
+                address: work.place,
+                series: work
+                    .issues
+                    .first()
+                    .map(|i| i.series.series_name.to_string()),
+                volume: work.issues.first().map(|i| i.issue_ordinal),
+                pages: work.page_interval,
+                doi: work.doi.map(|d| d.to_string()),
+                isbn,
+                issn: work
+                    .issues
+                    .first()
+                    .map(|i| i.series.issn_digital.to_string()),
+                url: work.landing_page,
+                copyright: work.license,
+                long_abstract: work.long_abstract,
+            })
+        }
+    }
+}

--- a/thoth-export-server/src/bibtex/mod.rs
+++ b/thoth-export-server/src/bibtex/mod.rs
@@ -19,5 +19,5 @@ pub(crate) trait BibtexEntry<T: BibtexSpecification> {
     fn bibtex_entry(&self, w: &mut Vec<u8>) -> ThothResult<()>;
 }
 
-mod bibtex_crossref;
-pub(crate) use bibtex_crossref::BibtexCrossref;
+mod bibtex_thoth;
+pub(crate) use bibtex_thoth::BibtexThoth;

--- a/thoth-export-server/src/bibtex/mod.rs
+++ b/thoth-export-server/src/bibtex/mod.rs
@@ -1,7 +1,6 @@
 use thoth_client::Work;
 use thoth_errors::{ThothError, ThothResult};
 
-
 pub(crate) trait BibtexSpecification {
     fn generate(&self, works: &[Work]) -> ThothResult<String> {
         let mut buffer: Vec<u8> = Vec::new();

--- a/thoth-export-server/src/bibtex/mod.rs
+++ b/thoth-export-server/src/bibtex/mod.rs
@@ -1,33 +1,27 @@
-use csv::{QuoteStyle, Writer, WriterBuilder};
 use std::io::Write;
 use thoth_client::Work;
 use thoth_errors::{ThothError, ThothResult};
 
+pub struct BibtexWriter<W: Write> {
+    writer: W,
+}
+
 pub(crate) trait BibtexSpecification {
-    fn generate(
-        &self,
-        works: &[Work],
-        quote_style: QuoteStyle,
-        delimiter: u8,
-    ) -> ThothResult<String> {
-        let mut writer = WriterBuilder::new()
-            .quote_style(quote_style)
-            .delimiter(delimiter)
-            .from_writer(Vec::new());
+    fn generate(&self, works: &[Work]) -> ThothResult<String> {
+        let mut writer = BibtexWriter { writer: vec![] };
         Self::handle_event(&mut writer, works)
-            .map(|_| writer.into_inner().map_err(|e| e.error().into()))
-            .and_then(|val| val)
+            .map(|_| writer)
             .and_then(|bibtex| {
-                String::from_utf8(bibtex)
+                String::from_utf8(bibtex.writer)
                     .map_err(|_| ThothError::InternalError("Could not parse BibTeX".to_string()))
             })
     }
 
-    fn handle_event<W: Write>(w: &mut Writer<W>, works: &[Work]) -> ThothResult<()>;
+    fn handle_event<W: Write>(w: &mut BibtexWriter<W>, works: &[Work]) -> ThothResult<()>;
 }
 
 pub(crate) trait BibtexEntry<T: BibtexSpecification> {
-    fn bibtex_entry<W: Write>(&self, w: &mut Writer<W>) -> ThothResult<()>;
+    fn bibtex_entry<W: Write>(&self, w: &mut BibtexWriter<W>) -> ThothResult<()>;
 }
 
 mod bibtex_crossref;

--- a/thoth-export-server/src/bibtex/mod.rs
+++ b/thoth-export-server/src/bibtex/mod.rs
@@ -1,27 +1,23 @@
-use std::io::Write;
 use thoth_client::Work;
 use thoth_errors::{ThothError, ThothResult};
 
-pub struct BibtexWriter<W: Write> {
-    writer: W,
-}
 
 pub(crate) trait BibtexSpecification {
     fn generate(&self, works: &[Work]) -> ThothResult<String> {
-        let mut writer = BibtexWriter { writer: vec![] };
-        Self::handle_event(&mut writer, works)
-            .map(|_| writer)
+        let mut buffer: Vec<u8> = Vec::new();
+        Self::handle_event(&mut buffer, works)
+            .map(|_| buffer)
             .and_then(|bibtex| {
-                String::from_utf8(bibtex.writer)
+                String::from_utf8(bibtex)
                     .map_err(|_| ThothError::InternalError("Could not parse BibTeX".to_string()))
             })
     }
 
-    fn handle_event<W: Write>(w: &mut BibtexWriter<W>, works: &[Work]) -> ThothResult<()>;
+    fn handle_event(w: &mut Vec<u8>, works: &[Work]) -> ThothResult<()>;
 }
 
 pub(crate) trait BibtexEntry<T: BibtexSpecification> {
-    fn bibtex_entry<W: Write>(&self, w: &mut BibtexWriter<W>) -> ThothResult<()>;
+    fn bibtex_entry(&self, w: &mut Vec<u8>) -> ThothResult<()>;
 }
 
 mod bibtex_crossref;

--- a/thoth-export-server/src/bibtex/mod.rs
+++ b/thoth-export-server/src/bibtex/mod.rs
@@ -1,0 +1,34 @@
+use csv::{QuoteStyle, Writer, WriterBuilder};
+use std::io::Write;
+use thoth_client::Work;
+use thoth_errors::{ThothError, ThothResult};
+
+pub(crate) trait BibtexSpecification {
+    fn generate(
+        &self,
+        works: &[Work],
+        quote_style: QuoteStyle,
+        delimiter: u8,
+    ) -> ThothResult<String> {
+        let mut writer = WriterBuilder::new()
+            .quote_style(quote_style)
+            .delimiter(delimiter)
+            .from_writer(Vec::new());
+        Self::handle_event(&mut writer, works)
+            .map(|_| writer.into_inner().map_err(|e| e.error().into()))
+            .and_then(|val| val)
+            .and_then(|bibtex| {
+                String::from_utf8(bibtex)
+                    .map_err(|_| ThothError::InternalError("Could not parse BibTeX".to_string()))
+            })
+    }
+
+    fn handle_event<W: Write>(w: &mut Writer<W>, works: &[Work]) -> ThothResult<()>;
+}
+
+pub(crate) trait BibtexEntry<T: BibtexSpecification> {
+    fn bibtex_entry<W: Write>(&self, w: &mut Writer<W>) -> ThothResult<()>;
+}
+
+mod bibtex_crossref;
+pub(crate) use bibtex_crossref::BibtexCrossref;

--- a/thoth-export-server/src/csv/kbart_oclc.rs
+++ b/thoth-export-server/src/csv/kbart_oclc.rs
@@ -132,10 +132,7 @@ impl TryFrom<Work> for KbartOclcRow {
                 false => None,
             };
             Ok(KbartOclcRow {
-                publication_title: match work.subtitle {
-                    Some(subtitle) => format!("{}: {}", work.title, subtitle),
-                    None => work.full_title,
-                },
+                publication_title: work.full_title,
                 print_identifier,
                 online_identifier,
                 date_first_issue_online: None,
@@ -237,9 +234,11 @@ mod tests {
         let mut test_work: Work = Work {
             work_id: Uuid::from_str("00000000-0000-0000-AAAA-000000000001").unwrap(),
             work_status: WorkStatus::ACTIVE,
+            // We must manually set full_title within this test framework, but
+            // Thoth UI compiles it automatically from title + (optional) subtitle
             full_title: "Book Title: Book Subtitle".to_string(),
             title: "Book Title".to_string(),
-            subtitle: Some("Separate Subtitle".to_string()),
+            subtitle: Some("Book Subtitle".to_string()),
             work_type: WorkType::MONOGRAPH,
             edition: Some(1),
             doi: Some(Doi::from_str("https://doi.org/10.00001/BOOK.0001").unwrap()),
@@ -438,7 +437,7 @@ mod tests {
         };
         let mut test_result = TestResult {
             headers: "publication_title\tprint_identifier\tonline_identifier\tdate_first_issue_online\tnum_first_vol_online\tnum_first_issue_online\tdate_last_issue_online\tnum_last_vol_online\tnum_last_issue_online\ttitle_url\tfirst_author\ttitle_id\tembargo_info\tcoverage_depth\tnotes\tpublisher_name\tpublication_type\tdate_monograph_published_print\tdate_monograph_published_online\tmonograph_volume\tmonograph_edition\tfirst_editor\tparent_publication_title_id\tpreceding_publication_title_id\taccess_type\n".to_string(),
-            title: "Book Title: Separate Subtitle".to_string(),
+            title: "Book Title: Book Subtitle".to_string(),
             print_identifier: "978-3-16-148410-0".to_string(),
             online_identifier: "978-1-56619-909-4".to_string(),
             title_url: "https://www.book.com".to_string(),
@@ -457,9 +456,6 @@ mod tests {
             KbartOclc.generate(&[test_work.clone()], QuoteStyle::Necessary, DELIMITER_TAB);
         assert_eq!(to_test, Ok(test_result.to_string()));
 
-        // Remove subtitle: full title is used instead of title + subtitle
-        test_work.subtitle = None;
-        test_result.title = "Book Title: Book Subtitle".to_string();
         // Remove DOI: no title_id
         test_work.doi = None;
         test_result.title_id = "".to_string();

--- a/thoth-export-server/src/data.rs
+++ b/thoth-export-server/src/data.rs
@@ -56,7 +56,7 @@ lazy_static! {
             ],
         },
         Specification {
-            id: "kbart::oclc",
+            id: "bibtex::crossref",
             name: "Crossref BibTeX",
             format: concat!(env!("THOTH_EXPORT_API"), "/formats/bibtex"),
             accepted_by: vec![concat!(env!("THOTH_EXPORT_API"), "/platforms/crossref"),],

--- a/thoth-export-server/src/data.rs
+++ b/thoth-export-server/src/data.rs
@@ -56,10 +56,10 @@ lazy_static! {
             ],
         },
         Specification {
-            id: "bibtex::crossref",
-            name: "Crossref BibTeX",
+            id: "bibtex::thoth",
+            name: "Thoth BibTeX",
             format: concat!(env!("THOTH_EXPORT_API"), "/formats/bibtex"),
-            accepted_by: vec![concat!(env!("THOTH_EXPORT_API"), "/platforms/crossref"),],
+            accepted_by: vec![concat!(env!("THOTH_EXPORT_API"), "/platforms/zotero"),],
         },
     ];
     pub(crate) static ref ALL_PLATFORMS: Vec<Platform<'static>> = vec![
@@ -155,11 +155,11 @@ lazy_static! {
             ),],
         },
         Platform {
-            id: "crossref",
-            name: "Crossref",
+            id: "zotero",
+            name: "Zotero",
             accepts: vec![concat!(
                 env!("THOTH_EXPORT_API"),
-                "/specifications/bibtex::crossref"
+                "/specifications/bibtex::thoth"
             ),],
         },
     ];
@@ -210,7 +210,7 @@ lazy_static! {
             version: None,
             specifications: vec![concat!(
                 env!("THOTH_EXPORT_API"),
-                "/specifications/bibtex::crossref"
+                "/specifications/bibtex::thoth"
             ),],
         },
     ];

--- a/thoth-export-server/src/data.rs
+++ b/thoth-export-server/src/data.rs
@@ -55,6 +55,14 @@ lazy_static! {
                 concat!(env!("THOTH_EXPORT_API"), "/platforms/jisc_kb"),
             ],
         },
+        Specification {
+            id: "kbart::oclc",
+            name: "Crossref BibTeX",
+            format: concat!(env!("THOTH_EXPORT_API"), "/formats/bibtex"),
+            accepted_by: vec![
+                concat!(env!("THOTH_EXPORT_API"), "/platforms/crossref"),
+            ],
+        },
     ];
     pub(crate) static ref ALL_PLATFORMS: Vec<Platform<'static>> = vec![
         Platform {
@@ -148,6 +156,14 @@ lazy_static! {
                 "/specifications/kbart::oclc"
             ),],
         },
+        Platform {
+            id: "crossref",
+            name: "Crossref",
+            accepts: vec![concat!(
+                env!("THOTH_EXPORT_API"),
+                "/specifications/bibtex::crossref"
+            ),],
+        },
     ];
     pub(crate) static ref ALL_FORMATS: Vec<Format<'static>> = vec![
         Format {
@@ -188,6 +204,15 @@ lazy_static! {
             specifications: vec![concat!(
                 env!("THOTH_EXPORT_API"),
                 "/specifications/kbart::oclc"
+            ),],
+        },
+        Format {
+            id: "bibtex",
+            name: "BibTeX",
+            version: None,
+            specifications: vec![concat!(
+                env!("THOTH_EXPORT_API"),
+                "/specifications/bibtex::crossref"
             ),],
         },
     ];

--- a/thoth-export-server/src/data.rs
+++ b/thoth-export-server/src/data.rs
@@ -59,9 +59,7 @@ lazy_static! {
             id: "kbart::oclc",
             name: "Crossref BibTeX",
             format: concat!(env!("THOTH_EXPORT_API"), "/formats/bibtex"),
-            accepted_by: vec![
-                concat!(env!("THOTH_EXPORT_API"), "/platforms/crossref"),
-            ],
+            accepted_by: vec![concat!(env!("THOTH_EXPORT_API"), "/platforms/crossref"),],
         },
     ];
     pub(crate) static ref ALL_PLATFORMS: Vec<Platform<'static>> = vec![

--- a/thoth-export-server/src/lib.rs
+++ b/thoth-export-server/src/lib.rs
@@ -6,6 +6,7 @@ use paperclip::actix::{web, web::HttpResponse, OpenApiExt};
 use paperclip::v2::models::{Contact, DefaultApiRaw, Info, License, Tag};
 use thoth_client::ThothClient;
 
+mod bibtex;
 mod csv;
 mod data;
 mod format;

--- a/thoth-export-server/src/record.rs
+++ b/thoth-export-server/src/record.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use thoth_client::Work;
 use thoth_errors::{ThothError, ThothResult};
 
-use crate::bibtex::{BibtexCrossref, BibtexSpecification};
+use crate::bibtex::{BibtexSpecification, BibtexThoth};
 use crate::csv::{CsvSpecification, CsvThoth, KbartOclc};
 use crate::xml::{Onix21EbscoHost, Onix3Jstor, Onix3Oapen, Onix3ProjectMuse, XmlSpecification};
 
@@ -28,7 +28,7 @@ pub(crate) enum MetadataSpecification {
     Onix21EbscoHost(Onix21EbscoHost),
     CsvThoth(CsvThoth),
     KbartOclc(KbartOclc),
-    BibtexCrossref(BibtexCrossref),
+    BibtexThoth(BibtexThoth),
 }
 
 pub(crate) struct MetadataRecord<T: AsRecord> {
@@ -66,7 +66,7 @@ where
             MetadataSpecification::Onix21EbscoHost(_) => Self::XML_MIME_TYPE,
             MetadataSpecification::CsvThoth(_) => Self::CSV_MIME_TYPE,
             MetadataSpecification::KbartOclc(_) => Self::TXT_MIME_TYPE,
-            MetadataSpecification::BibtexCrossref(_) => Self::BIB_MIME_TYPE,
+            MetadataSpecification::BibtexThoth(_) => Self::BIB_MIME_TYPE,
         }
     }
 
@@ -78,7 +78,7 @@ where
             MetadataSpecification::Onix21EbscoHost(_) => self.xml_file_name(),
             MetadataSpecification::CsvThoth(_) => self.csv_file_name(),
             MetadataSpecification::KbartOclc(_) => self.txt_file_name(),
-            MetadataSpecification::BibtexCrossref(_) => self.bib_file_name(),
+            MetadataSpecification::BibtexThoth(_) => self.bib_file_name(),
         }
     }
 
@@ -133,9 +133,7 @@ impl MetadataRecord<Vec<Work>> {
             MetadataSpecification::KbartOclc(kbart_oclc) => {
                 kbart_oclc.generate(&self.data, QuoteStyle::Necessary, DELIMITER_TAB)
             }
-            MetadataSpecification::BibtexCrossref(bibtex_crossref) => {
-                bibtex_crossref.generate(&self.data)
-            }
+            MetadataSpecification::BibtexThoth(bibtex_thoth) => bibtex_thoth.generate(&self.data),
         }
     }
 }
@@ -192,7 +190,7 @@ impl FromStr for MetadataSpecification {
             }
             "csv::thoth" => Ok(MetadataSpecification::CsvThoth(CsvThoth {})),
             "kbart::oclc" => Ok(MetadataSpecification::KbartOclc(KbartOclc {})),
-            "bibtex::crossref" => Ok(MetadataSpecification::BibtexCrossref(BibtexCrossref {})),
+            "bibtex::thoth" => Ok(MetadataSpecification::BibtexThoth(BibtexThoth {})),
             _ => Err(ThothError::InvalidMetadataSpecification(input.to_string())),
         }
     }
@@ -207,7 +205,7 @@ impl ToString for MetadataSpecification {
             MetadataSpecification::Onix21EbscoHost(_) => "onix_2.1::ebsco_host".to_string(),
             MetadataSpecification::CsvThoth(_) => "csv::thoth".to_string(),
             MetadataSpecification::KbartOclc(_) => "kbart::oclc".to_string(),
-            MetadataSpecification::BibtexCrossref(_) => "bibtex::crossref".to_string(),
+            MetadataSpecification::BibtexThoth(_) => "bibtex::thoth".to_string(),
         }
     }
 }
@@ -280,12 +278,12 @@ mod tests {
         assert_eq!(to_test.file_name(), "kbart__oclc__some_id.txt".to_string());
         let to_test = MetadataRecord::new(
             "some_id".to_string(),
-            MetadataSpecification::BibtexCrossref(BibtexCrossref {}),
+            MetadataSpecification::BibtexThoth(BibtexThoth {}),
             vec![],
         );
         assert_eq!(
             to_test.file_name(),
-            "bibtex__crossref__some_id.bib".to_string()
+            "bibtex__thoth__some_id.bib".to_string()
         );
     }
 }

--- a/thoth-export-server/src/record.rs
+++ b/thoth-export-server/src/record.rs
@@ -134,7 +134,7 @@ impl MetadataRecord<Vec<Work>> {
                 kbart_oclc.generate(&self.data, QuoteStyle::Necessary, DELIMITER_TAB)
             }
             MetadataSpecification::BibtexCrossref(bibtex_crossref) => {
-                bibtex_crossref.generate(&self.data, QuoteStyle::Necessary, DELIMITER_TAB)
+                bibtex_crossref.generate(&self.data)
             }
         }
     }

--- a/thoth-export-server/src/xml/onix3_jstor.rs
+++ b/thoth-export-server/src/xml/onix3_jstor.rs
@@ -159,21 +159,17 @@ impl XmlElementBlock<Onix3Jstor> for Work {
                             write_element_block("TitleElementLevel", w, |w| {
                                 w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
                             })?;
+                            write_element_block("TitleText", w, |w| {
+                                w.write(XmlEvent::Characters(&self.title))
+                                    .map_err(|e| e.into())
+                            })?;
                             if let Some(subtitle) = &self.subtitle {
-                                write_element_block("TitleText", w, |w| {
-                                    w.write(XmlEvent::Characters(&self.title))
-                                        .map_err(|e| e.into())
-                                })?;
                                 write_element_block("Subtitle", w, |w| {
                                     w.write(XmlEvent::Characters(subtitle))
                                         .map_err(|e| e.into())
-                                })
-                            } else {
-                                write_element_block("TitleText", w, |w| {
-                                    w.write(XmlEvent::Characters(&self.full_title))
-                                        .map_err(|e| e.into())
-                                })
+                                })?;
                             }
+                            Ok(())
                         })
                     })?;
                     for contribution in &self.contributions {
@@ -941,10 +937,8 @@ mod tests {
         assert!(!output
             .contains(r#"        <EpubLicenseExpressionType>02</EpubLicenseExpressionType>"#));
         assert!(!output.contains(r#"        <EpubLicenseExpressionLink>https://creativecommons.org/licenses/by/4.0/</EpubLicenseExpressionLink>"#));
-        // No subtitle supplied: work FullTitle is used instead of Title
-        assert!(!output.contains(r#"        <TitleText>Book Title</TitleText>"#));
+        // No subtitle supplied (within Thoth UI this would automatically update full_title)
         assert!(!output.contains(r#"        <Subtitle>Book Subtitle</Subtitle>"#));
-        assert!(output.contains(r#"        <TitleText>Book Title: Book Subtitle</TitleText>"#));
         // No page count supplied
         assert!(!output.contains(r#"    <Extent>"#));
         assert!(!output.contains(r#"      <ExtentType>00</ExtentType>"#));

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -162,21 +162,17 @@ impl XmlElementBlock<Onix3Oapen> for Work {
                             write_element_block("TitleElementLevel", w, |w| {
                                 w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
                             })?;
+                            write_element_block("TitleText", w, |w| {
+                                w.write(XmlEvent::Characters(&self.title))
+                                    .map_err(|e| e.into())
+                            })?;
                             if let Some(subtitle) = &self.subtitle {
-                                write_element_block("TitleText", w, |w| {
-                                    w.write(XmlEvent::Characters(&self.title))
-                                        .map_err(|e| e.into())
-                                })?;
                                 write_element_block("Subtitle", w, |w| {
                                     w.write(XmlEvent::Characters(subtitle))
                                         .map_err(|e| e.into())
-                                })
-                            } else {
-                                write_element_block("TitleText", w, |w| {
-                                    w.write(XmlEvent::Characters(&self.full_title))
-                                        .map_err(|e| e.into())
-                                })
+                                })?;
                             }
+                            Ok(())
                         })
                     })?;
                     for contribution in &self.contributions {
@@ -1133,10 +1129,8 @@ mod tests {
         assert!(!output
             .contains(r#"        <EpubLicenseExpressionType>02</EpubLicenseExpressionType>"#));
         assert!(!output.contains(r#"        <EpubLicenseExpressionLink>https://creativecommons.org/licenses/by/4.0/</EpubLicenseExpressionLink>"#));
-        // No subtitle supplied: work FullTitle is used instead of Title
-        assert!(!output.contains(r#"        <TitleText>Book Title</TitleText>"#));
+        // No subtitle supplied (within Thoth UI this would automatically update full_title)
         assert!(!output.contains(r#"        <Subtitle>Book Subtitle</Subtitle>"#));
-        assert!(output.contains(r#"        <TitleText>Book Title: Book Subtitle</TitleText>"#));
         // No page count supplied
         assert!(!output.contains(r#"    <Extent>"#));
         assert!(!output.contains(r#"      <ExtentType>00</ExtentType>"#));

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -170,21 +170,17 @@ impl XmlElementBlock<Onix3ProjectMuse> for Work {
                             write_element_block("TitleElementLevel", w, |w| {
                                 w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
                             })?;
+                            write_element_block("TitleText", w, |w| {
+                                w.write(XmlEvent::Characters(&self.title))
+                                    .map_err(|e| e.into())
+                            })?;
                             if let Some(subtitle) = &self.subtitle {
-                                write_element_block("TitleText", w, |w| {
-                                    w.write(XmlEvent::Characters(&self.title))
-                                        .map_err(|e| e.into())
-                                })?;
                                 write_element_block("Subtitle", w, |w| {
                                     w.write(XmlEvent::Characters(subtitle))
                                         .map_err(|e| e.into())
-                                })
-                            } else {
-                                write_element_block("TitleText", w, |w| {
-                                    w.write(XmlEvent::Characters(&self.full_title))
-                                        .map_err(|e| e.into())
-                                })
+                                })?;
                             }
+                            Ok(())
                         })
                     })?;
                     for contribution in &self.contributions {
@@ -958,10 +954,8 @@ mod tests {
         assert!(!output
             .contains(r#"        <EpubLicenseExpressionType>02</EpubLicenseExpressionType>"#));
         assert!(!output.contains(r#"        <EpubLicenseExpressionLink>https://creativecommons.org/licenses/by/4.0/</EpubLicenseExpressionLink>"#));
-        // No subtitle supplied: work FullTitle is used instead of Title
-        assert!(!output.contains(r#"        <TitleText>Book Title</TitleText>"#));
+        // No subtitle supplied (within Thoth UI this would automatically update full_title)
         assert!(!output.contains(r#"        <Subtitle>Book Subtitle</Subtitle>"#));
-        assert!(output.contains(r#"        <TitleText>Book Title: Book Subtitle</TitleText>"#));
         // No page count supplied
         assert!(!output.contains(r#"    <Extent>"#));
         assert!(!output.contains(r#"      <ExtentType>00</ExtentType>"#));


### PR DESCRIPTION
Fixes #104. Basic implementation e.g. no extra handling of special characters; can be extended if users report additional requirements.

Also removed unnecessary branching logic from existing (KBART/ONIX) output formats: UI constrains Work full_title field to always match title + (optional) subtitle, so no need to alternate between them.