### PR TITLE
Prevent setting prices to zero at database, API and app levels

### DIFF
--- a/thoth-api/migrations/0.8.5/down.sql
+++ b/thoth-api/migrations/0.8.5/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE price
+    DROP CONSTRAINT price_unit_price_check;

--- a/thoth-api/migrations/0.8.5/up.sql
+++ b/thoth-api/migrations/0.8.5/up.sql
@@ -1,0 +1,4 @@
+DELETE FROM price WHERE unit_price = 0.0;
+
+ALTER TABLE price
+    ADD CONSTRAINT price_unit_price_check CHECK (unit_price > 0.0);

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1431,6 +1431,11 @@ impl MutationRoot {
                 data.publication_id,
             )?)?;
 
+        if data.unit_price == 0.0 {
+            // Prices must be non-zero.
+            return Err(ThothError::PriceZeroError.into());
+        }
+
         Price::create(&context.db, &data).map_err(|e| e.into())
     }
 
@@ -1709,6 +1714,11 @@ impl MutationRoot {
                     &context.db,
                     data.publication_id,
                 )?)?;
+        }
+
+        if data.unit_price == 0.0 {
+            // Prices must be non-zero.
+            return Err(ThothError::PriceZeroError.into());
         }
 
         let account_id = context.token.jwt.as_ref().unwrap().account_id(&context.db);

--- a/thoth-api/src/graphql/model.rs
+++ b/thoth-api/src/graphql/model.rs
@@ -1431,8 +1431,8 @@ impl MutationRoot {
                 data.publication_id,
             )?)?;
 
-        if data.unit_price == 0.0 {
-            // Prices must be non-zero.
+        if data.unit_price <= 0.0 {
+            // Prices must be non-zero (and non-negative).
             return Err(ThothError::PriceZeroError.into());
         }
 
@@ -1716,8 +1716,8 @@ impl MutationRoot {
                 )?)?;
         }
 
-        if data.unit_price == 0.0 {
-            // Prices must be non-zero.
+        if data.unit_price <= 0.0 {
+            // Prices must be non-zero (and non-negative).
             return Err(ThothError::PriceZeroError.into());
         }
 

--- a/thoth-app/src/component/prices_form.rs
+++ b/thoth-app/src/component/prices_form.rs
@@ -295,6 +295,7 @@ impl Component for PricesFormComponent {
                                     oninput=self.link.callback(|e: InputData| Msg::ChangeUnitPrice(e.value))
                                     required = true
                                     step="0.01".to_string()
+                                    min="0.01".to_string()
                                 />
                             </form>
                         </section>

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -170,6 +170,8 @@ pub struct PureFloatInput {
     pub required: bool,
     #[prop_or_default]
     pub step: Option<String>,
+    #[prop_or("0".to_string())]
+    pub min: String,
     #[prop_or(false)]
     pub deactivated: bool,
 }
@@ -511,7 +513,7 @@ impl PureComponent for PureFloatInput {
                 onblur=self.onblur.clone()
                 required=self.required
                 step=self.step.clone()
-                min="0".to_string()
+                min=self.min.clone()
                 deactivated=self.deactivated
             />
         }

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -85,7 +85,7 @@ pub enum ThothError {
     )]
     DimensionDigitalError,
     #[fail(
-        display = "Prices may not be set at zero. To indicate an unpriced Publication, omit all Prices."
+        display = "Price values must be greater than zero. To indicate an unpriced Publication, omit all Prices."
     )]
     PriceZeroError,
 }

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -84,6 +84,10 @@ pub enum ThothError {
         display = "Width/Height/Depth/Weight are only applicable to physical (Paperback/Hardback) Publications."
     )]
     DimensionDigitalError,
+    #[fail(
+        display = "Prices may not be set at zero. To indicate an unpriced Publication, omit all Prices."
+    )]
+    PriceZeroError,
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/thoth-export-server/src/xml/onix3_google_books.rs
+++ b/thoth-export-server/src/xml/onix3_google_books.rs
@@ -392,7 +392,8 @@ impl XmlElementBlock<Onix3GoogleBooks> for Work {
                             .prices
                             .iter()
                             .find(|pr| {
-                                pr.currency_code.eq(&CurrencyCode::GBP) && pr.unit_price > 0.0
+                                // Thoth database only accepts non-zero prices
+                                pr.currency_code.eq(&CurrencyCode::GBP)
                             })
                             .map(|pr| pr.unit_price)
                         {


### PR DESCRIPTION
Fixes #360. Removes any existing zero-value prices from database on migration (this is safe as they do not hold any other salient information).