### PR TITLE
Enable editing of existing Contributions, including their Affiliations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  - [#287](https://github.com/thoth-pub/thoth/issues/287) - Allow editing contributions (and affiliations)
+
+### Fixed
+  - [#360](https://github.com/thoth-pub/thoth/issues/360) - Prevent adding 0 as the price of a publication
+  - [#376](https://github.com/thoth-pub/thoth/issues/376) - Restrict Licence field entries to URL-formatted strings
 
 ## [[0.8.4]](https://github.com/thoth-pub/thoth/releases/tag/v0.8.4) - 2022-05-11
 ### Added

--- a/thoth-app/src/component/affiliations_form.rs
+++ b/thoth-app/src/component/affiliations_form.rs
@@ -139,6 +139,16 @@ impl Component for AffiliationsFormComponent {
                 self.show_modal_form = show_form;
                 self.in_edit_mode = a.is_some();
                 if show_form {
+                    let body = InstitutionsRequestBody {
+                        variables: SearchVariables {
+                            limit: Some(9999),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    };
+                    let request = InstitutionsRequest { body };
+                    self.fetch_institutions = Fetch::new(request);
+                    self.link.send_message(Msg::GetInstitutions);
                     if let Some(affiliation) = a {
                         // Editing existing affiliation: load its current values.
                         self.affiliation = affiliation;

--- a/thoth-app/src/component/affiliations_form.rs
+++ b/thoth-app/src/component/affiliations_form.rs
@@ -112,6 +112,7 @@ impl Component for AffiliationsFormComponent {
         let notification_bus = NotificationBus::dispatcher();
 
         link.send_message(Msg::GetAffiliations);
+        link.send_message(Msg::GetInstitutions);
 
         AffiliationsFormComponent {
             fetch_affiliations,

--- a/thoth-app/src/component/affiliations_form.rs
+++ b/thoth-app/src/component/affiliations_form.rs
@@ -142,9 +142,6 @@ impl Component for AffiliationsFormComponent {
                     if let Some(affiliation) = a {
                         // Editing existing affiliation: load its current values.
                         self.affiliation = affiliation;
-                    } else {
-                        self.affiliation.institution_id = Default::default();
-                        self.affiliation.institution = Default::default();
                     }
                 }
                 true

--- a/thoth-app/src/component/contributions_form.rs
+++ b/thoth-app/src/component/contributions_form.rs
@@ -152,6 +152,16 @@ impl Component for ContributionsFormComponent {
                 self.show_modal_form = show_form;
                 self.in_edit_mode = c.is_some();
                 if show_form {
+                    let body = ContributorsRequestBody {
+                        variables: Variables {
+                            limit: Some(9999),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    };
+                    let request = ContributorsRequest { body };
+                    self.fetch_contributors = Fetch::new(request);
+                    self.link.send_message(Msg::GetContributors);
                     if let Some(contribution) = c {
                         // Editing existing contribution: load its current values.
                         self.contribution = contribution;

--- a/thoth-app/src/component/contributions_form.rs
+++ b/thoth-app/src/component/contributions_form.rs
@@ -155,12 +155,6 @@ impl Component for ContributionsFormComponent {
                     if let Some(contribution) = c {
                         // Editing existing contribution: load its current values.
                         self.contribution = contribution;
-                    } else {
-                        self.contribution.contributor_id = Default::default();
-                        // Clear user-editable name fields as no contributor is selected yet.
-                        self.contribution.first_name = Default::default();
-                        self.contribution.last_name = Default::default();
-                        self.contribution.full_name = Default::default();
                     }
                 }
                 true

--- a/thoth-app/src/component/contributions_form.rs
+++ b/thoth-app/src/component/contributions_form.rs
@@ -87,6 +87,7 @@ pub enum Msg {
     UpdateContribution,
     SetContributionDeleteState(PushActionDeleteContribution),
     DeleteContribution(Uuid),
+    ChangeContributor(Uuid),
     ChangeFirstName(String),
     ChangeLastName(String),
     ChangeFullName(String),
@@ -94,7 +95,6 @@ pub enum Msg {
     ChangeContributiontype(ContributionType),
     ChangeMainContribution(bool),
     ChangeOrdinal(String),
-    ChangeContributor(Uuid),
 }
 
 #[derive(Clone, Properties, PartialEq)]
@@ -392,27 +392,6 @@ impl Component for ContributionsFormComponent {
                     .send_message(Msg::SetContributionDeleteState(FetchAction::Fetching));
                 false
             }
-            Msg::ChangeFirstName(val) => {
-                self.contribution.first_name.neq_assign(val.to_opt_string())
-            }
-            Msg::ChangeLastName(val) => self
-                .contribution
-                .last_name
-                .neq_assign(val.trim().to_owned()),
-            Msg::ChangeFullName(val) => self
-                .contribution
-                .full_name
-                .neq_assign(val.trim().to_owned()),
-            Msg::ChangeBiography(val) => {
-                self.contribution.biography.neq_assign(val.to_opt_string())
-            }
-            Msg::ChangeContributiontype(val) => self.contribution.contribution_type.neq_assign(val),
-            Msg::ChangeMainContribution(val) => self.contribution.main_contribution.neq_assign(val),
-            Msg::ChangeOrdinal(ordinal) => {
-                let ordinal = ordinal.parse::<i32>().unwrap_or(0);
-                self.contribution.contribution_ordinal.neq_assign(ordinal);
-                false // otherwise we re-render the component and reset the value
-            }
             Msg::ChangeContributor(contributor_id) => {
                 // ID may be nil if placeholder option was selected.
                 // Reset contributor anyway, to keep display/underlying values in sync.
@@ -436,6 +415,27 @@ impl Component for ContributionsFormComponent {
                         .neq_assign(contributor.full_name.clone());
                 }
                 true
+            }
+            Msg::ChangeFirstName(val) => {
+                self.contribution.first_name.neq_assign(val.to_opt_string())
+            }
+            Msg::ChangeLastName(val) => self
+                .contribution
+                .last_name
+                .neq_assign(val.trim().to_owned()),
+            Msg::ChangeFullName(val) => self
+                .contribution
+                .full_name
+                .neq_assign(val.trim().to_owned()),
+            Msg::ChangeBiography(val) => {
+                self.contribution.biography.neq_assign(val.to_opt_string())
+            }
+            Msg::ChangeContributiontype(val) => self.contribution.contribution_type.neq_assign(val),
+            Msg::ChangeMainContribution(val) => self.contribution.main_contribution.neq_assign(val),
+            Msg::ChangeOrdinal(ordinal) => {
+                let ordinal = ordinal.parse::<i32>().unwrap_or(0);
+                self.contribution.contribution_ordinal.neq_assign(ordinal);
+                false // otherwise we re-render the component and reset the value
             }
         }
     }

--- a/thoth-app/src/component/imprint.rs
+++ b/thoth-app/src/component/imprint.rs
@@ -288,17 +288,16 @@ impl Component for ImprintComponent {
                 false
             }
             Msg::ChangePublisher(publisher_id) => {
-                if let Some(index) = self
+                if let Some(publisher) = self
                     .data
                     .publishers
                     .iter()
-                    .position(|p| p.publisher_id == publisher_id)
+                    .find(|p| p.publisher_id == publisher_id)
                 {
-                    self.imprint
-                        .publisher
-                        .neq_assign(self.data.publishers.get(index).unwrap().clone())
+                    self.imprint.publisher.neq_assign(publisher.clone())
                 } else {
-                    false
+                    // Publisher not found: clear existing selection
+                    self.imprint.publisher.neq_assign(Default::default())
                 }
             }
             Msg::ChangeImprintName(imprint_name) => self

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -1,3 +1,4 @@
+use thoth_api::model::contributor::Contributor;
 use thoth_api::model::contribution::ContributionType;
 use thoth_api::model::imprint::ImprintWithPublisher;
 use thoth_api::model::institution::CountryCode;
@@ -65,6 +66,7 @@ pub type FormBooleanSelect = Pure<PureBooleanSelect>;
 pub type FormImprintSelect = Pure<PureImprintSelect>;
 pub type FormPublisherSelect = Pure<PurePublisherSelect>;
 pub type FormInstitutionSelect = Pure<PureInstitutionSelect>;
+pub type FormContributorSelect = Pure<PureContributorSelect>;
 pub type Loader = Pure<PureLoader>;
 pub type Reloader = Pure<PureReloader>;
 
@@ -352,6 +354,16 @@ pub struct PurePublisherSelect {
 pub struct PureInstitutionSelect {
     pub label: String,
     pub data: Vec<Institution>,
+    pub value: Option<Uuid>,
+    pub onchange: Callback<ChangeData>,
+    #[prop_or(false)]
+    pub required: bool,
+}
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct PureContributorSelect {
+    pub label: String,
+    pub data: Vec<Contributor>,
     pub value: Option<Uuid>,
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
@@ -847,6 +859,24 @@ impl PureComponent for PureInstitutionSelect {
     }
 }
 
+impl PureComponent for PureContributorSelect {
+    fn render(&self) -> VNode {
+        html! {
+            <div class="field">
+                <label class="label">{ &self.label }</label>
+                <div class="control is-expanded">
+                    <div class="select is-fullwidth">
+                    <select required=self.required onchange=&self.onchange>
+                        <option value="">{"Select Contributor"}</option>
+                        { for self.data.iter().map(|i| self.render_contributor(i)) }
+                    </select>
+                    </div>
+                </div>
+            </div>
+        }
+    }
+}
+
 impl PureWorkTypeSelect {
     fn render_worktype(&self, w: &WorkTypeValues, deactivate: &[WorkType]) -> VNode {
         let deactivated = deactivate.contains(&w.name);
@@ -1003,6 +1033,17 @@ impl PureInstitutionSelect {
         html! {
             <option value={i.institution_id.to_string()} selected={&i.institution_id == value}>
                 {&i.institution_name}
+            </option>
+        }
+    }
+}
+
+impl PureContributorSelect {
+    fn render_contributor(&self, c: &Contributor) -> VNode {
+        let value = &self.value.unwrap_or_default();
+        html! {
+            <option value={c.contributor_id.to_string()} selected={&c.contributor_id == value}>
+                {&c.full_name}
             </option>
         }
     }

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -354,7 +354,7 @@ pub struct PurePublisherSelect {
 pub struct PureInstitutionSelect {
     pub label: String,
     pub data: Vec<Institution>,
-    pub value: Option<Uuid>,
+    pub value: Uuid,
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
     pub required: bool,
@@ -849,7 +849,7 @@ impl PureComponent for PureInstitutionSelect {
                 <div class="control is-expanded">
                     <div class="select is-fullwidth">
                     <select required=self.required onchange=&self.onchange>
-                        <option value="">{"Select Institution"}</option>
+                        <option value="" selected={self.value.is_nil()}>{"Select Institution"}</option>
                         { for self.data.iter().map(|i| self.render_institution(i)) }
                     </select>
                     </div>
@@ -868,7 +868,7 @@ impl PureComponent for PureContributorSelect {
                     <div class="select is-fullwidth">
                     <select required=self.required onchange=&self.onchange>
                         <option value="" selected={self.value.is_nil()}>{"Select Contributor"}</option>
-                        { for self.data.iter().map(|i| self.render_contributor(i)) }
+                        { for self.data.iter().map(|c| self.render_contributor(c)) }
                     </select>
                     </div>
                 </div>
@@ -1029,10 +1029,9 @@ impl PurePublisherSelect {
 
 impl PureInstitutionSelect {
     fn render_institution(&self, i: &Institution) -> VNode {
-        let value = &self.value.unwrap_or_default();
         html! {
-            <option value={i.institution_id.to_string()} selected={&i.institution_id == value}>
-                {&i.institution_name}
+            <option value={i.institution_id.to_string()} selected={i.institution_id == self.value}>
+                {&i.to_string()}
             </option>
         }
     }

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -1,6 +1,7 @@
 use thoth_api::model::contribution::ContributionType;
 use thoth_api::model::imprint::ImprintWithPublisher;
 use thoth_api::model::institution::CountryCode;
+use thoth_api::model::institution::Institution;
 use thoth_api::model::language::LanguageCode;
 use thoth_api::model::language::LanguageRelation;
 use thoth_api::model::location::LocationPlatform;
@@ -63,6 +64,7 @@ pub type FormRelationTypeSelect = Pure<PureRelationTypeSelect>;
 pub type FormBooleanSelect = Pure<PureBooleanSelect>;
 pub type FormImprintSelect = Pure<PureImprintSelect>;
 pub type FormPublisherSelect = Pure<PurePublisherSelect>;
+pub type FormInstitutionSelect = Pure<PureInstitutionSelect>;
 pub type Loader = Pure<PureLoader>;
 pub type Reloader = Pure<PureReloader>;
 
@@ -340,6 +342,16 @@ pub struct PureImprintSelect {
 pub struct PurePublisherSelect {
     pub label: String,
     pub data: Vec<Publisher>,
+    pub value: Option<Uuid>,
+    pub onchange: Callback<ChangeData>,
+    #[prop_or(false)]
+    pub required: bool,
+}
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct PureInstitutionSelect {
+    pub label: String,
+    pub data: Vec<Institution>,
     pub value: Option<Uuid>,
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
@@ -817,6 +829,24 @@ impl PureComponent for PurePublisherSelect {
     }
 }
 
+impl PureComponent for PureInstitutionSelect {
+    fn render(&self) -> VNode {
+        html! {
+            <div class="field">
+                <label class="label">{ &self.label }</label>
+                <div class="control is-expanded">
+                    <div class="select is-fullwidth">
+                    <select required=self.required onchange=&self.onchange>
+                        <option value="">{"Select Institution"}</option>
+                        { for self.data.iter().map(|i| self.render_institution(i)) }
+                    </select>
+                    </div>
+                </div>
+            </div>
+        }
+    }
+}
+
 impl PureWorkTypeSelect {
     fn render_worktype(&self, w: &WorkTypeValues, deactivate: &[WorkType]) -> VNode {
         let deactivated = deactivate.contains(&w.name);
@@ -962,6 +992,17 @@ impl PurePublisherSelect {
         html! {
             <option value={p.publisher_id.to_string()} selected={&p.publisher_id == value}>
                 {&p.publisher_name}
+            </option>
+        }
+    }
+}
+
+impl PureInstitutionSelect {
+    fn render_institution(&self, i: &Institution) -> VNode {
+        let value = &self.value.unwrap_or_default();
+        html! {
+            <option value={i.institution_id.to_string()} selected={&i.institution_id == value}>
+                {&i.institution_name}
             </option>
         }
     }

--- a/thoth-app/src/component/utils.rs
+++ b/thoth-app/src/component/utils.rs
@@ -1,5 +1,5 @@
-use thoth_api::model::contributor::Contributor;
 use thoth_api::model::contribution::ContributionType;
+use thoth_api::model::contributor::Contributor;
 use thoth_api::model::imprint::ImprintWithPublisher;
 use thoth_api::model::institution::CountryCode;
 use thoth_api::model::institution::Institution;
@@ -364,7 +364,7 @@ pub struct PureInstitutionSelect {
 pub struct PureContributorSelect {
     pub label: String,
     pub data: Vec<Contributor>,
-    pub value: Option<Uuid>,
+    pub value: Uuid,
     pub onchange: Callback<ChangeData>,
     #[prop_or(false)]
     pub required: bool,
@@ -867,7 +867,7 @@ impl PureComponent for PureContributorSelect {
                 <div class="control is-expanded">
                     <div class="select is-fullwidth">
                     <select required=self.required onchange=&self.onchange>
-                        <option value="">{"Select Contributor"}</option>
+                        <option value="" selected={self.value.is_nil()}>{"Select Contributor"}</option>
                         { for self.data.iter().map(|i| self.render_contributor(i)) }
                     </select>
                     </div>
@@ -1040,10 +1040,9 @@ impl PureInstitutionSelect {
 
 impl PureContributorSelect {
     fn render_contributor(&self, c: &Contributor) -> VNode {
-        let value = &self.value.unwrap_or_default();
         html! {
-            <option value={c.contributor_id.to_string()} selected={&c.contributor_id == value}>
-                {&c.full_name}
+            <option value={c.contributor_id.to_string()} selected={c.contributor_id == self.value}>
+                {&c.to_string()}
             </option>
         }
     }

--- a/thoth-app/src/component/work.rs
+++ b/thoth-app/src/component/work.rs
@@ -410,17 +410,16 @@ impl Component for WorkComponent {
             Msg::ChangeReference(value) => self.work.reference.neq_assign(value.to_opt_string()),
             Msg::ChangeImprint(imprint_id) => {
                 // we already have the full list of imprints
-                if let Some(index) = self
+                if let Some(imprint) = self
                     .data
                     .imprints
                     .iter()
-                    .position(|i| i.imprint_id == imprint_id)
+                    .find(|i| i.imprint_id == imprint_id)
                 {
-                    self.work
-                        .imprint
-                        .neq_assign(self.data.imprints.get(index).unwrap().clone())
+                    self.work.imprint.neq_assign(imprint.clone())
                 } else {
-                    false
+                    // Imprint not found: clear existing selection
+                    self.work.imprint.neq_assign(Default::default())
                 }
             }
             Msg::ChangeEdition(edition) => self.work.edition.neq_assign(edition.to_opt_int()),

--- a/thoth-app/src/models/affiliation/mod.rs
+++ b/thoth-app/src/models/affiliation/mod.rs
@@ -1,3 +1,4 @@
 pub mod affiliations_query;
 pub mod create_affiliation_mutation;
 pub mod delete_affiliation_mutation;
+pub mod update_affiliation_mutation;

--- a/thoth-app/src/models/affiliation/update_affiliation_mutation.rs
+++ b/thoth-app/src/models/affiliation/update_affiliation_mutation.rs
@@ -1,0 +1,61 @@
+use serde::Deserialize;
+use serde::Serialize;
+use thoth_api::model::affiliation::AffiliationWithInstitution;
+use uuid::Uuid;
+
+const UPDATE_AFFILIATION_MUTATION: &str = "
+    mutation UpdateAffiliation(
+        $affiliationId: Uuid!,
+        $contributionId: Uuid!,
+        $institutionId: Uuid!,
+        $affiliationOrdinal: Int!
+        $position: String,
+    ) {
+        updateAffiliation(data: {
+            affiliationId: $affiliationId
+            contributionId: $contributionId
+            institutionId: $institutionId
+            affiliationOrdinal: $affiliationOrdinal
+            position: $position
+        }){
+            affiliationId
+            contributionId
+            institutionId
+            affiliationOrdinal
+            position
+            institution {
+                institutionId
+                institutionName
+                createdAt
+                updatedAt
+            }
+        }
+    }
+";
+
+graphql_query_builder! {
+    UpdateAffiliationRequest,
+    UpdateAffiliationRequestBody,
+    Variables,
+    UPDATE_AFFILIATION_MUTATION,
+    UpdateAffiliationResponseBody,
+    UpdateAffiliationResponseData,
+    PushUpdateAffiliation,
+    PushActionUpdateAffiliation
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Variables {
+    pub affiliation_id: Uuid,
+    pub contribution_id: Uuid,
+    pub institution_id: Uuid,
+    pub affiliation_ordinal: i32,
+    pub position: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateAffiliationResponseData {
+    pub update_affiliation: Option<AffiliationWithInstitution>,
+}

--- a/thoth-app/src/models/contribution/mod.rs
+++ b/thoth-app/src/models/contribution/mod.rs
@@ -47,3 +47,4 @@ impl ListString for Contribution {
 pub mod contribution_types_query;
 pub mod create_contribution_mutation;
 pub mod delete_contribution_mutation;
+pub mod update_contribution_mutation;

--- a/thoth-app/src/models/contribution/update_contribution_mutation.rs
+++ b/thoth-app/src/models/contribution/update_contribution_mutation.rs
@@ -1,0 +1,79 @@
+use serde::Deserialize;
+use serde::Serialize;
+use thoth_api::model::contribution::Contribution;
+use thoth_api::model::contribution::ContributionType;
+use uuid::Uuid;
+
+const UPDATE_CONTRIBUTION_MUTATION: &str = "
+    mutation UpdateContribution(
+        $contributionId: Uuid!,
+        $workId: Uuid!,
+        $contributorId: Uuid!,
+        $contributionType: ContributionType!,
+        $mainContribution: Boolean!,
+        $biography: String,
+        $firstName: String,
+        $lastName: String!,
+        $fullName: String!,
+        $contributionOrdinal: Int!,
+    ) {
+        updateContribution(
+            data: {
+            contributionId: $contributionId
+            workId: $workId
+            contributorId: $contributorId
+            contributionType: $contributionType
+            mainContribution: $mainContribution
+            biography: $biography
+            firstName: $firstName
+            lastName: $lastName
+            fullName: $fullName
+            contributionOrdinal: $contributionOrdinal
+        }){
+            contributionId
+            workId
+            contributorId
+            contributionType
+            mainContribution
+            biography
+            createdAt
+            updatedAt
+            firstName
+            lastName
+            fullName
+            contributionOrdinal
+        }
+    }
+";
+
+graphql_query_builder! {
+    UpdateContributionRequest,
+    UpdateContributionRequestBody,
+    Variables,
+    UPDATE_CONTRIBUTION_MUTATION,
+    UpdateContributionResponseBody,
+    UpdateContributionResponseData,
+    PushUpdateContribution,
+    PushActionUpdateContribution
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Variables {
+    pub contribution_id: Uuid,
+    pub work_id: Uuid,
+    pub contributor_id: Uuid,
+    pub contribution_type: ContributionType,
+    pub main_contribution: bool,
+    pub biography: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: String,
+    pub full_name: String,
+    pub contribution_ordinal: i32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateContributionResponseData {
+    pub update_contribution: Option<Contribution>,
+}

--- a/thoth-app/src/models/work/work_query.rs
+++ b/thoth-app/src/models/work/work_query.rs
@@ -71,6 +71,7 @@ pub const WORK_QUERY: &str = "
                 biography
                 createdAt
                 updatedAt
+                firstName
                 lastName
                 fullName
                 contributionOrdinal


### PR DESCRIPTION
Fixes #287.

This work removes the existing search bar with dynamic dropdown list for Contributors and Institutions, for simplicity and consistency with other components, and to avoid the risk of inconsistencies in the display. We should await user feedback on this before extending it to other currently non-editable components.