### PR TITLE
Feature/rust 1.62

### DIFF
--- a/thoth-api/src/model/mod.rs
+++ b/thoth-api/src/model/mod.rs
@@ -411,7 +411,7 @@ macro_rules! crud_methods {
         /// history entity record.
         fn update(
             &self,
-            db: &crate::db::PgPool,
+            db: &$crate::db::PgPool,
             data: &Self::PatchEntity,
             account_id: &Uuid,
         ) -> ThothResult<Self> {
@@ -432,7 +432,7 @@ macro_rules! crud_methods {
             })
         }
 
-        fn delete(self, db: &crate::db::PgPool) -> ThothResult<Self> {
+        fn delete(self, db: &$crate::db::PgPool) -> ThothResult<Self> {
             use diesel::{QueryDsl, RunQueryDsl};
 
             let connection = db.get().unwrap();

--- a/thoth-api/src/model/mod.rs
+++ b/thoth-api/src/model/mod.rs
@@ -384,7 +384,7 @@ where
 #[macro_export]
 macro_rules! crud_methods {
     ($table_dsl:expr, $entity_dsl:expr) => {
-        fn from_id(db: &crate::db::PgPool, entity_id: &Uuid) -> ThothResult<Self> {
+        fn from_id(db: &$crate::db::PgPool, entity_id: &Uuid) -> ThothResult<Self> {
             use diesel::{QueryDsl, RunQueryDsl};
 
             let connection = db.get().unwrap();
@@ -394,7 +394,7 @@ macro_rules! crud_methods {
             }
         }
 
-        fn create(db: &crate::db::PgPool, data: &Self::NewEntity) -> ThothResult<Self> {
+        fn create(db: &$crate::db::PgPool, data: &Self::NewEntity) -> ThothResult<Self> {
             use diesel::RunQueryDsl;
 
             let connection = db.get().unwrap();

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -36,11 +36,11 @@ macro_rules! pagination_helpers {
                         <a class="pagination-previous"
                             onclick=self.link.callback(|_| Msg::PreviousPage)
                             disabled=self.is_previous_disabled()
-                        >{ crate::string::PREVIOUS_PAGE_BUTTON }</a>
+                        >{ $crate::string::PREVIOUS_PAGE_BUTTON }</a>
                         <a class="pagination-next"
                             onclick=self.link.callback(|_| Msg::NextPage)
                             disabled=self.is_next_disabled()
-                        >{ crate::string::NEXT_PAGE_BUTTON }</a>
+                        >{ $crate::string::NEXT_PAGE_BUTTON }</a>
                         <div class="pagination-list">
                             <div class="field" style="width: 80%">
                                 <p class="control is-expanded has-icons-left">
@@ -104,8 +104,8 @@ macro_rules! pagination_component {
 
         use $crate::component::utils::Loader;
         use $crate::component::utils::Reloader;
-        use crate::models::{EditRoute, CreateRoute, MetadataTable};
-        use crate::route::AppRoute;
+        use $crate::models::{EditRoute, CreateRoute, MetadataTable};
+        use $crate::route::AppRoute;
 
         pub struct $component {
             limit: i32,

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -1,8 +1,8 @@
 #[macro_export]
 macro_rules! pagination_helpers {
     ($component:ident, $pagination_text:ident, $search_text:ident) => {
-        use crate::string::$pagination_text;
-        use crate::string::$search_text;
+        use $crate::string::$pagination_text;
+        use $crate::string::$search_text;
 
         impl $component {
             fn search_text(&self) -> String {
@@ -102,8 +102,8 @@ macro_rules! pagination_component {
         use yewtil::future::LinkFuture;
         use yewtil::NeqAssign;
 
-        use crate::component::utils::Loader;
-        use crate::component::utils::Reloader;
+        use $crate::component::utils::Loader;
+        use $crate::component::utils::Reloader;
         use crate::models::{EditRoute, CreateRoute, MetadataTable};
         use crate::route::AppRoute;
 

--- a/thoth-app/src/models/mod.rs
+++ b/thoth-app/src/models/mod.rs
@@ -16,7 +16,7 @@ macro_rules! graphql_query_builder {
         use yewtil::fetch::Json;
         use yewtil::fetch::MethodBody;
 
-        use crate::THOTH_GRAPHQL_API;
+        use $crate::THOTH_GRAPHQL_API;
 
         pub type $fetch = Fetch<$request, $response_body>;
         pub type $fetch_action = FetchAction<$response_body>;
@@ -51,7 +51,7 @@ macro_rules! graphql_query_builder {
             }
 
             fn headers(&self) -> Vec<(String, String)> {
-                use crate::service::account::AccountService;
+                use $crate::service::account::AccountService;
 
                 let account_service = AccountService::new();
                 let json = ("Content-Type".into(), "application/json".into());


### PR DESCRIPTION
Fix `'crate' references the macro call's crate` warnings.

`this lifetime isn't used in the impl` originate inside derive macros and are supposedly fixed in https://github.com/rust-lang/rust-clippy/pull/9043