### PR TITLE
Upgrade packages flagged in Dependabot alerts (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
   - [#379](https://github.com/thoth-pub/thoth/issues/379) - Limit to 6 the number of ISBNs offered in CrossRef metadata export
+  - [#388](https://github.com/thoth-pub/thoth/issues/388) - Upgrade packages flagged in Dependabot alerts
 
 ## [[0.8.6]](https://github.com/thoth-pub/thoth/releases/tag/v0.8.6) - 2022-07-01
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.33"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,7 +2175,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -2235,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.3"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7cc03b910de9935007861dce440881f69102aaaedfd4bc5a6f40340ca5840c"
+checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2419,7 +2419,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "url 1.7.2",
+ "url 2.2.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
  "firestorm",
  "http 0.2.6",
  "log",
- "regex 1.5.4",
+ "regex",
  "serde",
 ]
 
@@ -190,7 +190,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite",
- "regex 1.5.4",
+ "regex",
  "serde",
  "serde_json",
  "serde_urlencoded 0.7.0",
@@ -277,15 +277,6 @@ dependencies = [
  "getrandom 0.2.2",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -738,7 +729,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "libc",
  "parking_lot 0.12.0",
- "regex 1.5.4",
+ "regex",
  "termios",
  "unicode-width",
  "winapi 0.3.9",
@@ -753,7 +744,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static 1.4.0",
  "libc",
- "regex 1.5.4",
+ "regex",
  "terminal_size",
  "unicode-width",
  "winapi 0.3.9",
@@ -1118,12 +1109,9 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 
 [[package]]
 name = "dotenv"
-version = "0.9.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400b347fe65ccfbd8f545c9d9a75d04b0caf23fec49aaa838a9a05398f94c019"
-dependencies = [
- "regex 0.2.11",
-]
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"
@@ -1173,7 +1161,7 @@ dependencies = [
  "atty",
  "humantime",
  "log",
- "regex 1.5.4",
+ "regex",
  "termcolor",
 ]
 
@@ -2388,7 +2376,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
 dependencies = [
- "regex 1.5.4",
+ "regex",
 ]
 
 [[package]]
@@ -2450,7 +2438,7 @@ dependencies = [
  "paperclip-macros",
  "parking_lot 0.12.0",
  "pin-project",
- "regex 1.5.4",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2586,7 +2574,7 @@ checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
 dependencies = [
  "base64 0.12.3",
  "once_cell",
- "regex 1.5.4",
+ "regex",
 ]
 
 [[package]]
@@ -2782,7 +2770,7 @@ dependencies = [
  "error-chain",
  "idna 0.2.0",
  "lazy_static 1.4.0",
- "regex 1.5.4",
+ "regex",
  "url 2.2.2",
 ]
 
@@ -3081,26 +3069,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick 0.6.10",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick 0.7.18",
+ "aho-corasick",
  "memchr",
- "regex-syntax 0.6.25",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3110,15 +3085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
 ]
 
 [[package]]
@@ -3821,7 +3787,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "phf",
  "rand 0.7.3",
- "regex 1.5.4",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3925,15 +3891,6 @@ dependencies = [
  "thoth-errors",
  "uuid 0.7.4",
  "xml-rs",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -4226,12 +4183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
-name = "ucd-util"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccdc2daea7cf8bc50cd8710d170a9d816678e54943829c5082bb1594312cf8e"
-
-[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4329,12 +4280,6 @@ dependencies = [
  "matches",
  "percent-encoding 2.1.0",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,9 +326,9 @@ checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.4"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "argon2rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3089,9 +3089,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,9 +2031,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "local-channel"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils 0.7.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ thoth-errors = { version = "0.8.6", path = "thoth-errors" }
 thoth-export-server = { version = "0.8.6", path = "thoth-export-server" }
 clap = "2.33.3"
 dialoguer = "0.7.1"
-dotenv = "0.9.0"
+dotenv = "0.15.0"
 
 [dev-dependencies]
 cargo-husky = { version = "1.5.0", default-features = false, features = ["prepush-hook", "run-cargo-check", "run-cargo-test", "run-cargo-clippy", "run-cargo-fmt"] }

--- a/thoth-api/Cargo.toml
+++ b/thoth-api/Cargo.toml
@@ -32,7 +32,7 @@ juniper = "0.14.2"
 lazy_static = "1.4.0"
 phf = { version = "0.8", features = ["macros"] }
 rand = "0.7.3"
-regex = "1.4.1"
+regex = "1.6.0"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/thoth-api/Cargo.toml
+++ b/thoth-api/Cargo.toml
@@ -21,7 +21,7 @@ actix-web = { version = "4.0.1", optional = true }
 argon2rs = "0.2.5"
 isbn2 = "0.4.0"
 chrono = { version = "0.4", features = ["serde"] }
-diesel = { version = "1.4.0", features = ["postgres", "uuidv07", "chrono", "r2d2", "64-column-tables", "serde_json"], optional = true }
+diesel = { version = "1.4.8", features = ["postgres", "uuidv07", "chrono", "r2d2", "64-column-tables", "serde_json"], optional = true }
 diesel-derive-enum = { version = "1.1.0", features = ["postgres"], optional = true }
 diesel-derive-newtype = "0.1"
 diesel_migrations = { version = "1.4.0", features = ["postgres"], optional = true }

--- a/thoth-api/Cargo.toml
+++ b/thoth-api/Cargo.toml
@@ -25,7 +25,7 @@ diesel = { version = "1.4.8", features = ["postgres", "uuidv07", "chrono", "r2d2
 diesel-derive-enum = { version = "1.1.0", features = ["postgres"], optional = true }
 diesel-derive-newtype = "0.1"
 diesel_migrations = { version = "1.4.0", features = ["postgres"], optional = true }
-dotenv = "0.9.0"
+dotenv = "0.15.0"
 futures = { version  = "0.3.5", optional = true }
 jsonwebtoken = "7.2.0"
 juniper = "0.14.2"

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -16,7 +16,7 @@ uuid = { version = "0.7", features = ["serde", "v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 actix-web = "4.0.1"
-diesel = "1.4.0"
+diesel = "1.4.8"
 csv = "1.1.6"
 juniper = "0.14.2"
 xml-rs = "0.8.0"


### PR DESCRIPTION
Part-fixes #388. Alerts that cannot yet be fixed are listed in [a comment on the issue](https://github.com/thoth-pub/thoth/issues/388#issuecomment-1176016793).