### PR TITLE
Upgrade graphql_client to v0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,6 +3953,7 @@ dependencies = [
  "serde",
  "thiserror",
  "uuid 0.7.4",
+ "uuid 0.8.2",
  "xml-rs",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,12 +1108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
-
-[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,30 +1587,29 @@ dependencies = [
 
 [[package]]
 name = "graphql-introspection-query"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610aac641dbd2a457ad4cef34aa2827dae3f035fd214cb38c2d62d8543f3973f"
+checksum = "7f2a4732cf5140bd6c082434494f785a19cfb566ab07d1382c3671f5812fed6d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "graphql-parser"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
- "failure",
+ "thiserror",
 ]
 
 [[package]]
 name = "graphql_client"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bb4f09181e4f80018d01c612125b07e0156f3753bfac37055fe2a25e031ca8"
+checksum = "7fc16d75d169fddb720d8f1c7aed6413e329e1584079b9734ff07266a193f5bc"
 dependencies = [
- "doc-comment",
  "graphql_query_derive",
  "serde",
  "serde_json",
@@ -1624,14 +1617,13 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e304c223c809b3bff4614018f8e6d9edb176b31d64ed9ea48b6ae8b1a03abb9"
+checksum = "f290ecfa3bea3e8a157899dc8a1d96ee7dd6405c18c8ddd213fc58939d18a0e9"
 dependencies = [
- "failure",
  "graphql-introspection-query",
  "graphql-parser",
- "heck 0.3.1",
+ "heck 0.4.0",
  "lazy_static 1.4.0",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -1642,11 +1634,10 @@ dependencies = [
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f6b14d5ce549227aa9e649cd9d36d008b91021275a8e0a67d71cef815adc2f"
+checksum = "a755cc59cda2641ea3037b4f9f7ef40471c329f55c1fa2db6fa0bb7ae6c1f7ce"
 dependencies = [
- "failure",
  "graphql_client_codegen",
  "proc-macro2 1.0.36",
  "syn 1.0.72",
@@ -2513,7 +2504,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "uuid 0.7.4",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3947,7 +3938,7 @@ dependencies = [
  "serde_json",
  "thoth-api",
  "thoth-errors",
- "uuid 0.7.4",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3982,7 +3973,7 @@ dependencies = [
  "thoth-api",
  "thoth-client",
  "thoth-errors",
- "uuid 0.7.4",
+ "uuid 0.8.2",
  "xml-rs",
 ]
 
@@ -4391,6 +4382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.2",
+ "serde",
 ]
 
 [[package]]

--- a/thoth-client/Cargo.toml
+++ b/thoth-client/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 [dependencies]
 thoth-api = {version = "0.8.7", path = "../thoth-api" }
 thoth-errors = {version = "0.8.7", path = "../thoth-errors" }
-graphql_client = "0.9.0"
+graphql_client = "0.11.0"
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
-uuid = { version = "0.7", features = ["serde"] }
+uuid = { version = "0.8.2", features = ["serde"] }

--- a/thoth-client/src/lib.rs
+++ b/thoth-client/src/lib.rs
@@ -64,7 +64,7 @@ impl ThothClient {
         let res = self.post_request(&request_body).await.await?;
         let response_body: Response<work_query::ResponseData> = res.json().await?;
         match response_body.data {
-            Some(data) => Ok(data.work.work),
+            Some(data) => Ok(data.work),
             None => Err(ThothError::EntityNotFound),
         }
     }
@@ -94,7 +94,7 @@ impl ThothClient {
         let res = self.post_request(&request_body).await.await?;
         let response_body: Response<works_query::ResponseData> = res.json().await?;
         match response_body.data {
-            Some(data) => Ok(data.works.iter().map(|w| w.work.clone().into()).collect()), // convert works_query::Work into work_query::Work
+            Some(data) => Ok(data.works.iter().map(|w| w.clone().into()).collect()), // convert works_query::Work into work_query::Work
             None => Err(ThothError::EntityNotFound),
         }
     }

--- a/thoth-client/src/queries.rs
+++ b/thoth-client/src/queries.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 #[graphql(
     schema_path = "assets/schema.json",
     query_path = "assets/queries.graphql",
-    response_derives = "Debug,Clone,Deserialize,Serialize"
+    response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq"
 )]
 pub struct WorkQuery;
 
@@ -26,7 +26,7 @@ impl fmt::Display for work_query::LanguageCode {
 #[graphql(
     schema_path = "assets/schema.json",
     query_path = "assets/queries.graphql",
-    response_derives = "Debug,Clone,Deserialize,Serialize"
+    response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq"
 )]
 pub struct WorksQuery;
 

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 thiserror = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0.115"
-uuid = { version = "0.7", features = ["serde", "v4"] }
+uuid-07 = { package = "uuid", version = "0.7", features = ["serde", "v4"] }
+uuid-08 = { package = "uuid", version = "0.8.2", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 actix-web = "4.0.1"

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -13,7 +13,6 @@ thiserror = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0.115"
 uuid-07 = { package = "uuid", version = "0.7", features = ["serde", "v4"] }
-uuid-08 = { package = "uuid", version = "0.8.2", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 actix-web = "4.0.1"
@@ -21,4 +20,5 @@ diesel = "1.4.8"
 csv = "1.1.6"
 juniper = "0.14.2"
 xml-rs = "0.8.0"
+uuid-08 = { package = "uuid", version = "0.8.2", features = ["serde"] }
 

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -172,8 +172,14 @@ impl From<xml::writer::Error> for ThothError {
     }
 }
 
-impl From<uuid::parser::ParseError> for ThothError {
-    fn from(_: uuid::parser::ParseError) -> ThothError {
+impl From<uuid_07::parser::ParseError> for ThothError {
+    fn from(_: uuid_07::parser::ParseError) -> ThothError {
+        ThothError::InvalidUuid
+    }
+}
+
+impl From<uuid_08::Error> for ThothError {
+    fn from(_: uuid_08::Error) -> ThothError {
         ThothError::InvalidUuid
     }
 }
@@ -198,7 +204,11 @@ mod tests {
     #[test]
     fn test_uuid_error() {
         assert_eq!(
-            ThothError::from(uuid::Uuid::parse_str("not-a-uuid").unwrap_err()),
+            ThothError::from(uuid_07::Uuid::parse_str("not-a-uuid").unwrap_err()),
+            ThothError::InvalidUuid
+        );
+        assert_eq!(
+            ThothError::from(uuid_08::Uuid::parse_str("not-a-uuid").unwrap_err()),
             ThothError::InvalidUuid
         );
     }

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -178,6 +178,7 @@ impl From<uuid_07::parser::ParseError> for ThothError {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<uuid_08::Error> for ThothError {
     fn from(_: uuid_08::Error) -> ThothError {
         ThothError::InvalidUuid

--- a/thoth-export-server/Cargo.toml
+++ b/thoth-export-server/Cargo.toml
@@ -22,5 +22,5 @@ log = "0.4.14"
 paperclip = { version = "0.7.0", features = ["actix-base", "actix4", "uuid", "v2"] }
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "0.7", features = ["serde"] }
+uuid = { version = "0.8.2", features = ["serde"] }
 xml-rs = "0.8.0"


### PR DESCRIPTION
Upgrading `graphql_client` removes their previous dependency on `failure`. After merging this PR and #407 the only package that depends on `failure` will be `wasm_pack` (and its dependencies `binary-install`, `cookie_store`, and `which`)