### PR TITLE
Ignore clippy warning extra_unused_lifetimes

### DIFF
--- a/thoth-api/src/lib.rs
+++ b/thoth-api/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::extra_unused_lifetimes)]
+
 #[cfg(feature = "backend")]
 #[macro_use]
 extern crate diesel;


### PR DESCRIPTION
Ignore `extra_unused_lifetimes` warning until [clippy's fix](https://github.com/rust-lang/rust-clippy/issues/9014) for the false positive is live