### PR TITLE
Feature/429 incomplete status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
   - [#425](https://github.com/thoth-pub/thoth/issues/425) - Fix typo in contribution type illustrator
+  - [#429](https://github.com/thoth-pub/thoth/issues/429) - Incomplete metadata record errors are now returned as a 404 instead of 500
   - Added derives for `Eq` alongside `PartialEq` to comply with [`rustc 1.63.0`](https://github.com/rust-lang/rust/releases/tag/1.63.0)
   - Upgrade rust to `1.63.0` in development `Dockerfile`
 

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -120,6 +120,9 @@ impl actix_web::error::ResponseError for ThothError {
             ThothError::DatabaseError { .. } => {
                 HttpResponse::InternalServerError().json("DB error")
             }
+            ThothError::IncompleteMetadataRecord(_, _) => {
+                HttpResponse::NotFound().json(self.to_string())
+            }
             _ => HttpResponse::InternalServerError().json(self.to_string()),
         }
     }

--- a/thoth-export-server/src/xml/doideposit_crossref.rs
+++ b/thoth-export-server/src/xml/doideposit_crossref.rs
@@ -1188,7 +1188,8 @@ mod tests {
         let output = generate_test_output(false, &test_work);
         assert_eq!(
             output,
-            "Could not generate doideposit::crossref: This work does not have any ISBNs".to_string()
+            "Could not generate doideposit::crossref: This work does not have any ISBNs"
+                .to_string()
         );
     }
 

--- a/thoth-export-server/src/xml/doideposit_crossref.rs
+++ b/thoth-export-server/src/xml/doideposit_crossref.rs
@@ -277,7 +277,7 @@ fn work_metadata<W: Write>(
             // element with a `reason` attribute - assume missing ISBNs are erroneous
             return Err(ThothError::IncompleteMetadataRecord(
                 "doideposit::crossref".to_string(),
-                "No ISBNs provided".to_string(),
+                "Missing ISBNs".to_string(),
             ));
         }
         write_element_block("publisher", w, |w| {
@@ -1188,7 +1188,7 @@ mod tests {
         let output = generate_test_output(false, &test_work);
         assert_eq!(
             output,
-            "Could not generate doideposit::crossref: No ISBNs provided".to_string()
+            "Could not generate doideposit::crossref: Missing ISBNs".to_string()
         );
     }
 

--- a/thoth-export-server/src/xml/doideposit_crossref.rs
+++ b/thoth-export-server/src/xml/doideposit_crossref.rs
@@ -277,7 +277,7 @@ fn work_metadata<W: Write>(
             // element with a `reason` attribute - assume missing ISBNs are erroneous
             return Err(ThothError::IncompleteMetadataRecord(
                 "doideposit::crossref".to_string(),
-                "Missing ISBNs".to_string(),
+                "This work does not have any ISBNs".to_string(),
             ));
         }
         write_element_block("publisher", w, |w| {
@@ -1188,7 +1188,7 @@ mod tests {
         let output = generate_test_output(false, &test_work);
         assert_eq!(
             output,
-            "Could not generate doideposit::crossref: Missing ISBNs".to_string()
+            "Could not generate doideposit::crossref: This work does not have any ISBNs".to_string()
         );
     }
 

--- a/thoth-export-server/src/xml/onix3_google_books.rs
+++ b/thoth-export-server/src/xml/onix3_google_books.rs
@@ -107,7 +107,7 @@ impl XmlElementBlock<Onix3GoogleBooks> for Work {
                 // Google Books requires at least one ProductIdentifier block with an ISBN type
                 return Err(ThothError::IncompleteMetadataRecord(
                     "onix_3.0::google_books".to_string(),
-                    "Missing ISBN".to_string(),
+                    "This work does not have a PDF, EPUB or paperback ISBN".to_string(),
                 ));
             }
             write_element_block("Product", w, |w| {
@@ -1128,7 +1128,7 @@ mod tests {
         let output = generate_test_output(false, &test_work);
         assert_eq!(
             output,
-            "Could not generate onix_3.0::google_books: Missing ISBN".to_string()
+            "Could not generate onix_3.0::google_books: This work does not have a PDF, EPUB or paperback ISBN".to_string()
         );
 
         // Replace ISBN but remove all contributors: result is error

--- a/thoth-export-server/src/xml/onix3_google_books.rs
+++ b/thoth-export-server/src/xml/onix3_google_books.rs
@@ -107,7 +107,7 @@ impl XmlElementBlock<Onix3GoogleBooks> for Work {
                 // Google Books requires at least one ProductIdentifier block with an ISBN type
                 return Err(ThothError::IncompleteMetadataRecord(
                     "onix_3.0::google_books".to_string(),
-                    "No ISBN supplied".to_string(),
+                    "Missing ISBN".to_string(),
                 ));
             }
             write_element_block("Product", w, |w| {
@@ -1128,7 +1128,7 @@ mod tests {
         let output = generate_test_output(false, &test_work);
         assert_eq!(
             output,
-            "Could not generate onix_3.0::google_books: No ISBN supplied".to_string()
+            "Could not generate onix_3.0::google_books: Missing ISBN".to_string()
         );
 
         // Replace ISBN but remove all contributors: result is error


### PR DESCRIPTION
Respond with a 404 when a metadata record cannot be exported because of insufficient metadata (fixes #429).

Rename "No ISBN provided" errors to "Missing ISBN", as "provided" could be understood as a client error