### PR TITLE
Use directives in graphql client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+  - [#438](https://github.com/thoth-pub/thoth/issues/438) - Allow specifying query parameters based on the requested specification
 
 ## [[0.8.9]](https://github.com/thoth-pub/thoth/releases/tag/v0.8.9) - 2022-09-21
 ### Added

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::let_unit_value)]
+
 #[macro_export]
 macro_rules! pagination_helpers {
     ($component:ident, $pagination_text:ident, $search_text:ident) => {

--- a/thoth-client/assets/queries.graphql
+++ b/thoth-client/assets/queries.graphql
@@ -116,7 +116,7 @@ fragment Work on Work {
             countryCode
         }
     }
-    relations {
+    relations @include(if: $withRelations) {
         relationType
         relationOrdinal
         relatedWork {
@@ -157,12 +157,12 @@ fragment Work on Work {
     }
 }
 
-query WorkQuery($workId: Uuid!) {
+query WorkQuery($workId: Uuid!, $withRelations: Boolean!) {
     work(workId: $workId) {
         ...Work
     }
 }
-query WorksQuery($publishers: [Uuid!]) {
+query WorksQuery($publishers: [Uuid!], $withRelations: Boolean!) {
     works(limit: 99999, publishers: $publishers) {
         ...Work
     }

--- a/thoth-client/assets/queries.graphql
+++ b/thoth-client/assets/queries.graphql
@@ -36,7 +36,7 @@ fragment Work on Work {
             publisherUrl
         }
     }
-    issues {
+    issues(limit: $issuesLimit) {
         issueOrdinal
         series {
             seriesType
@@ -67,12 +67,12 @@ fragment Work on Work {
             }
         }
     }
-    languages {
+    languages(limit: $languagesLimit) {
         languageCode
         languageRelation
         mainLanguage
     }
-    publications {
+    publications(limit: $publicationsLimit) {
         publicationId
         publicationType
         isbn
@@ -98,12 +98,12 @@ fragment Work on Work {
             canonical
         }
     }
-    subjects {
+    subjects(limit: $subjectsLimit) {
         subjectCode
         subjectType
         subjectOrdinal
     }
-    fundings {
+    fundings(limit: $fundingsLimit) {
         program
         projectName
         projectShortname
@@ -116,7 +116,7 @@ fragment Work on Work {
             countryCode
         }
     }
-    relations @include(if: $withRelations) {
+    relations(limit: $relationsLimit) {
         relationType
         relationOrdinal
         relatedWork {
@@ -157,12 +157,28 @@ fragment Work on Work {
     }
 }
 
-query WorkQuery($workId: Uuid!, $withRelations: Boolean!) {
+query WorkQuery(
+    $workId: Uuid!,
+    $issuesLimit: Int!,
+    $languagesLimit: Int!,
+    $publicationsLimit: Int!,
+    $subjectsLimit: Int!,
+    $fundingsLimit: Int!,
+    $relationsLimit: Int!
+) {
     work(workId: $workId) {
         ...Work
     }
 }
-query WorksQuery($publishers: [Uuid!], $withRelations: Boolean!) {
+query WorksQuery(
+    $publishers: [Uuid!],
+    $issuesLimit: Int!,
+    $languagesLimit: Int!,
+    $publicationsLimit: Int!,
+    $subjectsLimit: Int!,
+    $fundingsLimit: Int!,
+    $relationsLimit: Int!
+) {
     works(limit: 99999, publishers: $publishers) {
         ...Work
     }

--- a/thoth-client/src/lib.rs
+++ b/thoth-client/src/lib.rs
@@ -59,7 +59,7 @@ impl ThothClient {
     /// # async fn run() -> ThothResult<Work> {
     /// let thoth_client = ThothClient::new("https://api.thoth.pub/graphql".to_string());
     /// let work_id = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001")?;
-    /// let work = thoth_client.get_work(work_id, QueryParameters::all_on()).await?;
+    /// let work = thoth_client.get_work(work_id, QueryParameters::new()).await?;
     /// # Ok(work)
     /// # }
     /// ```
@@ -90,7 +90,7 @@ impl ThothClient {
     /// # async fn run() -> ThothResult<Vec<Work>> {
     /// let thoth_client = ThothClient::new("https://api.thoth.pub/graphql".to_string());
     /// let publisher_id = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001")?;
-    /// let works = thoth_client.get_works(Some(vec![publisher_id]), QueryParameters::all_off()).await?;
+    /// let works = thoth_client.get_works(Some(vec![publisher_id]), QueryParameters::new()).await?;
     /// # Ok(works)
     /// # }
     /// ```

--- a/thoth-client/src/lib.rs
+++ b/thoth-client/src/lib.rs
@@ -56,12 +56,12 @@ impl ThothClient {
     /// # async fn run() -> ThothResult<Work> {
     /// let thoth_client = ThothClient::new("https://api.thoth.pub/graphql".to_string());
     /// let work_id = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001")?;
-    /// let work = thoth_client.get_work(work_id).await?;
+    /// let work = thoth_client.get_work(work_id, false).await?;
     /// # Ok(work)
     /// # }
     /// ```
-    pub async fn get_work(&self, work_id: Uuid) -> ThothResult<Work> {
-        let request_body = WorkQuery::build_query(work_query::Variables { work_id });
+    pub async fn get_work(&self, work_id: Uuid, with_relations: bool) -> ThothResult<Work> {
+        let request_body = WorkQuery::build_query(work_query::Variables { work_id, with_relations });
         let res = self.post_request(&request_body).await.await?;
         let response_body: Response<work_query::ResponseData> = res.json().await?;
         match response_body.data {
@@ -86,12 +86,16 @@ impl ThothClient {
     /// # async fn run() -> ThothResult<Vec<Work>> {
     /// let thoth_client = ThothClient::new("https://api.thoth.pub/graphql".to_string());
     /// let publisher_id = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001")?;
-    /// let works = thoth_client.get_works(Some(vec![publisher_id])).await?;
+    /// let works = thoth_client.get_works(Some(vec![publisher_id]), false).await?;
     /// # Ok(works)
     /// # }
     /// ```
-    pub async fn get_works(&self, publishers: Option<Vec<Uuid>>) -> ThothResult<Vec<Work>> {
-        let request_body = WorksQuery::build_query(works_query::Variables { publishers });
+    pub async fn get_works(
+        &self,
+        publishers: Option<Vec<Uuid>>,
+        with_relations: bool,
+    ) -> ThothResult<Vec<Work>> {
+        let request_body = WorksQuery::build_query(works_query::Variables { publishers, with_relations });
         let res = self.post_request(&request_body).await.await?;
         let response_body: Response<works_query::ResponseData> = res.json().await?;
         match response_body.data {

--- a/thoth-client/src/lib.rs
+++ b/thoth-client/src/lib.rs
@@ -1,7 +1,7 @@
+mod parameters;
 // GraphQLQuery derive macro breaks this linting rule - ignore while awaiting fix
 #[allow(clippy::derive_partial_eq_without_eq)]
 mod queries;
-mod parameters;
 
 use graphql_client::GraphQLQuery;
 use graphql_client::Response;
@@ -10,10 +10,10 @@ use std::future::Future;
 use thoth_errors::{ThothError, ThothResult};
 use uuid::Uuid;
 
+pub use crate::parameters::QueryParameters;
+use crate::parameters::{WorkQueryVariables, WorksQueryVariables};
 pub use crate::queries::work_query::*;
 use crate::queries::{work_query, works_query, WorkQuery, WorksQuery};
-pub use crate::parameters::QueryParameters;
-use crate::parameters::{WorksQueryVariables, WorkQueryVariables};
 
 type HttpFuture = Result<reqwest::Response, reqwest::Error>;
 
@@ -99,7 +99,8 @@ impl ThothClient {
         publishers: Option<Vec<Uuid>>,
         parameters: QueryParameters,
     ) -> ThothResult<Vec<Work>> {
-        let variables: works_query::Variables = WorksQueryVariables::new(publishers, parameters).into();
+        let variables: works_query::Variables =
+            WorksQueryVariables::new(publishers, parameters).into();
         let request_body = WorksQuery::build_query(variables);
         let res = self.post_request(&request_body).await.await?;
         let response_body: Response<works_query::ResponseData> = res.json().await?;

--- a/thoth-client/src/lib.rs
+++ b/thoth-client/src/lib.rs
@@ -61,7 +61,10 @@ impl ThothClient {
     /// # }
     /// ```
     pub async fn get_work(&self, work_id: Uuid, with_relations: bool) -> ThothResult<Work> {
-        let request_body = WorkQuery::build_query(work_query::Variables { work_id, with_relations });
+        let request_body = WorkQuery::build_query(work_query::Variables {
+            work_id,
+            with_relations,
+        });
         let res = self.post_request(&request_body).await.await?;
         let response_body: Response<work_query::ResponseData> = res.json().await?;
         match response_body.data {
@@ -95,7 +98,10 @@ impl ThothClient {
         publishers: Option<Vec<Uuid>>,
         with_relations: bool,
     ) -> ThothResult<Vec<Work>> {
-        let request_body = WorksQuery::build_query(works_query::Variables { publishers, with_relations });
+        let request_body = WorksQuery::build_query(works_query::Variables {
+            publishers,
+            with_relations,
+        });
         let res = self.post_request(&request_body).await.await?;
         let response_body: Response<works_query::ResponseData> = res.json().await?;
         match response_body.data {

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -305,7 +305,7 @@ mod tests {
         let publishers = Some(vec![publisher_id]);
         let mut parameters = QueryParameters::new().with_all();
         let mut variables: works_query::Variables =
-            WorksQueryVariables::new(publishers, parameters).into();
+            WorksQueryVariables::new(publishers.clone(), parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -188,7 +188,7 @@ mod tests {
     use crate::queries::{work_query, works_query};
     use thoth_api::model::language::LanguageCode::Que;
 
-    const work_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001")?;
+    const work_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001").unwrap();
     const publishers: Option<Vec<Uuid>> = Some(vec![work_id]);
 
     #[test]

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -1,5 +1,5 @@
-use uuid::Uuid;
 use crate::queries::{work_query, works_query};
+use uuid::Uuid;
 
 /// A set of booleans to toggle directives in the GraphQL queries
 pub struct QueryParameters {
@@ -27,7 +27,7 @@ impl WorkQueryVariables {
     pub(crate) fn new(work_id: Uuid, parameters: QueryParameters) -> Self {
         WorkQueryVariables {
             work_id,
-            parameters
+            parameters,
         }
     }
 }
@@ -36,7 +36,7 @@ impl WorksQueryVariables {
     pub(crate) fn new(publishers: Option<Vec<Uuid>>, parameters: QueryParameters) -> Self {
         WorksQueryVariables {
             publishers,
-            parameters
+            parameters,
         }
     }
 }
@@ -94,11 +94,23 @@ impl From<WorkQueryVariables> for work_query::Variables {
         work_query::Variables {
             work_id: v.work_id,
             issues_limit: if v.parameters.with_issues { 99999 } else { 0 },
-            languages_limit: if v.parameters.with_languages { 99999 } else { 0 },
-            publications_limit: if v.parameters.with_publications { 99999 } else { 0 },
+            languages_limit: if v.parameters.with_languages {
+                99999
+            } else {
+                0
+            },
+            publications_limit: if v.parameters.with_publications {
+                99999
+            } else {
+                0
+            },
             subjects_limit: if v.parameters.with_subjects { 99999 } else { 0 },
             fundings_limit: if v.parameters.with_fundings { 99999 } else { 0 },
-            relations_limit: if v.parameters.with_relations { 99999 } else { 0 },
+            relations_limit: if v.parameters.with_relations {
+                99999
+            } else {
+                0
+            },
         }
     }
 }
@@ -108,11 +120,23 @@ impl From<WorksQueryVariables> for works_query::Variables {
         works_query::Variables {
             publishers: v.publishers,
             issues_limit: if v.parameters.with_issues { 99999 } else { 0 },
-            languages_limit: if v.parameters.with_languages { 99999 } else { 0 },
-            publications_limit: if v.parameters.with_publications { 99999 } else { 0 },
+            languages_limit: if v.parameters.with_languages {
+                99999
+            } else {
+                0
+            },
+            publications_limit: if v.parameters.with_publications {
+                99999
+            } else {
+                0
+            },
             subjects_limit: if v.parameters.with_subjects { 99999 } else { 0 },
             fundings_limit: if v.parameters.with_fundings { 99999 } else { 0 },
-            relations_limit: if v.parameters.with_relations { 99999 } else { 0 },
+            relations_limit: if v.parameters.with_relations {
+                99999
+            } else {
+                0
+            },
         }
     }
 }

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -334,7 +334,7 @@ mod tests {
             }
         );
         parameters = QueryParameters::new().with_all().without_relations();
-        variables = WorskQueryVariables::new(publishers, parameters).into();
+        variables = WorksQueryVariables::new(publishers, parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -184,6 +184,11 @@ impl From<WorksQueryVariables> for works_query::Variables {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::queries::{work_query, works_query};
+    use thoth_api::model::language::LanguageCode::Que;
+
+    const work_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001")?;
+    const publishers: Option<Vec<Uuid>> = Some(vec![work_id]);
 
     #[test]
     fn test_default_query_parameters() {
@@ -246,6 +251,100 @@ mod tests {
                 with_fundings: true,
                 with_relations: true
             },
+        );
+    }
+
+    #[test]
+    fn test_convert_parameters_to_work_query_variables() {
+        let mut parameters = QueryParameters::new().with_all();
+        let mut variables: work_query::Variables =
+            WorkQueryVariables::new(work_id, parameters).into();
+        assert_eq!(
+            variables,
+            work_query::Variables {
+                work_id,
+                issues_limit: 99999,
+                languages_limit: 99999,
+                publications_limit: 99999,
+                subjects_limit: 99999,
+                fundings_limit: 99999,
+                relations_limit: 99999,
+            }
+        );
+        parameters = QueryParameters::new();
+        variables = WorkQueryVariables::new(work_id, parameters).into();
+        assert_eq!(
+            variables,
+            work_query::Variables {
+                work_id,
+                issues_limit: 0,
+                languages_limit: 0,
+                publications_limit: 0,
+                subjects_limit: 0,
+                fundings_limit: 0,
+                relations_limit: 0,
+            }
+        );
+        parameters = QueryParameters::new().with_all().without_relations();
+        variables = WorkQueryVariables::new(work_id, parameters).into();
+        assert_eq!(
+            variables,
+            work_query::Variables {
+                work_id,
+                issues_limit: 99999,
+                languages_limit: 99999,
+                publications_limit: 99999,
+                subjects_limit: 99999,
+                fundings_limit: 99999,
+                relations_limit: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn test_convert_parameters_to_works_query_variables() {
+        let mut parameters = QueryParameters::new().with_all();
+        let mut variables: works_query::Variables =
+            WorksQueryVariables::new(publishers, parameters).into();
+        assert_eq!(
+            variables,
+            works_query::Variables {
+                publishers,
+                issues_limit: 99999,
+                languages_limit: 99999,
+                publications_limit: 99999,
+                subjects_limit: 99999,
+                fundings_limit: 99999,
+                relations_limit: 99999,
+            }
+        );
+        parameters = QueryParameters::new();
+        variables = WorksQueryVariables::new(publishers, parameters).into();
+        assert_eq!(
+            variables,
+            works_query::Variables {
+                publishers,
+                issues_limit: 0,
+                languages_limit: 0,
+                publications_limit: 0,
+                subjects_limit: 0,
+                fundings_limit: 0,
+                relations_limit: 0,
+            }
+        );
+        parameters = QueryParameters::new().with_all().without_relations();
+        variables = WorskQueryVariables::new(publishers, parameters).into();
+        assert_eq!(
+            variables,
+            works_query::Variables {
+                publishers,
+                issues_limit: 99999,
+                languages_limit: 99999,
+                publications_limit: 99999,
+                subjects_limit: 99999,
+                fundings_limit: 99999,
+                relations_limit: 0,
+            }
         );
     }
 }

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -2,6 +2,7 @@ use crate::queries::{work_query, works_query};
 use uuid::Uuid;
 
 /// A set of booleans to toggle directives in the GraphQL queries
+#[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Default)]
 pub struct QueryParameters {
     with_issues: bool,

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -130,27 +130,42 @@ impl QueryParameters {
     }
 }
 
+const FILTER_INCLUDE_ALL: i64 = 99999;
+const FILTER_INCLUDE_NONE: i64 = 0;
+
 impl From<WorkQueryVariables> for work_query::Variables {
     fn from(v: WorkQueryVariables) -> Self {
         work_query::Variables {
             work_id: v.work_id,
-            issues_limit: if v.parameters.with_issues { 99999 } else { 0 },
-            languages_limit: if v.parameters.with_languages {
-                99999
+            issues_limit: if v.parameters.with_issues {
+                FILTER_INCLUDE_ALL
             } else {
-                0
+                FILTER_INCLUDE_NONE
+            },
+            languages_limit: if v.parameters.with_languages {
+                FILTER_INCLUDE_ALL
+            } else {
+                FILTER_INCLUDE_NONE
             },
             publications_limit: if v.parameters.with_publications {
-                99999
+                FILTER_INCLUDE_ALL
             } else {
-                0
+                FILTER_INCLUDE_NONE
             },
-            subjects_limit: if v.parameters.with_subjects { 99999 } else { 0 },
-            fundings_limit: if v.parameters.with_fundings { 99999 } else { 0 },
-            relations_limit: if v.parameters.with_relations {
-                99999
+            subjects_limit: if v.parameters.with_subjects {
+                FILTER_INCLUDE_ALL
             } else {
-                0
+                FILTER_INCLUDE_NONE
+            },
+            fundings_limit: if v.parameters.with_fundings {
+                FILTER_INCLUDE_ALL
+            } else {
+                FILTER_INCLUDE_NONE
+            },
+            relations_limit: if v.parameters.with_relations {
+                FILTER_INCLUDE_ALL
+            } else {
+                FILTER_INCLUDE_NONE
             },
         }
     }
@@ -160,23 +175,35 @@ impl From<WorksQueryVariables> for works_query::Variables {
     fn from(v: WorksQueryVariables) -> Self {
         works_query::Variables {
             publishers: v.publishers,
-            issues_limit: if v.parameters.with_issues { 99999 } else { 0 },
-            languages_limit: if v.parameters.with_languages {
-                99999
+            issues_limit: if v.parameters.with_issues {
+                FILTER_INCLUDE_ALL
             } else {
-                0
+                FILTER_INCLUDE_NONE
+            },
+            languages_limit: if v.parameters.with_languages {
+                FILTER_INCLUDE_ALL
+            } else {
+                FILTER_INCLUDE_NONE
             },
             publications_limit: if v.parameters.with_publications {
-                99999
+                FILTER_INCLUDE_ALL
             } else {
-                0
+                FILTER_INCLUDE_NONE
             },
-            subjects_limit: if v.parameters.with_subjects { 99999 } else { 0 },
-            fundings_limit: if v.parameters.with_fundings { 99999 } else { 0 },
-            relations_limit: if v.parameters.with_relations {
-                99999
+            subjects_limit: if v.parameters.with_subjects {
+                FILTER_INCLUDE_ALL
             } else {
-                0
+                FILTER_INCLUDE_NONE
+            },
+            fundings_limit: if v.parameters.with_fundings {
+                FILTER_INCLUDE_ALL
+            } else {
+                FILTER_INCLUDE_NONE
+            },
+            relations_limit: if v.parameters.with_relations {
+                FILTER_INCLUDE_ALL
+            } else {
+                FILTER_INCLUDE_NONE
             },
         }
     }
@@ -261,12 +288,12 @@ mod tests {
             variables,
             work_query::Variables {
                 work_id,
-                issues_limit: 99999,
-                languages_limit: 99999,
-                publications_limit: 99999,
-                subjects_limit: 99999,
-                fundings_limit: 99999,
-                relations_limit: 99999,
+                issues_limit: FILTER_INCLUDE_ALL,
+                languages_limit: FILTER_INCLUDE_ALL,
+                publications_limit: FILTER_INCLUDE_ALL,
+                subjects_limit: FILTER_INCLUDE_ALL,
+                fundings_limit: FILTER_INCLUDE_ALL,
+                relations_limit: FILTER_INCLUDE_ALL,
             }
         );
         parameters = QueryParameters::new();
@@ -275,12 +302,12 @@ mod tests {
             variables,
             work_query::Variables {
                 work_id,
-                issues_limit: 0,
-                languages_limit: 0,
-                publications_limit: 0,
-                subjects_limit: 0,
-                fundings_limit: 0,
-                relations_limit: 0,
+                issues_limit: FILTER_INCLUDE_NONE,
+                languages_limit: FILTER_INCLUDE_NONE,
+                publications_limit: FILTER_INCLUDE_NONE,
+                subjects_limit: FILTER_INCLUDE_NONE,
+                fundings_limit: FILTER_INCLUDE_NONE,
+                relations_limit: FILTER_INCLUDE_NONE,
             }
         );
         parameters = QueryParameters::new().with_all().without_relations();
@@ -289,12 +316,12 @@ mod tests {
             variables,
             work_query::Variables {
                 work_id,
-                issues_limit: 99999,
-                languages_limit: 99999,
-                publications_limit: 99999,
-                subjects_limit: 99999,
-                fundings_limit: 99999,
-                relations_limit: 0,
+                issues_limit: FILTER_INCLUDE_ALL,
+                languages_limit: FILTER_INCLUDE_ALL,
+                publications_limit: FILTER_INCLUDE_ALL,
+                subjects_limit: FILTER_INCLUDE_ALL,
+                fundings_limit: FILTER_INCLUDE_ALL,
+                relations_limit: FILTER_INCLUDE_NONE,
             }
         );
     }
@@ -310,12 +337,12 @@ mod tests {
             variables,
             works_query::Variables {
                 publishers: publishers.clone(),
-                issues_limit: 99999,
-                languages_limit: 99999,
-                publications_limit: 99999,
-                subjects_limit: 99999,
-                fundings_limit: 99999,
-                relations_limit: 99999,
+                issues_limit: FILTER_INCLUDE_ALL,
+                languages_limit: FILTER_INCLUDE_ALL,
+                publications_limit: FILTER_INCLUDE_ALL,
+                subjects_limit: FILTER_INCLUDE_ALL,
+                fundings_limit: FILTER_INCLUDE_ALL,
+                relations_limit: FILTER_INCLUDE_ALL,
             }
         );
         parameters = QueryParameters::new();
@@ -324,12 +351,12 @@ mod tests {
             variables,
             works_query::Variables {
                 publishers: publishers.clone(),
-                issues_limit: 0,
-                languages_limit: 0,
-                publications_limit: 0,
-                subjects_limit: 0,
-                fundings_limit: 0,
-                relations_limit: 0,
+                issues_limit: FILTER_INCLUDE_NONE,
+                languages_limit: FILTER_INCLUDE_NONE,
+                publications_limit: FILTER_INCLUDE_NONE,
+                subjects_limit: FILTER_INCLUDE_NONE,
+                fundings_limit: FILTER_INCLUDE_NONE,
+                relations_limit: FILTER_INCLUDE_NONE,
             }
         );
         parameters = QueryParameters::new().with_all().without_relations();
@@ -338,12 +365,12 @@ mod tests {
             variables,
             works_query::Variables {
                 publishers,
-                issues_limit: 99999,
-                languages_limit: 99999,
-                publications_limit: 99999,
-                subjects_limit: 99999,
-                fundings_limit: 99999,
-                relations_limit: 0,
+                issues_limit: FILTER_INCLUDE_ALL,
+                languages_limit: FILTER_INCLUDE_ALL,
+                publications_limit: FILTER_INCLUDE_ALL,
+                subjects_limit: FILTER_INCLUDE_ALL,
+                fundings_limit: FILTER_INCLUDE_ALL,
+                relations_limit: FILTER_INCLUDE_NONE,
             }
         );
     }

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -51,7 +51,7 @@ impl WorksQueryVariables {
 /// # use thoth_client::{QueryParameters};
 ///
 /// # async fn run() -> QueryParameters {
-/// let parameters = QueryParameters::new().with_series().with_languages();
+/// let parameters = QueryParameters::new().with_issues().with_languages();
 /// # parameters
 /// # }
 /// ```

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -2,13 +2,14 @@ use crate::queries::{work_query, works_query};
 use uuid::Uuid;
 
 /// A set of booleans to toggle directives in the GraphQL queries
+#[derive(Default)]
 pub struct QueryParameters {
-    pub with_issues: bool,
-    pub with_languages: bool,
-    pub with_publications: bool,
-    pub with_subjects: bool,
-    pub with_fundings: bool,
-    pub with_relations: bool,
+    with_issues: bool,
+    with_languages: bool,
+    with_publications: bool,
+    with_subjects: bool,
+    with_fundings: bool,
+    with_relations: bool,
 }
 
 /// An intermediate struct to parse QueryParameters into work_query::Variables
@@ -41,51 +42,90 @@ impl WorksQueryVariables {
     }
 }
 
+/// Implement builder pattern for `QueryParameters`
+///
+/// # Example
+///
+/// ```
+/// # use thoth_client::{QueryParameters};
+///
+/// # async fn run() -> QueryParameters {
+/// let parameters = QueryParameters::new().with_series().with_languages();
+/// # parameters
+/// # }
+/// ```
 impl QueryParameters {
-    /// Get a `QueryParameters` with all its attributes set to `true`
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use thoth_client::{QueryParameters};
-    ///
-    /// # async fn run() -> QueryParameters {
-    /// let parameters = QueryParameters::all_on();
-    /// # parameters
-    /// # }
-    /// ```
-    pub fn all_on() -> Self {
-        QueryParameters {
-            with_issues: true,
-            with_languages: true,
-            with_publications: true,
-            with_subjects: true,
-            with_fundings: true,
-            with_relations: true,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Get a `QueryParameters` with all its attributes set to `false`
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use thoth_client::{QueryParameters};
-    ///
-    /// # async fn run() -> QueryParameters {
-    /// let parameters = QueryParameters::all_off();
-    /// # parameters
-    /// # }
-    /// ```
-    pub fn all_off() -> Self {
-        QueryParameters {
-            with_issues: false,
-            with_languages: false,
-            with_publications: false,
-            with_subjects: false,
-            with_fundings: false,
-            with_relations: false,
-        }
+    pub fn with_all(self) -> Self {
+        self.with_issues()
+            .with_languages()
+            .with_publications()
+            .with_subjects()
+            .with_fundings()
+            .with_relations()
+    }
+
+    pub fn with_issues(mut self) -> Self {
+        self.with_issues = true;
+        self
+    }
+
+    pub fn with_languages(mut self) -> Self {
+        self.with_languages = true;
+        self
+    }
+
+    pub fn with_publications(mut self) -> Self {
+        self.with_publications = true;
+        self
+    }
+
+    pub fn with_subjects(mut self) -> Self {
+        self.with_subjects = true;
+        self
+    }
+
+    pub fn with_fundings(mut self) -> Self {
+        self.with_fundings = true;
+        self
+    }
+
+    pub fn with_relations(mut self) -> Self {
+        self.with_relations = true;
+        self
+    }
+
+    pub fn without_issues(mut self) -> Self {
+        self.with_issues = false;
+        self
+    }
+
+    pub fn without_languages(mut self) -> Self {
+        self.with_languages = false;
+        self
+    }
+
+    pub fn without_publications(mut self) -> Self {
+        self.with_publications = false;
+        self
+    }
+
+    pub fn without_subjects(mut self) -> Self {
+        self.with_subjects = false;
+        self
+    }
+
+    pub fn without_fundings(mut self) -> Self {
+        self.with_fundings = false;
+        self
+    }
+
+    pub fn without_relations(mut self) -> Self {
+        self.with_relations = false;
+        self
     }
 }
 
@@ -138,5 +178,74 @@ impl From<WorksQueryVariables> for works_query::Variables {
                 0
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_query_parameters() {
+        let to_test = QueryParameters {
+            with_issues: false,
+            with_languages: false,
+            with_publications: false,
+            with_subjects: false,
+            with_fundings: false,
+            with_relations: false,
+        };
+        assert_eq!(to_test, QueryParameters::default());
+        assert_eq!(to_test, QueryParameters::new())
+    }
+
+    #[test]
+    fn test_query_parameters_builder() {
+        assert_eq!(
+            QueryParameters::new().with_all(),
+            QueryParameters {
+                with_issues: true,
+                with_languages: true,
+                with_publications: true,
+                with_subjects: true,
+                with_fundings: true,
+                with_relations: true
+            },
+        );
+        assert_eq!(
+            QueryParameters::new()
+                .with_all()
+                .without_issues()
+                .without_languages()
+                .without_publications()
+                .without_subjects()
+                .without_fundings()
+                .without_relations(),
+            QueryParameters {
+                with_issues: false,
+                with_languages: false,
+                with_publications: false,
+                with_subjects: false,
+                with_fundings: false,
+                with_relations: false
+            },
+        );
+        assert_eq!(
+            QueryParameters::new()
+                .with_issues()
+                .with_languages()
+                .with_publications()
+                .with_subjects()
+                .with_fundings()
+                .with_relations(),
+            QueryParameters {
+                with_issues: true,
+                with_languages: true,
+                with_publications: true,
+                with_subjects: true,
+                with_fundings: true,
+                with_relations: true
+            },
+        );
     }
 }

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -302,13 +302,14 @@ mod tests {
     #[test]
     fn test_convert_parameters_to_works_query_variables() {
         let publisher_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001").unwrap();
+        let publishers = Some(vec![publisher_id]);
         let mut parameters = QueryParameters::new().with_all();
         let mut variables: works_query::Variables =
-            WorksQueryVariables::new(Some(vec![publisher_id]), parameters).into();
+            WorksQueryVariables::new(publishers, parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {
-                publishers,
+                publishers: publishers.clone(),
                 issues_limit: 99999,
                 languages_limit: 99999,
                 publications_limit: 99999,
@@ -318,11 +319,11 @@ mod tests {
             }
         );
         parameters = QueryParameters::new();
-        variables = WorksQueryVariables::new(Some(vec![publisher_id]), parameters).into();
+        variables = WorksQueryVariables::new(publishers.clone(), parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {
-                publishers,
+                publishers: publishers.clone(),
                 issues_limit: 0,
                 languages_limit: 0,
                 publications_limit: 0,
@@ -332,11 +333,11 @@ mod tests {
             }
         );
         parameters = QueryParameters::new().with_all().without_relations();
-        variables = WorksQueryVariables::new(Some(vec![publisher_id]), parameters).into();
+        variables = WorksQueryVariables::new(publishers.clone(), parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {
-                publishers,
+                publishers: publishers.clone(),
                 issues_limit: 99999,
                 languages_limit: 99999,
                 publications_limit: 99999,

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -187,9 +187,6 @@ mod tests {
     use super::*;
     use crate::queries::{work_query, works_query};
 
-    const work_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001").unwrap();
-    const publishers: Option<Vec<Uuid>> = Some(vec![work_id]);
-
     #[test]
     fn test_default_query_parameters() {
         let to_test = QueryParameters {
@@ -256,6 +253,7 @@ mod tests {
 
     #[test]
     fn test_convert_parameters_to_work_query_variables() {
+        let work_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001").unwrap();
         let mut parameters = QueryParameters::new().with_all();
         let mut variables: work_query::Variables =
             WorkQueryVariables::new(work_id, parameters).into();
@@ -303,9 +301,10 @@ mod tests {
 
     #[test]
     fn test_convert_parameters_to_works_query_variables() {
+        let publisher_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001").unwrap();
         let mut parameters = QueryParameters::new().with_all();
         let mut variables: works_query::Variables =
-            WorksQueryVariables::new(publishers, parameters).into();
+            WorksQueryVariables::new(Some(vec![publisher_id]), parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {
@@ -319,7 +318,7 @@ mod tests {
             }
         );
         parameters = QueryParameters::new();
-        variables = WorksQueryVariables::new(publishers, parameters).into();
+        variables = WorksQueryVariables::new(Some(vec![publisher_id]), parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {
@@ -333,7 +332,7 @@ mod tests {
             }
         );
         parameters = QueryParameters::new().with_all().without_relations();
-        variables = WorksQueryVariables::new(publishers, parameters).into();
+        variables = WorksQueryVariables::new(Some(vec![publisher_id]), parameters).into();
         assert_eq!(
             variables,
             works_query::Variables {

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -186,7 +186,6 @@ impl From<WorksQueryVariables> for works_query::Variables {
 mod tests {
     use super::*;
     use crate::queries::{work_query, works_query};
-    use thoth_api::model::language::LanguageCode::Que;
 
     const work_id: Uuid = Uuid::parse_str("00000000-0000-0000-AAAA-000000000001").unwrap();
     const publishers: Option<Vec<Uuid>> = Some(vec![work_id]);

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -2,7 +2,7 @@ use crate::queries::{work_query, works_query};
 use uuid::Uuid;
 
 /// A set of booleans to toggle directives in the GraphQL queries
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
 #[derive(Default)]
 pub struct QueryParameters {
     with_issues: bool,
@@ -337,7 +337,7 @@ mod tests {
         assert_eq!(
             variables,
             works_query::Variables {
-                publishers: publishers.clone(),
+                publishers,
                 issues_limit: 99999,
                 languages_limit: 99999,
                 publications_limit: 99999,

--- a/thoth-client/src/parameters.rs
+++ b/thoth-client/src/parameters.rs
@@ -1,0 +1,118 @@
+use uuid::Uuid;
+use crate::queries::{work_query, works_query};
+
+/// A set of booleans to toggle directives in the GraphQL queries
+pub struct QueryParameters {
+    pub with_issues: bool,
+    pub with_languages: bool,
+    pub with_publications: bool,
+    pub with_subjects: bool,
+    pub with_fundings: bool,
+    pub with_relations: bool,
+}
+
+/// An intermediate struct to parse QueryParameters into work_query::Variables
+pub(crate) struct WorkQueryVariables {
+    pub work_id: Uuid,
+    pub parameters: QueryParameters,
+}
+
+/// An intermediate struct to parse QueryParameters into works_query::Variables
+pub(crate) struct WorksQueryVariables {
+    pub publishers: Option<Vec<Uuid>>,
+    pub parameters: QueryParameters,
+}
+
+impl WorkQueryVariables {
+    pub(crate) fn new(work_id: Uuid, parameters: QueryParameters) -> Self {
+        WorkQueryVariables {
+            work_id,
+            parameters
+        }
+    }
+}
+
+impl WorksQueryVariables {
+    pub(crate) fn new(publishers: Option<Vec<Uuid>>, parameters: QueryParameters) -> Self {
+        WorksQueryVariables {
+            publishers,
+            parameters
+        }
+    }
+}
+
+impl QueryParameters {
+    /// Get a `QueryParameters` with all its attributes set to `true`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use thoth_client::{QueryParameters};
+    ///
+    /// # async fn run() -> QueryParameters {
+    /// let parameters = QueryParameters::all_on();
+    /// # parameters
+    /// # }
+    /// ```
+    pub fn all_on() -> Self {
+        QueryParameters {
+            with_issues: true,
+            with_languages: true,
+            with_publications: true,
+            with_subjects: true,
+            with_fundings: true,
+            with_relations: true,
+        }
+    }
+
+    /// Get a `QueryParameters` with all its attributes set to `false`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use thoth_client::{QueryParameters};
+    ///
+    /// # async fn run() -> QueryParameters {
+    /// let parameters = QueryParameters::all_off();
+    /// # parameters
+    /// # }
+    /// ```
+    pub fn all_off() -> Self {
+        QueryParameters {
+            with_issues: false,
+            with_languages: false,
+            with_publications: false,
+            with_subjects: false,
+            with_fundings: false,
+            with_relations: false,
+        }
+    }
+}
+
+impl From<WorkQueryVariables> for work_query::Variables {
+    fn from(v: WorkQueryVariables) -> Self {
+        work_query::Variables {
+            work_id: v.work_id,
+            issues_limit: if v.parameters.with_issues { 99999 } else { 0 },
+            languages_limit: if v.parameters.with_languages { 99999 } else { 0 },
+            publications_limit: if v.parameters.with_publications { 99999 } else { 0 },
+            subjects_limit: if v.parameters.with_subjects { 99999 } else { 0 },
+            fundings_limit: if v.parameters.with_fundings { 99999 } else { 0 },
+            relations_limit: if v.parameters.with_relations { 99999 } else { 0 },
+        }
+    }
+}
+
+impl From<WorksQueryVariables> for works_query::Variables {
+    fn from(v: WorksQueryVariables) -> Self {
+        works_query::Variables {
+            publishers: v.publishers,
+            issues_limit: if v.parameters.with_issues { 99999 } else { 0 },
+            languages_limit: if v.parameters.with_languages { 99999 } else { 0 },
+            publications_limit: if v.parameters.with_publications { 99999 } else { 0 },
+            subjects_limit: if v.parameters.with_subjects { 99999 } else { 0 },
+            fundings_limit: if v.parameters.with_fundings { 99999 } else { 0 },
+            relations_limit: if v.parameters.with_relations { 99999 } else { 0 },
+        }
+    }
+}

--- a/thoth-client/src/queries.rs
+++ b/thoth-client/src/queries.rs
@@ -12,7 +12,8 @@ use uuid::Uuid;
 #[graphql(
     schema_path = "assets/schema.json",
     query_path = "assets/queries.graphql",
-    response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq"
+    response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq",
+    variable_derives = "Debug,PartialEq"
 )]
 pub struct WorkQuery;
 
@@ -26,7 +27,8 @@ impl fmt::Display for work_query::LanguageCode {
 #[graphql(
     schema_path = "assets/schema.json",
     query_path = "assets/queries.graphql",
-    response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq"
+    response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq",
+    variable_derives = "Debug,PartialEq"
 )]
 pub struct WorksQuery;
 

--- a/thoth-client/src/queries.rs
+++ b/thoth-client/src/queries.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
     schema_path = "assets/schema.json",
     query_path = "assets/queries.graphql",
     response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq",
-    variable_derives = "Debug,PartialEq"
+    variables_derives = "Debug,PartialEq"
 )]
 pub struct WorkQuery;
 
@@ -28,7 +28,7 @@ impl fmt::Display for work_query::LanguageCode {
     schema_path = "assets/schema.json",
     query_path = "assets/queries.graphql",
     response_derives = "Debug,Clone,Deserialize,Serialize,PartialEq",
-    variable_derives = "Debug,PartialEq"
+    variables_derives = "Debug,PartialEq"
 )]
 pub struct WorksQuery;
 

--- a/thoth-export-server/src/bibtex/bibtex_thoth.rs
+++ b/thoth-export-server/src/bibtex/bibtex_thoth.rs
@@ -6,6 +6,7 @@ use thoth_errors::{ThothError, ThothResult};
 
 use super::{BibtexEntry, BibtexSpecification};
 
+#[derive(Copy, Clone)]
 pub(crate) struct BibtexThoth;
 
 #[derive(Debug)]

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -10,6 +10,7 @@ use thoth_errors::ThothResult;
 
 use super::{CsvCell, CsvRow, CsvSpecification};
 
+#[derive(Copy, Clone)]
 pub(crate) struct CsvThoth;
 
 #[derive(Debug, Serialize)]

--- a/thoth-export-server/src/csv/kbart_oclc.rs
+++ b/thoth-export-server/src/csv/kbart_oclc.rs
@@ -7,6 +7,7 @@ use thoth_errors::{ThothError, ThothResult};
 
 use super::{CsvRow, CsvSpecification};
 
+#[derive(Copy, Clone)]
 pub(crate) struct KbartOclc;
 
 #[derive(Debug, Serialize)]

--- a/thoth-export-server/src/lib.rs
+++ b/thoth-export-server/src/lib.rs
@@ -14,6 +14,7 @@ mod platform;
 mod rapidoc;
 mod record;
 mod specification;
+mod specification_query;
 mod xml;
 
 use crate::rapidoc::rapidoc_source;

--- a/thoth-export-server/src/record.rs
+++ b/thoth-export-server/src/record.rs
@@ -23,6 +23,7 @@ pub const DELIMITER_TAB: u8 = b'\t';
 pub const XML_DECLARATION: &str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
 pub const DOCTYPE_ONIX21_REF: &str = "<!DOCTYPE ONIXMessage SYSTEM \"http://www.editeur.org/onix/2.1/reference/onix-international.dtd\">\n";
 
+#[derive(Copy, Clone)]
 pub(crate) enum MetadataSpecification {
     Onix3ProjectMuse(Onix3ProjectMuse),
     Onix3Oapen(Onix3Oapen),

--- a/thoth-export-server/src/specification/handler.rs
+++ b/thoth-export-server/src/specification/handler.rs
@@ -3,7 +3,8 @@ use paperclip::actix::{
     api_v2_operation,
     web::{self, Json},
 };
-use thoth_client::{ThothClient, Work};
+use thoth_api::model::language::LanguageCode::Que;
+use thoth_client::{QueryParameters, ThothClient, Work};
 use thoth_errors::ThothError;
 use uuid::Uuid;
 
@@ -44,8 +45,9 @@ pub(crate) async fn by_work(
     thoth_client: web::Data<ThothClient>,
 ) -> Result<MetadataRecord<Vec<Work>>, Error> {
     let (specification_id, work_id) = path.into_inner();
+    let parameters = QueryParameters::new().with_all();
     thoth_client
-        .get_work(work_id, true)
+        .get_work(work_id, parameters)
         .await
         .and_then(|data| {
             specification_id.parse().map(|specification| {
@@ -74,8 +76,9 @@ pub(crate) async fn by_publisher(
         )
         .into());
     }
+    let parameters = QueryParameters::new().with_all().without_relations();
     thoth_client
-        .get_works(Some(vec![publisher_id]), true)
+        .get_works(Some(vec![publisher_id]), parameters)
         .await
         .and_then(|data| {
             specification_id.parse().map(|specification| {

--- a/thoth-export-server/src/specification/handler.rs
+++ b/thoth-export-server/src/specification/handler.rs
@@ -46,7 +46,8 @@ pub(crate) async fn by_work(
     let (specification_id, work_id) = path.into_inner();
     let specification: MetadataSpecification = specification_id.parse()?;
 
-    SpecificationQuery::by_work(thoth_client.into_inner(), specification, work_id)
+    SpecificationQuery::new(thoth_client.into_inner(), specification)
+        .by_work(work_id)
         .await
         .map(|data| MetadataRecord::new(work_id.to_string(), specification, vec![data]))
         .map_err(|e| e.into())
@@ -65,7 +66,8 @@ pub(crate) async fn by_publisher(
     let (specification_id, publisher_id) = path.into_inner();
     let specification: MetadataSpecification = specification_id.parse()?;
 
-    SpecificationQuery::by_publisher(thoth_client.into_inner(), specification, publisher_id)
+    SpecificationQuery::new(thoth_client.into_inner(), specification)
+        .by_publisher(publisher_id)
         .await
         .map(|data| MetadataRecord::new(publisher_id.to_string(), specification, data))
         .map_err(|e| e.into())

--- a/thoth-export-server/src/specification/handler.rs
+++ b/thoth-export-server/src/specification/handler.rs
@@ -45,7 +45,7 @@ pub(crate) async fn by_work(
 ) -> Result<MetadataRecord<Vec<Work>>, Error> {
     let (specification_id, work_id) = path.into_inner();
     thoth_client
-        .get_work(work_id)
+        .get_work(work_id, true)
         .await
         .and_then(|data| {
             specification_id.parse().map(|specification| {
@@ -75,7 +75,7 @@ pub(crate) async fn by_publisher(
         .into());
     }
     thoth_client
-        .get_works(Some(vec![publisher_id]))
+        .get_works(Some(vec![publisher_id]), true)
         .await
         .and_then(|data| {
             specification_id.parse().map(|specification| {

--- a/thoth-export-server/src/specification/handler.rs
+++ b/thoth-export-server/src/specification/handler.rs
@@ -3,8 +3,7 @@ use paperclip::actix::{
     api_v2_operation,
     web::{self, Json},
 };
-use std::convert::TryInto;
-use thoth_client::{QueryParameters, ThothClient, Work};
+use thoth_client::{ThothClient, Work};
 use uuid::Uuid;
 
 use super::model::Specification;
@@ -46,10 +45,8 @@ pub(crate) async fn by_work(
 ) -> Result<MetadataRecord<Vec<Work>>, Error> {
     let (specification_id, work_id) = path.into_inner();
     let specification: MetadataSpecification = specification_id.parse()?;
-    let parameters: QueryParameters = SpecificationQuery::by_work(specification).try_into()?;
 
-    thoth_client
-        .get_work(work_id, parameters)
+    SpecificationQuery::by_work(thoth_client.into_inner(), specification, work_id)
         .await
         .map(|data| MetadataRecord::new(work_id.to_string(), specification, vec![data]))
         .map_err(|e| e.into())
@@ -67,10 +64,8 @@ pub(crate) async fn by_publisher(
 ) -> Result<MetadataRecord<Vec<Work>>, Error> {
     let (specification_id, publisher_id) = path.into_inner();
     let specification: MetadataSpecification = specification_id.parse()?;
-    let parameters: QueryParameters = SpecificationQuery::by_publisher(specification).try_into()?;
 
-    thoth_client
-        .get_works(Some(vec![publisher_id]), parameters)
+    SpecificationQuery::by_publisher(thoth_client.into_inner(), specification, publisher_id)
         .await
         .map(|data| MetadataRecord::new(publisher_id.to_string(), specification, data))
         .map_err(|e| e.into())

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -68,34 +68,27 @@ impl TryFrom<QueryConfiguration> for QueryParameters {
 
     fn try_from(q: QueryConfiguration) -> ThothResult<Self> {
         match q.specification {
-            MetadataSpecification::Onix3ProjectMuse(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
-            },
-            MetadataSpecification::Onix3Oapen(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
-            },
-            MetadataSpecification::Onix3Jstor(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
-            },
-            MetadataSpecification::Onix3GoogleBooks(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
-            },
-            MetadataSpecification::Onix3Overdrive(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
-            },
-            MetadataSpecification::Onix21EbscoHost(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
-            },
-            MetadataSpecification::Onix21ProquestEbrary(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
-            },
+            MetadataSpecification::Onix3ProjectMuse(_) => {
+                Ok(QueryParameters::new().with_all().without_relations())
+            }
+            MetadataSpecification::Onix3Oapen(_) => {
+                Ok(QueryParameters::new().with_all().without_relations())
+            }
+            MetadataSpecification::Onix3Jstor(_) => {
+                Ok(QueryParameters::new().with_all().without_relations())
+            }
+            MetadataSpecification::Onix3GoogleBooks(_) => {
+                Ok(QueryParameters::new().with_all().without_relations())
+            }
+            MetadataSpecification::Onix3Overdrive(_) => {
+                Ok(QueryParameters::new().with_all().without_relations())
+            }
+            MetadataSpecification::Onix21EbscoHost(_) => {
+                Ok(QueryParameters::new().with_all().without_relations())
+            }
+            MetadataSpecification::Onix21ProquestEbrary(_) => {
+                Ok(QueryParameters::new().with_all().without_relations())
+            }
             MetadataSpecification::CsvThoth(_) => match q.request {
                 SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
                 SpecificationRequest::ByPublisher => {
@@ -104,7 +97,7 @@ impl TryFrom<QueryConfiguration> for QueryParameters {
             },
             MetadataSpecification::KbartOclc(_) => {
                 Ok(QueryParameters::new().with_issues().with_publications())
-            },
+            }
             MetadataSpecification::BibtexThoth(_) => match q.request {
                 SpecificationRequest::ByWork => Ok(QueryParameters::new()
                     .with_issues()

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -1,4 +1,6 @@
+use std::convert::TryFrom;
 use thoth_client::QueryParameters;
+use thoth_errors::{ThothError, ThothResult};
 
 use crate::record::MetadataSpecification;
 
@@ -28,52 +30,57 @@ impl SpecificationQuery {
     }
 }
 
-impl From<SpecificationQuery> for QueryParameters {
-    fn from(q: SpecificationQuery) -> Self {
+impl TryFrom<SpecificationQuery> for QueryParameters {
+    type Error = ThothError;
+
+    fn try_from(q: SpecificationQuery) -> ThothResult<Self> {
         match q.specification {
             MetadataSpecification::Onix3ProjectMuse(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::Onix3Oapen(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::Onix3Jstor(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::Onix3GoogleBooks(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::Onix3Overdrive(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::Onix21EbscoHost(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::Onix21ProquestEbrary(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::CsvThoth(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::KbartOclc(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::BibtexThoth(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::DoiDepositCrossref(_) => match q.request {
-                SpecificationRequest::ByWork => QueryParameters::new(),
-                SpecificationRequest::ByPublisher => QueryParameters::new(),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => Err(ThothError::IncompleteMetadataRecord(
+                    "doideposit::crossref".to_string(),
+                    "Output can only be generated for one work at a time".to_string(),
+                )),
             },
         }
     }

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -116,7 +116,10 @@ impl TryFrom<QueryConfiguration> for QueryParameters {
                 }
             },
             MetadataSpecification::DoiDepositCrossref(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new()
+                    .with_issues()
+                    .with_publications()
+                    .with_relations()),
                 SpecificationRequest::ByPublisher => Err(ThothError::IncompleteMetadataRecord(
                     "doideposit::crossref".to_string(),
                     "Output can only be generated for one work at a time".to_string(),

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -102,9 +102,8 @@ impl TryFrom<QueryConfiguration> for QueryParameters {
                     Ok(QueryParameters::new().with_all().without_relations())
                 }
             },
-            MetadataSpecification::KbartOclc(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
+            MetadataSpecification::KbartOclc(_) => {
+                Ok(QueryParameters::new().with_issues().with_publications())
             },
             MetadataSpecification::BibtexThoth(_) => match q.request {
                 SpecificationRequest::ByWork => Ok(QueryParameters::new()

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -1,8 +1,8 @@
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
-use uuid::Uuid;
 use thoth_client::{QueryParameters, ThothClient, Work};
 use thoth_errors::{ThothError, ThothResult};
+use uuid::Uuid;
 
 use crate::record::MetadataSpecification;
 
@@ -38,7 +38,9 @@ impl SpecificationQuery {
             request: SpecificationRequest::ByPublisher,
             specification,
         };
-        thoth_client.get_works(Some(vec![publisher_id]), query.try_into()?).await
+        thoth_client
+            .get_works(Some(vec![publisher_id]), query.try_into()?)
+            .await
     }
 }
 

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -1,5 +1,7 @@
-use std::convert::TryFrom;
-use thoth_client::QueryParameters;
+use std::convert::{TryFrom, TryInto};
+use std::sync::Arc;
+use uuid::Uuid;
+use thoth_client::{QueryParameters, ThothClient, Work};
 use thoth_errors::{ThothError, ThothResult};
 
 use crate::record::MetadataSpecification;
@@ -15,18 +17,28 @@ pub(crate) struct SpecificationQuery {
 }
 
 impl SpecificationQuery {
-    pub(crate) fn by_work(specification: MetadataSpecification) -> Self {
-        Self {
+    pub(crate) async fn by_work(
+        thoth_client: Arc<ThothClient>,
+        specification: MetadataSpecification,
+        work_id: Uuid,
+    ) -> ThothResult<Work> {
+        let query = SpecificationQuery {
             request: SpecificationRequest::ByWork,
             specification,
-        }
+        };
+        thoth_client.get_work(work_id, query.try_into()?).await
     }
 
-    pub(crate) fn by_publisher(specification: MetadataSpecification) -> Self {
-        Self {
+    pub(crate) async fn by_publisher(
+        thoth_client: Arc<ThothClient>,
+        specification: MetadataSpecification,
+        publisher_id: Uuid,
+    ) -> ThothResult<Vec<Work>> {
+        let query = SpecificationQuery {
             request: SpecificationRequest::ByPublisher,
             specification,
-        }
+        };
+        thoth_client.get_works(Some(vec![publisher_id]), query.try_into()?).await
     }
 }
 

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -107,8 +107,13 @@ impl TryFrom<QueryConfiguration> for QueryParameters {
                 SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
             },
             MetadataSpecification::BibtexThoth(_) => match q.request {
-                SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByWork => Ok(QueryParameters::new()
+                    .with_issues()
+                    .with_publications()
+                    .with_relations()),
+                SpecificationRequest::ByPublisher => {
+                    Ok(QueryParameters::new().with_issues().with_publications())
+                }
             },
             MetadataSpecification::DoiDepositCrossref(_) => match q.request {
                 SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -1,0 +1,80 @@
+use thoth_client::QueryParameters;
+
+use crate::record::MetadataSpecification;
+
+enum SpecificationRequest {
+    ByWork,
+    ByPublisher,
+}
+
+pub(crate) struct SpecificationQuery {
+    request: SpecificationRequest,
+    specification: MetadataSpecification,
+}
+
+impl SpecificationQuery {
+    pub(crate) fn by_work(specification: MetadataSpecification) -> Self {
+        Self {
+            request: SpecificationRequest::ByWork,
+            specification,
+        }
+    }
+
+    pub(crate) fn by_publisher(specification: MetadataSpecification) -> Self {
+        Self {
+            request: SpecificationRequest::ByPublisher,
+            specification,
+        }
+    }
+}
+
+impl From<SpecificationQuery> for QueryParameters {
+    fn from(q: SpecificationQuery) -> Self {
+        match q.specification {
+            MetadataSpecification::Onix3ProjectMuse(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::Onix3Oapen(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::Onix3Jstor(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::Onix3GoogleBooks(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::Onix3Overdrive(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::Onix21EbscoHost(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::Onix21ProquestEbrary(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::CsvThoth(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::KbartOclc(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::BibtexThoth(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+            MetadataSpecification::DoiDepositCrossref(_) => match q.request {
+                SpecificationRequest::ByWork => QueryParameters::new(),
+                SpecificationRequest::ByPublisher => QueryParameters::new(),
+            },
+        }
+    }
+}

--- a/thoth-export-server/src/specification_query.rs
+++ b/thoth-export-server/src/specification_query.rs
@@ -1,4 +1,3 @@
-use actix_web::web::Query;
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 use thoth_client::{QueryParameters, ThothClient, Work};
@@ -99,7 +98,9 @@ impl TryFrom<QueryConfiguration> for QueryParameters {
             },
             MetadataSpecification::CsvThoth(_) => match q.request {
                 SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),
-                SpecificationRequest::ByPublisher => Ok(QueryParameters::new().with_all()),
+                SpecificationRequest::ByPublisher => {
+                    Ok(QueryParameters::new().with_all().without_relations())
+                }
             },
             MetadataSpecification::KbartOclc(_) => match q.request {
                 SpecificationRequest::ByWork => Ok(QueryParameters::new().with_all()),

--- a/thoth-export-server/src/xml/doideposit_crossref.rs
+++ b/thoth-export-server/src/xml/doideposit_crossref.rs
@@ -12,6 +12,7 @@ use super::{write_element_block, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct DoiDepositCrossref {}
 
 // Output format based on schema documentation at https://data.crossref.org/reports/help/schema_doc/5.3.1/index.html

--- a/thoth-export-server/src/xml/onix21_ebsco_host.rs
+++ b/thoth-export-server/src/xml/onix21_ebsco_host.rs
@@ -11,6 +11,7 @@ use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct Onix21EbscoHost {}
 
 impl XmlSpecification for Onix21EbscoHost {

--- a/thoth-export-server/src/xml/onix21_proquest_ebrary.rs
+++ b/thoth-export-server/src/xml/onix21_proquest_ebrary.rs
@@ -11,6 +11,7 @@ use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct Onix21ProquestEbrary {}
 
 // This specification is exactly the same as EBSCO Host's except for the price point:

--- a/thoth-export-server/src/xml/onix3_google_books.rs
+++ b/thoth-export-server/src/xml/onix3_google_books.rs
@@ -11,6 +11,7 @@ use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct Onix3GoogleBooks {}
 
 // Output format based on documentation at https://support.google.com/books/partner/answer/6374180.

--- a/thoth-export-server/src/xml/onix3_jstor.rs
+++ b/thoth-export-server/src/xml/onix3_jstor.rs
@@ -11,6 +11,7 @@ use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct Onix3Jstor {}
 
 impl XmlSpecification for Onix3Jstor {

--- a/thoth-export-server/src/xml/onix3_oapen.rs
+++ b/thoth-export-server/src/xml/onix3_oapen.rs
@@ -11,6 +11,7 @@ use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct Onix3Oapen {}
 
 impl XmlSpecification for Onix3Oapen {

--- a/thoth-export-server/src/xml/onix3_overdrive.rs
+++ b/thoth-export-server/src/xml/onix3_overdrive.rs
@@ -12,6 +12,7 @@ use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct Onix3Overdrive {}
 
 impl XmlSpecification for Onix3Overdrive {

--- a/thoth-export-server/src/xml/onix3_project_muse.rs
+++ b/thoth-export-server/src/xml/onix3_project_muse.rs
@@ -11,6 +11,7 @@ use super::{write_element_block, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock};
 use thoth_errors::{ThothError, ThothResult};
 
+#[derive(Copy, Clone)]
 pub struct Onix3ProjectMuse {}
 
 impl XmlSpecification for Onix3ProjectMuse {


### PR DESCRIPTION
Fixes #438 

- `thoth-client` queries now accept parameters to toggle the inclusion of certain fragments (using limits: `limit: 9999` or `limit: 0`)
- Queries in `thoth-export-server` now live in `thoth-export-server/src/specification_query.rs` and can choose what parameters will be passed onto `thoth-client` based on the type of specification and wether the specification is being output for a single or multiple works