### PR TITLE
Feature/upgrade GitHub actions

### DIFF
--- a/.github/workflows/build_test_and_check.yml
+++ b/.github/workflows/build_test_and_check.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16.16.0'
     - uses: actions-rs/toolchain@v1
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16.16.0'
     - uses: actions-rs/toolchain@v1
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16.16.0'
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build_test_and_check.yml
+++ b/.github/workflows/build_test_and_check.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
       with:
         node-version: '12.19.0'
@@ -56,7 +56,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
       with:
         node-version: '12.19.0'
@@ -85,7 +85,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
       with:
         node-version: '12.19.0'
@@ -114,7 +114,7 @@ jobs:
   format_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable

--- a/.github/workflows/build_test_and_check.yml
+++ b/.github/workflows/build_test_and_check.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
       with:
-        node-version: '12.19.0'
+        node-version: '16.16.0'
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
       with:
-        node-version: '12.19.0'
+        node-version: '16.16.0'
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
       with:
-        node-version: '12.19.0'
+        node-version: '16.16.0'
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/build_test_and_check.yml
+++ b/.github/workflows/build_test_and_check.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         version: 'v0.10.3'
     - name: Install rollup
-      run: sudo npm install -g rollup@2.28.2
+      run: sudo npm install -g rollup@2.77.2
     - name: Compile WASM
       run: wasm-pack build thoth-app/ --target web --release
     - name: Pack APP
@@ -67,7 +67,7 @@ jobs:
       with:
         version: 'v0.10.3'
     - name: Install rollup
-      run: sudo npm install -g rollup@2.28.2
+      run: sudo npm install -g rollup@2.77.2
     - name: Compile WASM
       run: wasm-pack build thoth-app/ --target web --release
     - name: Pack APP
@@ -96,7 +96,7 @@ jobs:
       with:
         version: 'v0.10.3'
     - name: Install rollup
-      run: sudo npm install -g rollup@2.28.2
+      run: sudo npm install -g rollup@2.77.2
     - name: Compile WASM
       run: wasm-pack build thoth-app/ --target web --release
     - name: Pack APP

--- a/.github/workflows/build_test_and_check.yml
+++ b/.github/workflows/build_test_and_check.yml
@@ -41,7 +41,7 @@ jobs:
         toolchain: stable
     - uses: jetli/wasm-pack-action@v0.3.0
       with:
-        version: 'v0.9.1'
+        version: 'v0.10.3'
     - name: Install rollup
       run: sudo npm install -g rollup@2.28.2
     - name: Compile WASM
@@ -65,7 +65,7 @@ jobs:
         toolchain: stable
     - uses: jetli/wasm-pack-action@v0.3.0
       with:
-        version: 'v0.9.1'
+        version: 'v0.10.3'
     - name: Install rollup
       run: sudo npm install -g rollup@2.28.2
     - name: Compile WASM
@@ -94,7 +94,7 @@ jobs:
         toolchain: stable
     - uses: jetli/wasm-pack-action@v0.3.0
       with:
-        version: 'v0.9.1'
+        version: 'v0.10.3'
     - name: Install rollup
       run: sudo npm install -g rollup@2.28.2
     - name: Compile WASM

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: false
           tags: openbookpublishers/thoth:latest

--- a/.github/workflows/docker_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/docker_build_and_push_to_dockerhub.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -23,17 +23,17 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/docker_build_and_push_to_dockerhub.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3

--- a/.github/workflows/docker_build_dev.yml
+++ b/.github/workflows/docker_build_dev.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: false
           tags: openbookpublishers/thoth:latest


### PR DESCRIPTION
Upgrade github actions to latest versions available as some were outputting deprecation warnings (e.g. https://github.com/thoth-pub/thoth/actions/runs/3311994527)

Rust actions have not yet been upgraded to fix the issue. We'll need to keep an eye on https://github.com/actions-rs/toolchain/issues/219, https://github.com/actions-rs/toolchain/issues/221 and https://github.com/actions-rs/cargo/issues/216