### PR TITLE
Update EBSCO ONIX 2.1 output: correct PriceTypeCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-  - [#xxx](https://github.com/thoth-pub/thoth/pull/xxx) - Update EBSCO Host ONIX price type code
+  - [#449](https://github.com/thoth-pub/thoth/pull/449) - Update EBSCO Host ONIX price type code
 
 ## [[0.9.0]](https://github.com/thoth-pub/thoth/releases/tag/v0.9.0) - 2022-10-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+  - [#xxx](https://github.com/thoth-pub/thoth/pull/xxx) - Update EBSCO Host ONIX price type code
 
 ## [[0.9.0]](https://github.com/thoth-pub/thoth/releases/tag/v0.9.0) - 2022-10-24
 ### Added

--- a/thoth-export-server/src/xml/onix21_ebsco_host.rs
+++ b/thoth-export-server/src/xml/onix21_ebsco_host.rs
@@ -402,9 +402,9 @@ impl XmlElementBlock<Onix21EbscoHost> for Work {
                     })?;
                     // EBSCO Host require the price point for Open Access titles to be listed as "0.01 USD".
                     write_element_block("Price", w, |w| {
-                        // 02 RRP including tax
+                        // 01 RRP excluding tax (price code requested by EBSCO)
                         write_element_block("PriceTypeCode", w, |w| {
-                            w.write(XmlEvent::Characters("02")).map_err(|e| e.into())
+                            w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
                         })?;
                         write_element_block("PriceAmount", w, |w| {
                             w.write(XmlEvent::Characters("0.01")).map_err(|e| e.into())
@@ -1059,7 +1059,7 @@ mod tests {
         assert!(output
             .contains(r#"    <AudienceRestrictionNote>Open access</AudienceRestrictionNote>"#));
         assert!(output.contains(r#"    <Price>"#));
-        assert!(output.contains(r#"      <PriceTypeCode>02</PriceTypeCode>"#));
+        assert!(output.contains(r#"      <PriceTypeCode>01</PriceTypeCode>"#));
         assert!(output.contains(r#"      <PriceAmount>0.01</PriceAmount>"#));
         assert!(output.contains(r#"      <CurrencyCode>USD</CurrencyCode>"#));
 


### PR DESCRIPTION
EBSCO Host requested that we use a PriceTypeCode representing price excluding tax, rather than price including tax. (We currently submit all prices as $0.01, as we are providing the free OA PDFs only and EBSCO don't accept zero price points, so the tax code change is academic.)