### PR TITLE
Fix new Clippy lint under rustc 1.67.0: inline variables in format strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+  - Use inlined syntax in format strings to comply with [`rustc 1.67.0`](https://github.com/rust-lang/rust/releases/tag/1.67.0)
 
 ## [[0.9.5]](https://github.com/thoth-pub/thoth/releases/tag/v0.9.5) - 2023-01-17
 ### Changed

--- a/thoth-api-server/src/graphiql.rs
+++ b/thoth-api-server/src/graphiql.rs
@@ -76,7 +76,7 @@ pub fn graphiql_source(graphql_endpoint_url: &str) -> String {
         <script src="//cdnjs.cloudflare.com/ajax/libs/react/16.10.2/umd/react.production.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/react-dom/16.10.2/umd/react-dom.production.min.js"></script>
         <script src="//cdn.jsdelivr.net/npm/graphiql@0.17.2/graphiql.min.js"></script>
-        <script>var GRAPHQL_URL = '{graphql_url}';</script>
+        <script>var GRAPHQL_URL = '{graphql_endpoint_url}';</script>
         <script>
             function graphQLFetcher(params) {{
                 return fetch(GRAPHQL_URL, {{
@@ -107,7 +107,5 @@ pub fn graphiql_source(graphql_endpoint_url: &str) -> String {
     </body>
 </html>
 "#,
-        graphql_url = graphql_endpoint_url,
-        default_query = default_query,
     )
 }

--- a/thoth-api-server/src/lib.rs
+++ b/thoth-api-server/src/lib.rs
@@ -38,8 +38,8 @@ struct ApiConfig {
 impl ApiConfig {
     pub fn new(public_url: String) -> Self {
         Self {
-            public_url: format!("{}/graphql", public_url),
-            schema_explorer_url: format!("{}/graphiql", public_url),
+            public_url: format!("{public_url}/graphql"),
+            schema_explorer_url: format!("{public_url}/graphiql"),
             ..Default::default()
         }
     }
@@ -221,7 +221,7 @@ pub async fn start_server(
             .app_data(Data::new(ApiConfig::new(public_url.clone())))
             .configure(config)
     })
-    .bind(format!("{}:{}", host, port))?
+    .bind(format!("{host}:{port}"))?
     .run()
     .await
 }

--- a/thoth-api/src/model/contributor/crud.rs
+++ b/thoth-api/src/model/contributor/crud.rs
@@ -76,9 +76,9 @@ impl Crud for Contributor {
         if let Some(filter) = filter {
             query = query.filter(
                 full_name
-                    .ilike(format!("%{}%", filter))
-                    .or(last_name.ilike(format!("%{}%", filter)))
-                    .or(orcid.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(last_name.ilike(format!("%{filter}%")))
+                    .or(orcid.ilike(format!("%{filter}%"))),
             );
         }
         match query
@@ -104,9 +104,9 @@ impl Crud for Contributor {
         if let Some(filter) = filter {
             query = query.filter(
                 full_name
-                    .ilike(format!("%{}%", filter))
-                    .or(last_name.ilike(format!("%{}%", filter)))
-                    .or(orcid.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(last_name.ilike(format!("%{filter}%")))
+                    .or(orcid.ilike(format!("%{filter}%"))),
             );
         }
 

--- a/thoth-api/src/model/imprint/crud.rs
+++ b/thoth-api/src/model/imprint/crud.rs
@@ -71,8 +71,8 @@ impl Crud for Imprint {
         if let Some(filter) = filter {
             query = query.filter(
                 imprint_name
-                    .ilike(format!("%{}%", filter))
-                    .or(imprint_url.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(imprint_url.ilike(format!("%{filter}%"))),
             );
         }
         match query
@@ -101,8 +101,8 @@ impl Crud for Imprint {
         if let Some(filter) = filter {
             query = query.filter(
                 imprint_name
-                    .ilike(format!("%{}%", filter))
-                    .or(imprint_url.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(imprint_url.ilike(format!("%{filter}%"))),
             );
         }
 

--- a/thoth-api/src/model/institution/crud.rs
+++ b/thoth-api/src/model/institution/crud.rs
@@ -72,9 +72,9 @@ impl Crud for Institution {
         if let Some(filter) = filter {
             query = query.filter(
                 institution_name
-                    .ilike(format!("%{}%", filter))
-                    .or(ror.ilike(format!("%{}%", filter)))
-                    .or(institution_doi.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(ror.ilike(format!("%{filter}%")))
+                    .or(institution_doi.ilike(format!("%{filter}%"))),
             );
         }
         match query
@@ -100,9 +100,9 @@ impl Crud for Institution {
         if let Some(filter) = filter {
             query = query.filter(
                 institution_name
-                    .ilike(format!("%{}%", filter))
-                    .or(ror.ilike(format!("%{}%", filter)))
-                    .or(institution_doi.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(ror.ilike(format!("%{filter}%")))
+                    .or(institution_doi.ilike(format!("%{filter}%"))),
             );
         }
 

--- a/thoth-api/src/model/mod.rs
+++ b/thoth-api/src/model/mod.rs
@@ -598,31 +598,31 @@ fn test_timestamp_default() {
 #[test]
 fn test_doi_display() {
     let doi = Doi("https://doi.org/10.12345/Test-Suffix.01".to_string());
-    assert_eq!(format!("{}", doi), "10.12345/Test-Suffix.01");
+    assert_eq!(format!("{doi}"), "10.12345/Test-Suffix.01");
 }
 
 #[test]
 fn test_isbn_display() {
     let isbn = Isbn("978-3-16-148410-0".to_string());
-    assert_eq!(format!("{}", isbn), "978-3-16-148410-0");
+    assert_eq!(format!("{isbn}"), "978-3-16-148410-0");
 }
 
 #[test]
 fn test_orcid_display() {
     let orcid = Orcid("https://orcid.org/0000-0002-1234-5678".to_string());
-    assert_eq!(format!("{}", orcid), "0000-0002-1234-5678");
+    assert_eq!(format!("{orcid}"), "0000-0002-1234-5678");
 }
 
 #[test]
 fn test_ror_display() {
     let ror = Ror("https://ror.org/0abcdef12".to_string());
-    assert_eq!(format!("{}", ror), "0abcdef12");
+    assert_eq!(format!("{ror}"), "0abcdef12");
 }
 
 #[test]
 fn test_timestamp_display() {
     let stamp: Timestamp = Default::default();
-    assert_eq!(format!("{}", stamp), "1970-01-01 00:00:00");
+    assert_eq!(format!("{stamp}"), "1970-01-01 00:00:00");
 }
 
 #[test]

--- a/thoth-api/src/model/publication/crud.rs
+++ b/thoth-api/src/model/publication/crud.rs
@@ -112,7 +112,7 @@ impl Crud for Publication {
         if let Some(filter) = filter {
             // ISBN field is nullable, so searching with an empty filter could fail
             if !filter.is_empty() {
-                query = query.filter(isbn.ilike(format!("%{}%", filter)));
+                query = query.filter(isbn.ilike(format!("%{filter}%")));
             }
         }
         match query
@@ -146,7 +146,7 @@ impl Crud for Publication {
         if let Some(filter) = filter {
             // ISBN field is nullable, so searching with an empty filter could fail
             if !filter.is_empty() {
-                query = query.filter(isbn.ilike(format!("%{}%", filter)));
+                query = query.filter(isbn.ilike(format!("%{filter}%")));
             }
         }
 

--- a/thoth-api/src/model/publisher/crud.rs
+++ b/thoth-api/src/model/publisher/crud.rs
@@ -72,8 +72,8 @@ impl Crud for Publisher {
         if let Some(filter) = filter {
             query = query.filter(
                 publisher_name
-                    .ilike(format!("%{}%", filter))
-                    .or(publisher_shortname.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(publisher_shortname.ilike(format!("%{filter}%"))),
             );
         }
         match query
@@ -102,8 +102,8 @@ impl Crud for Publisher {
         if let Some(filter) = filter {
             query = query.filter(
                 publisher_name
-                    .ilike(format!("%{}%", filter))
-                    .or(publisher_shortname.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(publisher_shortname.ilike(format!("%{filter}%"))),
             );
         }
 

--- a/thoth-api/src/model/reference/crud.rs
+++ b/thoth-api/src/model/reference/crud.rs
@@ -155,19 +155,19 @@ impl Crud for Reference {
             // All searchable fields are nullable, so searching with an empty filter could fail
             if !filter.is_empty() {
                 query = query.filter(
-                    doi.ilike(format!("%{}%", filter))
-                        .or(unstructured_citation.ilike(format!("%{}%", filter)))
-                        .or(issn.ilike(format!("%{}%", filter)))
-                        .or(isbn.ilike(format!("%{}%", filter)))
-                        .or(journal_title.ilike(format!("%{}%", filter)))
-                        .or(article_title.ilike(format!("%{}%", filter)))
-                        .or(series_title.ilike(format!("%{}%", filter)))
-                        .or(volume_title.ilike(format!("%{}%", filter)))
-                        .or(author.ilike(format!("%{}%", filter)))
-                        .or(standard_designator.ilike(format!("%{}%", filter)))
-                        .or(standards_body_name.ilike(format!("%{}%", filter)))
-                        .or(url.ilike(format!("%{}%", filter)))
-                        .or(standards_body_acronym.ilike(format!("%{}%", filter))),
+                    doi.ilike(format!("%{filter}%"))
+                        .or(unstructured_citation.ilike(format!("%{filter}%")))
+                        .or(issn.ilike(format!("%{filter}%")))
+                        .or(isbn.ilike(format!("%{filter}%")))
+                        .or(journal_title.ilike(format!("%{filter}%")))
+                        .or(article_title.ilike(format!("%{filter}%")))
+                        .or(series_title.ilike(format!("%{filter}%")))
+                        .or(volume_title.ilike(format!("%{filter}%")))
+                        .or(author.ilike(format!("%{filter}%")))
+                        .or(standard_designator.ilike(format!("%{filter}%")))
+                        .or(standards_body_name.ilike(format!("%{filter}%")))
+                        .or(url.ilike(format!("%{filter}%")))
+                        .or(standards_body_acronym.ilike(format!("%{filter}%"))),
                 );
             }
         }
@@ -200,19 +200,19 @@ impl Crud for Reference {
             // All searchable fields are nullable, so searching with an empty filter could fail
             if !filter.is_empty() {
                 query = query.filter(
-                    doi.ilike(format!("%{}%", filter))
-                        .or(unstructured_citation.ilike(format!("%{}%", filter)))
-                        .or(issn.ilike(format!("%{}%", filter)))
-                        .or(isbn.ilike(format!("%{}%", filter)))
-                        .or(journal_title.ilike(format!("%{}%", filter)))
-                        .or(article_title.ilike(format!("%{}%", filter)))
-                        .or(series_title.ilike(format!("%{}%", filter)))
-                        .or(volume_title.ilike(format!("%{}%", filter)))
-                        .or(author.ilike(format!("%{}%", filter)))
-                        .or(standard_designator.ilike(format!("%{}%", filter)))
-                        .or(standards_body_name.ilike(format!("%{}%", filter)))
-                        .or(url.ilike(format!("%{}%", filter)))
-                        .or(standards_body_acronym.ilike(format!("%{}%", filter))),
+                    doi.ilike(format!("%{filter}%"))
+                        .or(unstructured_citation.ilike(format!("%{filter}%")))
+                        .or(issn.ilike(format!("%{filter}%")))
+                        .or(isbn.ilike(format!("%{filter}%")))
+                        .or(journal_title.ilike(format!("%{filter}%")))
+                        .or(article_title.ilike(format!("%{filter}%")))
+                        .or(series_title.ilike(format!("%{filter}%")))
+                        .or(volume_title.ilike(format!("%{filter}%")))
+                        .or(author.ilike(format!("%{filter}%")))
+                        .or(standard_designator.ilike(format!("%{filter}%")))
+                        .or(standards_body_name.ilike(format!("%{filter}%")))
+                        .or(url.ilike(format!("%{filter}%")))
+                        .or(standards_body_acronym.ilike(format!("%{filter}%"))),
                 );
             }
         }

--- a/thoth-api/src/model/series/crud.rs
+++ b/thoth-api/src/model/series/crud.rs
@@ -94,11 +94,11 @@ impl Crud for Series {
         if let Some(filter) = filter {
             query = query.filter(
                 series_name
-                    .ilike(format!("%{}%", filter))
-                    .or(issn_print.ilike(format!("%{}%", filter)))
-                    .or(issn_digital.ilike(format!("%{}%", filter)))
-                    .or(series_url.ilike(format!("%{}%", filter)))
-                    .or(series_description.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(issn_print.ilike(format!("%{filter}%")))
+                    .or(issn_digital.ilike(format!("%{filter}%")))
+                    .or(series_url.ilike(format!("%{filter}%")))
+                    .or(series_description.ilike(format!("%{filter}%"))),
             );
         }
         match query
@@ -132,11 +132,11 @@ impl Crud for Series {
         if let Some(filter) = filter {
             query = query.filter(
                 series_name
-                    .ilike(format!("%{}%", filter))
-                    .or(issn_print.ilike(format!("%{}%", filter)))
-                    .or(issn_digital.ilike(format!("%{}%", filter)))
-                    .or(series_url.ilike(format!("%{}%", filter)))
-                    .or(series_description.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(issn_print.ilike(format!("%{filter}%")))
+                    .or(issn_digital.ilike(format!("%{filter}%")))
+                    .or(series_url.ilike(format!("%{filter}%")))
+                    .or(series_description.ilike(format!("%{filter}%"))),
             );
         }
 

--- a/thoth-api/src/model/subject/crud.rs
+++ b/thoth-api/src/model/subject/crud.rs
@@ -81,7 +81,7 @@ impl Crud for Subject {
             query = query.filter(subject_type.eq(any(subject_types)));
         }
         if let Some(filter) = filter {
-            query = query.filter(subject_code.ilike(format!("%{}%", filter)));
+            query = query.filter(subject_code.ilike(format!("%{filter}%")));
         }
         match query
             .then_order_by(subject_code.asc())
@@ -108,7 +108,7 @@ impl Crud for Subject {
             query = query.filter(subject_type.eq(any(subject_types)));
         }
         if let Some(filter) = filter {
-            query = query.filter(subject_code.ilike(format!("%{}%", filter)));
+            query = query.filter(subject_code.ilike(format!("%{filter}%")));
         }
         // `SELECT COUNT(*)` in postgres returns a BIGINT, which diesel parses as i64. Juniper does
         // not implement i64 yet, only i32. The only sensible way, albeit shameful, to solve this

--- a/thoth-api/src/model/work/crud.rs
+++ b/thoth-api/src/model/work/crud.rs
@@ -279,12 +279,12 @@ impl Crud for Work {
         if let Some(filter) = filter {
             query = query.filter(
                 dsl::full_title
-                    .ilike(format!("%{}%", filter))
-                    .or(dsl::doi.ilike(format!("%{}%", filter)))
-                    .or(dsl::reference.ilike(format!("%{}%", filter)))
-                    .or(dsl::short_abstract.ilike(format!("%{}%", filter)))
-                    .or(dsl::long_abstract.ilike(format!("%{}%", filter)))
-                    .or(dsl::landing_page.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(dsl::doi.ilike(format!("%{filter}%")))
+                    .or(dsl::reference.ilike(format!("%{filter}%")))
+                    .or(dsl::short_abstract.ilike(format!("%{filter}%")))
+                    .or(dsl::long_abstract.ilike(format!("%{filter}%")))
+                    .or(dsl::landing_page.ilike(format!("%{filter}%"))),
             );
         }
         match query
@@ -321,12 +321,12 @@ impl Crud for Work {
         if let Some(filter) = filter {
             query = query.filter(
                 dsl::full_title
-                    .ilike(format!("%{}%", filter))
-                    .or(dsl::doi.ilike(format!("%{}%", filter)))
-                    .or(dsl::reference.ilike(format!("%{}%", filter)))
-                    .or(dsl::short_abstract.ilike(format!("%{}%", filter)))
-                    .or(dsl::long_abstract.ilike(format!("%{}%", filter)))
-                    .or(dsl::landing_page.ilike(format!("%{}%", filter))),
+                    .ilike(format!("%{filter}%"))
+                    .or(dsl::doi.ilike(format!("%{filter}%")))
+                    .or(dsl::reference.ilike(format!("%{filter}%")))
+                    .or(dsl::short_abstract.ilike(format!("%{filter}%")))
+                    .or(dsl::long_abstract.ilike(format!("%{filter}%")))
+                    .or(dsl::landing_page.ilike(format!("%{filter}%"))),
             );
         }
 

--- a/thoth-api/src/model/work/mod.rs
+++ b/thoth-api/src/model/work/mod.rs
@@ -332,7 +332,7 @@ impl WorkWithRelations {
 
     pub fn compile_page_interval(&self) -> Option<String> {
         if let (Some(first), Some(last)) = (&self.first_page.clone(), &self.last_page.clone()) {
-            Some(format!("{}–{}", first, last))
+            Some(format!("{first}–{last}"))
         } else {
             None
         }

--- a/thoth-app-server/src/lib.rs
+++ b/thoth-app-server/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn start_server(host: String, port: String) -> io::Result<()> {
             .configure(config)
             .default_service(web::route().to(index))
     })
-    .bind(format!("{}:{}", host, port))?
+    .bind(format!("{host}:{port}"))?
     .run()
     .await
 }

--- a/thoth-app/src/component/hero.rs
+++ b/thoth-app/src/component/hero.rs
@@ -5,7 +5,7 @@ use crate::{THOTH_EXPORT_API, THOTH_GRAPHQL_API};
 
 #[function_component(HeroComponent)]
 pub fn hero_component() -> VNode {
-    let graphiql = format!("{}/graphiql", THOTH_GRAPHQL_API);
+    let graphiql = format!("{THOTH_GRAPHQL_API}/graphiql");
     html! {
         <section class="hero is-warning">
             <div class="hero-body">

--- a/thoth-app/src/component/navbar.rs
+++ b/thoth-app/src/component/navbar.rs
@@ -42,7 +42,7 @@ impl Component for NavbarComponent {
             e.prevent_default();
             Msg::Logout
         });
-        let graphiql = format!("{}/graphiql", THOTH_GRAPHQL_API);
+        let graphiql = format!("{THOTH_GRAPHQL_API}/graphiql");
         html! {
             <nav class="navbar is-warning" role="navigation" aria-label="main navigation">
                 <div class="navbar-brand">

--- a/thoth-app/src/component/new_contributor.rs
+++ b/thoth-app/src/component/new_contributor.rs
@@ -244,7 +244,7 @@ impl Component for NewContributorComponent {
         if self.show_duplicate_tooltip && !self.contributors.is_empty() {
             tooltip = "Existing contributors with similar names:\n\n".to_string();
             for c in &self.contributors {
-                tooltip = format!("{}{}\n", tooltip, c);
+                tooltip = format!("{tooltip}{c}\n");
             }
         }
         html! {

--- a/thoth-app/src/models/book/books_query.rs
+++ b/thoth-app/src/models/book/books_query.rs
@@ -18,7 +18,7 @@ graphql_query_builder! {
     BooksRequest,
     BooksRequestBody,
     Variables,
-    format!("{}{}{}", BOOKS_QUERY_HEADER, WORKS_QUERY_BODY, BOOKS_QUERY_FOOTER),
+    format!("{BOOKS_QUERY_HEADER}{WORKS_QUERY_BODY}{BOOKS_QUERY_FOOTER}"),
     BooksResponseBody,
     BooksResponseData,
     FetchBooks,

--- a/thoth-app/src/models/chapter/chapters_query.rs
+++ b/thoth-app/src/models/chapter/chapters_query.rs
@@ -18,7 +18,7 @@ graphql_query_builder! {
     ChaptersRequest,
     ChaptersRequestBody,
     Variables,
-    format!("{}{}{}", CHAPTERS_QUERY_HEADER, WORKS_QUERY_BODY, CHAPTERS_QUERY_FOOTER),
+    format!("{CHAPTERS_QUERY_HEADER}{WORKS_QUERY_BODY}{CHAPTERS_QUERY_FOOTER}"),
     ChaptersResponseBody,
     ChaptersResponseData,
     FetchChapters,

--- a/thoth-app/src/models/work/slim_works_query.rs
+++ b/thoth-app/src/models/work/slim_works_query.rs
@@ -22,7 +22,7 @@ graphql_query_builder! {
     SlimWorksRequest,
     SlimWorksRequestBody,
     Variables,
-    format!("{}{}{}", WORKS_QUERY_HEADER, SLIM_WORKS_QUERY_BODY, WORKS_QUERY_FOOTER),
+    format!("{WORKS_QUERY_HEADER}{SLIM_WORKS_QUERY_BODY}{WORKS_QUERY_FOOTER}"),
     SlimWorksResponseBody,
     SlimWorksResponseData,
     FetchSlimWorks,

--- a/thoth-app/src/models/work/works_query.rs
+++ b/thoth-app/src/models/work/works_query.rs
@@ -58,7 +58,7 @@ graphql_query_builder! {
     WorksRequest,
     WorksRequestBody,
     Variables,
-    format!("{}{}{}", WORKS_QUERY_HEADER, WORKS_QUERY_BODY, WORKS_QUERY_FOOTER),
+    format!("{WORKS_QUERY_HEADER}{WORKS_QUERY_BODY}{WORKS_QUERY_FOOTER}"),
     WorksResponseBody,
     WorksResponseData,
     FetchWorks,

--- a/thoth-app/src/service/account.rs
+++ b/thoth-app/src/service/account.rs
@@ -133,7 +133,7 @@ impl AccountService {
             .request(verb, uri)
             .header("Content-Type", "application/json");
         if let Some(token) = self.get_token() {
-            request = request.header("Authorization", format!("Bearer {}", token));
+            request = request.header("Authorization", format!("Bearer {token}"));
         }
         if let Some(content) = body {
             request = request.body(content);

--- a/thoth-client/src/queries.rs
+++ b/thoth-client/src/queries.rs
@@ -19,13 +19,13 @@ pub struct WorkQuery;
 
 impl fmt::Display for work_query::LanguageCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
 impl fmt::Display for work_query::SubjectType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/thoth-errors/src/database_errors.rs
+++ b/thoth-errors/src/database_errors.rs
@@ -245,7 +245,7 @@ mod tests {
             error_information,
         ));
         assert_eq!(
-            format!("{}", error),
+            format!("{error}"),
             "A contribution with this ordinal number already exists.",
         )
     }
@@ -269,7 +269,7 @@ mod tests {
             DatabaseErrorKind::__Unknown,
             error_information,
         ));
-        assert_eq!(format!("{}", error), "Database error: Some error happened")
+        assert_eq!(format!("{error}"), "Database error: Some error happened")
     }
 
     #[test]

--- a/thoth-errors/src/lib.rs
+++ b/thoth-errors/src/lib.rs
@@ -158,7 +158,7 @@ impl fmt::Display for GraphqlError {
 impl fmt::Display for GraqphqlErrorMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for error in &self.errors {
-            write!(f, "{}", error)?;
+            write!(f, "{error}")?;
         }
         Ok(())
     }

--- a/thoth-export-server/src/bibtex/bibtex_thoth.rs
+++ b/thoth-export-server/src/bibtex/bibtex_thoth.rs
@@ -79,53 +79,53 @@ impl fmt::Display for BibtexThothEntry {
         writeln!(f, "@{}{{{},", self.entry_type, citekey)?;
         write!(f, "\ttitle\t\t= {{{}}}", self.title)?;
         if let Some(shorttitle) = &self.shorttitle {
-            write!(f, ",\n\tshorttitle\t= {{{}}}", shorttitle)?;
+            write!(f, ",\n\tshorttitle\t= {{{shorttitle}}}")?;
         }
         if let Some(author) = &self.author {
-            write!(f, ",\n\tauthor\t\t= {{{}}}", author)?;
+            write!(f, ",\n\tauthor\t\t= {{{author}}}")?;
         }
         if let Some(editor) = &self.editor {
-            write!(f, ",\n\teditor\t\t= {{{}}}", editor)?;
+            write!(f, ",\n\teditor\t\t= {{{editor}}}")?;
         }
         write!(f, ",\n\tyear\t\t= {}", self.year)?;
         write!(f, ",\n\tmonth\t\t= {}", self.month)?;
         write!(f, ",\n\tday\t\t\t= {}", self.day)?;
         write!(f, ",\n\tpublisher\t= {{{}}}", self.publisher)?;
         if let Some(address) = &self.address {
-            write!(f, ",\n\taddress\t\t= {{{}}}", address)?;
+            write!(f, ",\n\taddress\t\t= {{{address}}}")?;
         }
         if let Some(series) = &self.series {
-            write!(f, ",\n\tseries\t\t= {{{}}}", series)?;
+            write!(f, ",\n\tseries\t\t= {{{series}}}")?;
         }
         if let Some(volume) = &self.volume {
-            write!(f, ",\n\tvolume\t\t= {}", volume)?;
+            write!(f, ",\n\tvolume\t\t= {volume}")?;
         }
         if let Some(booktitle) = &self.booktitle {
-            write!(f, ",\n\tbooktitle\t= {{{}}}", booktitle)?;
+            write!(f, ",\n\tbooktitle\t= {{{booktitle}}}")?;
         }
         if let Some(chapter) = &self.chapter {
-            write!(f, ",\n\tchapter\t\t= {}", chapter)?;
+            write!(f, ",\n\tchapter\t\t= {chapter}")?;
         }
         if let Some(pages) = &self.pages {
-            write!(f, ",\n\tpages\t\t= {{{}}}", pages)?;
+            write!(f, ",\n\tpages\t\t= {{{pages}}}")?;
         }
         if let Some(doi) = &self.doi {
-            write!(f, ",\n\tdoi\t\t\t= {{{}}}", doi)?;
+            write!(f, ",\n\tdoi\t\t\t= {{{doi}}}")?;
         }
         if let Some(isbn) = &self.isbn {
-            write!(f, ",\n\tisbn\t\t= {{{}}}", isbn)?;
+            write!(f, ",\n\tisbn\t\t= {{{isbn}}}")?;
         }
         if let Some(issn) = &self.issn {
-            write!(f, ",\n\tissn\t\t= {{{}}}", issn)?;
+            write!(f, ",\n\tissn\t\t= {{{issn}}}")?;
         }
         if let Some(url) = &self.url {
-            write!(f, ",\n\turl\t\t\t= {{{}}}", url)?;
+            write!(f, ",\n\turl\t\t\t= {{{url}}}")?;
         }
         if let Some(copyright) = &self.copyright {
-            write!(f, ",\n\tcopyright\t= {{{}}}", copyright)?;
+            write!(f, ",\n\tcopyright\t= {{{copyright}}}")?;
         }
         if let Some(long_abstract) = &self.long_abstract {
-            write!(f, ",\n\tabstract\t= {{{}}}", long_abstract)?;
+            write!(f, ",\n\tabstract\t= {{{long_abstract}}}")?;
         }
         writeln!(f, "\n}}")
     }

--- a/thoth-export-server/src/csv/csv_thoth.rs
+++ b/thoth-export-server/src/csv/csv_thoth.rs
@@ -380,7 +380,7 @@ impl CsvCell<CsvThoth> for WorkContributionsAffiliations {
             self.institution
                 .country_code
                 .as_ref()
-                .map(|c| format!("{:?}", c))
+                .map(|c| format!("{c:?}"))
                 .unwrap_or_default(),
         )
     }
@@ -435,7 +435,7 @@ impl CsvCell<CsvThoth> for WorkFundings {
             self.institution
                 .country_code
                 .as_ref()
-                .map(|c| format!("{:?}", c))
+                .map(|c| format!("{c:?}"))
                 .unwrap_or_default(),
             self.program.clone().unwrap_or_default(),
             self.project_name.clone().unwrap_or_default(),

--- a/thoth-export-server/src/lib.rs
+++ b/thoth-export-server/src/lib.rs
@@ -27,7 +27,7 @@ struct ApiConfig {
 impl ApiConfig {
     pub fn new(public_url: String) -> Self {
         Self {
-            api_schema: format!("{}/swagger.json", public_url),
+            api_schema: format!("{public_url}/swagger.json"),
         }
     }
 }
@@ -103,7 +103,7 @@ pub async fn start_server(
             .with_json_spec_at("/swagger.json")
             .build()
     })
-    .bind(format!("{}:{}", host, port))?
+    .bind(format!("{host}:{port}"))?
     .run()
     .await
 }

--- a/thoth-export-server/src/rapidoc.rs
+++ b/thoth-export-server/src/rapidoc.rs
@@ -29,7 +29,6 @@ pub fn rapidoc_source(openapi_spec: &str) -> String {
       </rapi-doc>
     </body>
 </html>
-"#,
-        openapi_spec = openapi_spec
+"#
     )
 }

--- a/thoth-export-server/src/xml/onix3_google_books.rs
+++ b/thoth-export-server/src/xml/onix3_google_books.rs
@@ -406,7 +406,7 @@ impl XmlElementBlock<Onix3GoogleBooks> for Work {
                             })
                             .map(|pr| pr.unit_price)
                         {
-                            let formatted_price = format!("{:.2}", price);
+                            let formatted_price = format!("{price:.2}");
                             write_element_block("Price", w, |w| {
                                 // 02 RRP including tax
                                 write_element_block("PriceType", w, |w| {

--- a/thoth-export-server/src/xml/onix3_overdrive.rs
+++ b/thoth-export-server/src/xml/onix3_overdrive.rs
@@ -490,7 +490,7 @@ impl XmlElementBlock<Onix3Overdrive> for Work {
                                 })
                                 .map(|pr| pr.unit_price)
                             {
-                                let formatted_price = format!("{:.2}", price);
+                                let formatted_price = format!("{price:.2}");
                                 write_element_block("Price", w, |w| {
                                     // 02 RRP including tax
                                     write_element_block("PriceType", w, |w| {


### PR DESCRIPTION
Some non-inlined variables remain where the format string contains a mixture of variables which can and can't be inlined. These won't trigger Clippy warnings unless [allow-mixed-uninlined-format-args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) is set to false.