### PR TITLE
Feature/reduce institution queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Upgrade `openssl-src` to v111.25.0
   - Upgrade `bumpalo` to v3.12.0
 
+### Fixed
+  - [#326](https://github.com/thoth-pub/thoth/issues/326) - Debounce search queries
+
 ## [[0.9.13]](https://github.com/thoth-pub/thoth/releases/tag/v0.9.13) - 2023-02-21
 ### Changed
   - Input actix keep alive via CLI arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+  - Upgrade `openssl-src` to v111.25.0
 
 ## [[0.9.13]](https://github.com/thoth-pub/thoth/releases/tag/v0.9.13) - 2023-02-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
   - Upgrade `openssl-src` to v111.25.0
+  - Upgrade `bumpalo` to v3.12.0
 
 ## [[0.9.13]](https://github.com/thoth-pub/thoth/releases/tag/v0.9.13) - 2023-02-21
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,9 +2647,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.25.0+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,13 +962,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "autocfg 1.0.0",
  "cfg-if 1.0.0",
- "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -3508,7 +3506,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.4",
+ "crossbeam-utils 0.8.15",
 ]
 
 [[package]]

--- a/thoth-app/src/component/affiliations_form.rs
+++ b/thoth-app/src/component/affiliations_form.rs
@@ -138,7 +138,7 @@ impl Component for AffiliationsFormComponent {
                 if show_form {
                     let body = InstitutionsRequestBody {
                         variables: SearchVariables {
-                            limit: Some(9999),
+                            limit: Some(25),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -395,7 +395,7 @@ impl Component for AffiliationsFormComponent {
                 let body = InstitutionsRequestBody {
                     variables: SearchVariables {
                         filter: Some(value),
-                        limit: Some(9999),
+                        limit: Some(25),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/thoth-app/src/component/affiliations_form.rs
+++ b/thoth-app/src/component/affiliations_form.rs
@@ -1,3 +1,4 @@
+use gloo_timers::callback::Timeout;
 use thoth_api::model::affiliation::AffiliationWithInstitution;
 use thoth_api::model::institution::Institution;
 use thoth_errors::ThothError;
@@ -46,6 +47,7 @@ use crate::models::Dropdown;
 use crate::string::CANCEL_BUTTON;
 use crate::string::EDIT_BUTTON;
 use crate::string::REMOVE_BUTTON;
+use crate::DEFAULT_DEBOUNCING_TIMEOUT;
 
 use super::ToElementValue;
 use super::ToOption;
@@ -62,6 +64,9 @@ pub struct AffiliationsFormComponent {
     delete_affiliation: PushDeleteAffiliation,
     update_affiliation: PushUpdateAffiliation,
     notification_bus: NotificationDispatcher,
+    search_callback: Callback<()>,
+    search_query: String,
+    debounce_timeout: Option<Timeout>,
 }
 
 #[derive(Default)]
@@ -77,7 +82,8 @@ pub enum Msg {
     SetInstitutionsFetchState(FetchActionInstitutions),
     GetInstitutions,
     ToggleSearchResultDisplay(bool),
-    SearchInstitution(String),
+    SearchQueryChanged(String),
+    SearchInstitution,
     SetAffiliationCreateState(PushActionCreateAffiliation),
     CreateAffiliation,
     SetAffiliationUpdateState(PushActionUpdateAffiliation),
@@ -111,6 +117,8 @@ impl Component for AffiliationsFormComponent {
         let delete_affiliation = Default::default();
         let update_affiliation = Default::default();
         let notification_bus = NotificationBus::dispatcher();
+        let search_callback = ctx.link().callback(|_| Msg::SearchInstitution);
+        let search_query: String = Default::default();
 
         ctx.link().send_message(Msg::GetAffiliations);
         ctx.link().send_message(Msg::GetInstitutions);
@@ -127,6 +135,9 @@ impl Component for AffiliationsFormComponent {
             delete_affiliation,
             update_affiliation,
             notification_bus,
+            search_callback,
+            search_query,
+            debounce_timeout: None,
         }
     }
 
@@ -391,10 +402,25 @@ impl Component for AffiliationsFormComponent {
                 self.show_results = value;
                 true
             }
-            Msg::SearchInstitution(value) => {
+            Msg::SearchQueryChanged(value) => {
+                self.search_query = value;
+                // cancel previous timeout
+                self.debounce_timeout = self.debounce_timeout.take().and_then(|timeout| {
+                    timeout.cancel();
+                    None
+                });
+                // start new timeout
+                let search_callback = self.search_callback.clone();
+                let timeout = Timeout::new(DEFAULT_DEBOUNCING_TIMEOUT, move || {
+                    search_callback.emit(());
+                });
+                self.debounce_timeout = Some(timeout);
+                false
+            }
+            Msg::SearchInstitution => {
                 let body = InstitutionsRequestBody {
                     variables: SearchVariables {
-                        filter: Some(value),
+                        filter: Some(self.search_query.clone()),
                         limit: Some(25),
                         ..Default::default()
                     },
@@ -531,7 +557,7 @@ impl Component for AffiliationsFormComponent {
                                                 placeholder="Search Institution"
                                                 aria-haspopup="true"
                                                 aria-controls="institutions-menu"
-                                                oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchInstitution(e.to_value())) }
+                                                oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchQueryChanged(e.to_value())) }
                                                 onfocus={ ctx.link().callback(|_| Msg::ToggleSearchResultDisplay(true)) }
                                                 onblur={ ctx.link().callback(|_| Msg::ToggleSearchResultDisplay(false)) }
                                             />

--- a/thoth-app/src/component/catalogue.rs
+++ b/thoth-app/src/component/catalogue.rs
@@ -25,7 +25,7 @@ pub struct CatalogueComponent {
     limit: i32,
     offset: i32,
     page_size: i32,
-    search_term: String,
+    search_query: String,
     data: Vec<WorkWithRelations>,
     result_count: i32,
     fetch_data: FetchWorks,
@@ -39,7 +39,7 @@ pub enum Msg {
     PaginateData,
     #[allow(dead_code)]
     Search(String),
-    ChangeSearchTerm(String),
+    SearchQueryChanged(String),
     TriggerSearch,
     NextPage,
     PreviousPage,
@@ -53,7 +53,7 @@ impl Component for CatalogueComponent {
         let offset: i32 = Default::default();
         let page_size: i32 = 10;
         let limit: i32 = page_size;
-        let search_term: String = Default::default();
+        let search_query: String = Default::default();
         let result_count: i32 = Default::default();
         let data = Default::default();
         let fetch_data = Default::default();
@@ -64,7 +64,7 @@ impl Component for CatalogueComponent {
             limit,
             offset,
             page_size,
-            search_term,
+            search_query,
             data,
             result_count,
             fetch_data,
@@ -93,7 +93,7 @@ impl Component for CatalogueComponent {
                 false
             }
             Msg::PaginateData => {
-                let filter = self.search_term.clone();
+                let filter = self.search_query.clone();
                 let body = WorksRequestBody {
                     variables: Variables {
                         limit: Some(self.limit),
@@ -115,8 +115,8 @@ impl Component for CatalogueComponent {
                 // needed because of macro, but unused here
                 false
             }
-            Msg::ChangeSearchTerm(term) => {
-                self.search_term = term;
+            Msg::SearchQueryChanged(term) => {
+                self.search_query = term;
                 false
             }
             Msg::TriggerSearch => {
@@ -178,9 +178,9 @@ impl Component for CatalogueComponent {
                                     <input
                                         class="input"
                                         type="search"
-                                        value={ self.search_term.clone() }
+                                        value={ self.search_query.clone() }
                                         placeholder={ self.search_text() }
-                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::ChangeSearchTerm(e.to_value())) }
+                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchQueryChanged(e.to_value())) }
                                     />
                                     <span class="icon is-left">
                                         <i class="fas fa-search" aria-hidden="true"></i>

--- a/thoth-app/src/component/contributions_form.rs
+++ b/thoth-app/src/component/contributions_form.rs
@@ -435,7 +435,7 @@ impl Component for ContributionsFormComponent {
                 let body = ContributorsRequestBody {
                     variables: Variables {
                         filter: Some(self.search_query.clone()),
-                        limit: Some(50),
+                        limit: Some(25),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/thoth-app/src/component/fundings_form.rs
+++ b/thoth-app/src/component/fundings_form.rs
@@ -250,7 +250,7 @@ impl Component for FundingsFormComponent {
                 let body = InstitutionsRequestBody {
                     variables: Variables {
                         filter: Some(value),
-                        limit: Some(9999),
+                        limit: Some(25),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -281,7 +281,7 @@ impl Component for IssuesFormComponent {
                 let body = SeriesesRequestBody {
                     variables: Variables {
                         filter: Some(self.search_query.clone()),
-                        limit: Some(50),
+                        limit: Some(25),
                         publishers: ctx.props().current_user.resource_access.restricted_to(),
                         ..Default::default()
                     },

--- a/thoth-app/src/component/issues_form.rs
+++ b/thoth-app/src/component/issues_form.rs
@@ -1,3 +1,4 @@
+use gloo_timers::callback::Timeout;
 use thoth_api::account::model::AccountAccess;
 use thoth_api::account::model::AccountDetails;
 use thoth_api::model::issue::IssueWithSeries;
@@ -36,6 +37,7 @@ use crate::models::Dropdown;
 use crate::string::CANCEL_BUTTON;
 use crate::string::EMPTY_ISSUES;
 use crate::string::REMOVE_BUTTON;
+use crate::DEFAULT_DEBOUNCING_TIMEOUT;
 
 use super::ToElementValue;
 
@@ -50,6 +52,9 @@ pub struct IssuesFormComponent {
     notification_bus: NotificationDispatcher,
     // Store props value locally in order to test whether it has been updated on props change
     resource_access: AccountAccess,
+    search_callback: Callback<()>,
+    search_query: String,
+    debounce_timeout: Option<Timeout>,
 }
 
 #[derive(Default)]
@@ -68,7 +73,8 @@ pub enum Msg {
     DeleteIssue(Uuid),
     AddIssue(SeriesWithImprint),
     ToggleSearchResultDisplay(bool),
-    SearchSeries(String),
+    SearchQueryChanged(String),
+    SearchSeries,
     ChangeOrdinal(String),
 }
 
@@ -103,6 +109,8 @@ impl Component for IssuesFormComponent {
         let delete_issue = Default::default();
         let notification_bus = NotificationBus::dispatcher();
         let resource_access = ctx.props().current_user.resource_access.clone();
+        let search_callback = ctx.link().callback(|_| Msg::SearchSeries);
+        let search_query: String = Default::default();
 
         ctx.link().send_message(Msg::GetSerieses);
 
@@ -116,6 +124,9 @@ impl Component for IssuesFormComponent {
             delete_issue,
             notification_bus,
             resource_access,
+            search_callback,
+            search_query,
+            debounce_timeout: None,
         }
     }
 
@@ -251,11 +262,26 @@ impl Component for IssuesFormComponent {
                 self.show_results = value;
                 true
             }
-            Msg::SearchSeries(value) => {
+            Msg::SearchQueryChanged(value) => {
+                self.search_query = value;
+                // cancel previous timeout
+                self.debounce_timeout = self.debounce_timeout.take().and_then(|timeout| {
+                    timeout.cancel();
+                    None
+                });
+                // start new timeout
+                let search_callback = self.search_callback.clone();
+                let timeout = Timeout::new(DEFAULT_DEBOUNCING_TIMEOUT, move || {
+                    search_callback.emit(());
+                });
+                self.debounce_timeout = Some(timeout);
+                false
+            }
+            Msg::SearchSeries => {
                 let body = SeriesesRequestBody {
                     variables: Variables {
-                        filter: Some(value),
-                        limit: Some(9999),
+                        filter: Some(self.search_query.clone()),
+                        limit: Some(50),
                         publishers: ctx.props().current_user.resource_access.restricted_to(),
                         ..Default::default()
                     },
@@ -308,7 +334,7 @@ impl Component for IssuesFormComponent {
                                         placeholder="Search Series"
                                         aria-haspopup="true"
                                         aria-controls="serieses-menu"
-                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchSeries(e.to_value())) }
+                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchQueryChanged(e.to_value())) }
                                         onfocus={ ctx.link().callback(|_| Msg::ToggleSearchResultDisplay(true)) }
                                         onblur={ ctx.link().callback(|_| Msg::ToggleSearchResultDisplay(false)) }
                                     />

--- a/thoth-app/src/component/mod.rs
+++ b/thoth-app/src/component/mod.rs
@@ -49,9 +49,9 @@ macro_rules! pagination_helpers {
                                     <input
                                         class="input"
                                         type="search"
-                                        value={ self.search_term.clone() }
+                                        value={ self.search_query.clone() }
                                         placeholder={ self.search_text() }
-                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::Search(e.to_value())) }
+                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchQueryChanged(e.to_value())) }
                                     />
                                     <span class="icon is-left">
                                         <i class="fas fa-search" aria-hidden="true"></i>
@@ -84,11 +84,13 @@ macro_rules! pagination_component {
         $order_struct:ty,
         $order_field:ty,
     ) => {
+        use gloo_timers::callback::Timeout;
         use std::str::FromStr;
         use thoth_api::account::model::AccountAccess;
         use thoth_api::account::model::AccountDetails;
         use thoth_api::graphql::utils::Direction::*;
         use thoth_errors::ThothError;
+        use yew::Callback;
         use yew::html;
         use yew::prelude::Component;
         use yew::prelude::Context;
@@ -107,12 +109,15 @@ macro_rules! pagination_component {
         use $crate::component::utils::Reloader;
         use $crate::models::{EditRoute, CreateRoute, MetadataTable};
         use $crate::route::AdminRoute;
+        use $crate::DEFAULT_DEBOUNCING_TIMEOUT;
 
         pub struct $component {
             limit: i32,
             offset: i32,
             page_size: i32,
-            search_term: String,
+            search_callback: Callback<()>,
+            search_query: String,
+            debounce_timeout: Option<Timeout>,
             order: $order_struct,
             data: Vec<$entity>,
             table_headers: Vec<String>,
@@ -128,7 +133,7 @@ macro_rules! pagination_component {
             SetFetchState($fetch_action),
             GetData,
             PaginateData,
-            Search(String),
+            SearchQueryChanged(String),
             NextPage,
             PreviousPage,
             ChangeRoute(AdminRoute),
@@ -148,7 +153,8 @@ macro_rules! pagination_component {
                 let offset: i32 = Default::default();
                 let page_size: i32 = 20;
                 let limit: i32 = page_size;
-                let search_term: String = Default::default();
+                let search_callback = ctx.link().callback(|_| Msg::PaginateData);
+                let search_query: String = Default::default();
                 let order = Default::default();
                 let result_count: i32 = Default::default();
                 let data = Default::default();
@@ -163,7 +169,9 @@ macro_rules! pagination_component {
                     limit,
                     offset,
                     page_size,
-                    search_term,
+                    search_callback,
+                    search_query,
+                    debounce_timeout: None,
                     order,
                     data,
                     table_headers,
@@ -195,7 +203,7 @@ macro_rules! pagination_component {
                         false
                     }
                     Msg::PaginateData => {
-                        let filter = self.search_term.clone();
+                        let filter = self.search_query.clone();
                         let order = self.order.clone();
                         let body = $request_body {
                             variables: $request_variables {
@@ -212,10 +220,21 @@ macro_rules! pagination_component {
                         ctx.link().send_message(Msg::GetData);
                         false
                     }
-                    Msg::Search(term) => {
+                    Msg::SearchQueryChanged(query) => {
                         self.offset = 0;
-                        self.search_term = term;
-                        ctx.link().send_message(Msg::PaginateData);
+                        self.search_query = query;
+
+                        // cancel previous timeout
+                        self.debounce_timeout = self.debounce_timeout.take().and_then(|timeout| {
+                            timeout.cancel();
+                            None
+                        });
+                        // start new timeout
+                        let search_callback = self.search_callback.clone();
+                        let timeout = Timeout::new(DEFAULT_DEBOUNCING_TIMEOUT, move || {
+                            search_callback.emit(());
+                        });
+                        self.debounce_timeout = Some(timeout);
                         false
                     }
                     Msg::NextPage => {

--- a/thoth-app/src/component/related_works_form.rs
+++ b/thoth-app/src/component/related_works_form.rs
@@ -413,7 +413,7 @@ impl Component for RelatedWorksFormComponent {
                 let body = SlimWorksRequestBody {
                     variables: Variables {
                         filter: Some(self.search_query.clone()),
-                        limit: Some(50),
+                        limit: Some(25),
                         publishers: ctx.props().current_user.resource_access.restricted_to(),
                         ..Default::default()
                     },

--- a/thoth-app/src/component/related_works_form.rs
+++ b/thoth-app/src/component/related_works_form.rs
@@ -1,3 +1,4 @@
+use gloo_timers::callback::Timeout;
 use std::str::FromStr;
 use thoth_api::account::model::AccountAccess;
 use thoth_api::account::model::AccountDetails;
@@ -53,6 +54,7 @@ use crate::string::EDIT_BUTTON;
 use crate::string::EMPTY_RELATIONS;
 use crate::string::REMOVE_BUTTON;
 use crate::string::VIEW_BUTTON;
+use crate::DEFAULT_DEBOUNCING_TIMEOUT;
 
 use super::ToElementValue;
 
@@ -70,6 +72,9 @@ pub struct RelatedWorksFormComponent {
     notification_bus: NotificationDispatcher,
     // Store props value locally in order to test whether it has been updated on props change
     resource_access: AccountAccess,
+    search_callback: Callback<()>,
+    search_query: String,
+    debounce_timeout: Option<Timeout>,
 }
 
 #[derive(Default)]
@@ -86,7 +91,8 @@ pub enum Msg {
     SetRelationTypesFetchState(FetchActionRelationTypes),
     GetRelationTypes,
     ToggleSearchResultDisplay(bool),
-    SearchWork(String),
+    SearchQueryChanged(String),
+    SearchWork,
     SetRelationCreateState(PushActionCreateWorkRelation),
     CreateWorkRelation,
     SetRelationUpdateState(PushActionUpdateWorkRelation),
@@ -132,6 +138,8 @@ impl Component for RelatedWorksFormComponent {
         let update_relation = Default::default();
         let notification_bus = NotificationBus::dispatcher();
         let resource_access = ctx.props().current_user.resource_access.clone();
+        let search_callback = ctx.link().callback(|_| Msg::SearchWork);
+        let search_query: String = Default::default();
 
         ctx.link().send_message(Msg::GetWorks);
         ctx.link().send_message(Msg::GetRelationTypes);
@@ -149,6 +157,9 @@ impl Component for RelatedWorksFormComponent {
             update_relation,
             notification_bus,
             resource_access,
+            search_callback,
+            search_query,
+            debounce_timeout: None,
         }
     }
 
@@ -383,11 +394,26 @@ impl Component for RelatedWorksFormComponent {
                 self.show_results = value;
                 true
             }
-            Msg::SearchWork(value) => {
+            Msg::SearchQueryChanged(value) => {
+                self.search_query = value;
+                // cancel previous timeout
+                self.debounce_timeout = self.debounce_timeout.take().and_then(|timeout| {
+                    timeout.cancel();
+                    None
+                });
+                // start new timeout
+                let search_callback = self.search_callback.clone();
+                let timeout = Timeout::new(DEFAULT_DEBOUNCING_TIMEOUT, move || {
+                    search_callback.emit(());
+                });
+                self.debounce_timeout = Some(timeout);
+                false
+            }
+            Msg::SearchWork => {
                 let body = SlimWorksRequestBody {
                     variables: Variables {
-                        filter: Some(value),
-                        limit: Some(9999),
+                        filter: Some(self.search_query.clone()),
+                        limit: Some(50),
                         publishers: ctx.props().current_user.resource_access.restricted_to(),
                         ..Default::default()
                     },
@@ -456,7 +482,7 @@ impl Component for RelatedWorksFormComponent {
                                         placeholder="Search Work"
                                         aria-haspopup="true"
                                         aria-controls="works-menu"
-                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchWork(e.to_value())) }
+                                        oninput={ ctx.link().callback(|e: InputEvent| Msg::SearchQueryChanged(e.to_value())) }
                                         onfocus={ ctx.link().callback(|_| Msg::ToggleSearchResultDisplay(true)) }
                                         onblur={ ctx.link().callback(|_| Msg::ToggleSearchResultDisplay(false)) }
                                     />

--- a/thoth-app/src/lib.rs
+++ b/thoth-app/src/lib.rs
@@ -17,6 +17,8 @@ use crate::component::root::RootComponent;
 pub const THOTH_GRAPHQL_API: &str = env!("THOTH_GRAPHQL_API");
 pub const THOTH_EXPORT_API: &str = env!("THOTH_EXPORT_API");
 const SESSION_KEY: &str = "thoth.token";
+/// Default number of milliseconds to wait before sending a search query
+const DEFAULT_DEBOUNCING_TIMEOUT: u32 = 500;
 
 #[wasm_bindgen]
 pub fn run_app() -> Result<(), JsValue> {


### PR DESCRIPTION
Fixes #326 

Uses a `gloo_timers::callback::Timeout` to debounce search queries. The dynamic is the same in all files:
1. Instead of querying `oninput` we call an intermediary step
2. `Msg::SearchQueryChanged(value)` stores the input value and
    1. stops any running timer
    2. starts a new timer (500ms) with a callback that triggers the query
3. The actual search function uses the stored value and gets triggered by the timeout callback