### PR TITLE
Update ProQuest ONIX 2.1 (replace zero price composite with UnpricedItemType)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
   - Upgrade rust to `1.73.0` in production and development `Dockerfile`
   - Upgrade build dependencies (npm `v10.2.0`, node `v18.18.2`, n `v9.2.0` and rollup `v4.1.4`) in production and development `Dockerfile`
+  - [519](https://github.com/thoth-pub/thoth/issues/519) - Update ProQuest Ebrary (Ebook Central) ONIX output pricing
 
 ## [[0.11.7]](https://github.com/thoth-pub/thoth/releases/tag/v0.11.7) - 2023-10-02
 ### Changed

--- a/thoth-export-server/src/xml/onix21_proquest_ebrary.rs
+++ b/thoth-export-server/src/xml/onix21_proquest_ebrary.rs
@@ -405,18 +405,9 @@ impl XmlElementBlock<Onix21ProquestEbrary> for Work {
                         w.write(XmlEvent::Characters("Open access"))
                             .map_err(|e| e.into())
                     })?;
-                    // ProQuest Ebrary require the price point for Open Access titles to be listed as "0.00 USD".
-                    write_element_block("Price", w, |w| {
-                        // 02 RRP including tax
-                        write_element_block("PriceTypeCode", w, |w| {
-                            w.write(XmlEvent::Characters("02")).map_err(|e| e.into())
-                        })?;
-                        write_element_block("PriceAmount", w, |w| {
-                            w.write(XmlEvent::Characters("0.00")).map_err(|e| e.into())
-                        })?;
-                        write_element_block("CurrencyCode", w, |w| {
-                            w.write(XmlEvent::Characters("USD")).map_err(|e| e.into())
-                        })
+                    // ProQuest Ebrary require Open Access titles to be listed as 01 Free of charge
+                    write_element_block("UnpricedItemType", w, |w| {
+                        w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
                     })
                 })
             })
@@ -1072,10 +1063,7 @@ mod tests {
         assert!(output.contains(r#"    <AudienceRestrictionFlag>R</AudienceRestrictionFlag>"#));
         assert!(output
             .contains(r#"    <AudienceRestrictionNote>Open access</AudienceRestrictionNote>"#));
-        assert!(output.contains(r#"    <Price>"#));
-        assert!(output.contains(r#"      <PriceTypeCode>02</PriceTypeCode>"#));
-        assert!(output.contains(r#"      <PriceAmount>0.00</PriceAmount>"#));
-        assert!(output.contains(r#"      <CurrencyCode>USD</CurrencyCode>"#));
+        assert!(output.contains(r#"    <UnpricedItemType>01</UnpricedItemType>"#));
 
         // Remove some values to test non-output of optional blocks
         test_work.doi = None;


### PR DESCRIPTION
Fixes #519.