### PR TITLE
Fix bug where New Publication form for Chapter could have an ISBN pre-populated but greyed out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+  - [531](https://github.com/thoth-pub/thoth/pull/531) - Fix bug where New Publication form for Chapter could have an ISBN pre-populated but greyed out
 
 ## [[0.11.12]](https://github.com/thoth-pub/thoth/releases/tag/v0.11.12) - 2023-12-20
 ### Fixed

--- a/thoth-app/src/component/publication_modal.rs
+++ b/thoth-app/src/component/publication_modal.rs
@@ -140,9 +140,10 @@ impl Component for PublicationModalComponent {
                     if let Some(publication) = ctx.props().publication_under_edit.clone() {
                         // Editing existing publication: load its current values.
                         self.publication = publication;
-                    }
-                    if ctx.props().work_type == WorkType::BookChapter {
-                        // ISBNs cannot be added for publications whose work type is Book Chapter.
+                    } else {
+                        // Previous values will be retained if creating new publication, which may be
+                        // useful for batch-adding, but this is less likely for ISBNs (and they also
+                        // cannot be added for publications whose work type is Book Chapter).
                         self.publication.isbn = None;
                     }
                     // Ensure ISBN variable value is kept in sync with publication object.

--- a/thoth-app/src/component/publication_modal.rs
+++ b/thoth-app/src/component/publication_modal.rs
@@ -141,6 +141,10 @@ impl Component for PublicationModalComponent {
                         // Editing existing publication: load its current values.
                         self.publication = publication;
                     }
+                    if ctx.props().work_type == WorkType::BookChapter {
+                        // ISBNs cannot be added for publications whose work type is Book Chapter.
+                        self.publication.isbn = None;
+                    }
                     // Ensure ISBN variable value is kept in sync with publication object.
                     self.isbn = self
                         .publication


### PR DESCRIPTION
Every time a user opens the New Publications form, it's pre-populated with the details of the last Publication that was saved. For Publications with work type Book Chapter, the ISBN field in the form is greyed out, because Book Chapter Publications can't have ISBNs. This can result in a scenario where the form is populated with a non-permitted but non-removable ISBN.

![image](https://github.com/thoth-pub/thoth/assets/73792779/a28fd0ab-3e5b-440a-a300-cc6cbbdbff64)

![image](https://github.com/thoth-pub/thoth/assets/73792779/6f6cd4f9-e32b-4c0c-8cc6-ffb2a8528641)
