### PR TITLE
Crossref: correct formatting of locale code, and remove ISBNs workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+  - [749](https://github.com/thoth-pub/thoth/pull/749) - Correct locale code formatting in Crossref metadata output
+### Changed
+  - [749](https://github.com/thoth-pub/thoth/pull/749) - Remove ISBN limit in Crossref metadata output (introduced in v0.8.7)
 
 ## [[1.2.0]](https://github.com/thoth-pub/thoth/releases/tag/v1.2.0) - 2026-05-04
 ### Added

--- a/thoth-export-server/src/xml/doideposit_crossref.rs
+++ b/thoth-export-server/src/xml/doideposit_crossref.rs
@@ -20,21 +20,21 @@ pub struct DoiDepositCrossref {}
 
 const DEPOSIT_ERROR: &str = "doideposit::crossref";
 const CROSSREF_NS: &[(&str, &str)] = &[
-    ("version", "5.3.1"),
-    ("xmlns", "http://www.crossref.org/schema/5.3.1"),
+    ("version", "5.4.0"),
+    ("xmlns", "http://www.crossref.org/schema/5.4.0"),
     ("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"),
     (
         "xsi:schemaLocation",
-        "http://www.crossref.org/schema/5.3.1 http://www.crossref.org/schemas/crossref5.3.1.xsd",
+        "http://www.crossref.org/schema/5.4.0 http://www.crossref.org/schemas/crossref5.4.0.xsd",
     ),
     ("xmlns:ai", "http://www.crossref.org/AccessIndicators.xsd"),
     ("xmlns:jats", "http://www.ncbi.nlm.nih.gov/JATS1"),
     ("xmlns:fr", "http://www.crossref.org/fundref.xsd"),
 ];
 
-// Output format based on schema documentation at https://data.crossref.org/reports/help/schema_doc/5.3.1/index.html
+// Output format based on schema documentation at https://data.crossref.org/reports/help/schema_doc/5.4.0/index.html
 // (retrieved via https://www.crossref.org/documentation/schema-library/xsd-schema-quick-reference/).
-// Output validity tested using tool at https://www.crossref.org/02publishers/parser.html
+// Output validity previously tested for schema version 5.3.1 using tool at https://www.crossref.org/02publishers/parser.html
 // (retrieved via https://www.crossref.org/documentation/member-setup/direct-deposit-xml/testing-your-xml/).
 impl XmlSpecification for DoiDepositCrossref {
     fn handle_event<W: Write>(w: &mut EventWriter<W>, works: &[Work]) -> ThothResult<()> {
@@ -496,32 +496,13 @@ fn write_publication_date_content<W: Write>(
 }
 
 fn write_work_publications<W: Write>(work: &Work, w: &mut EventWriter<W>) -> ThothResult<()> {
-    let mut publications: Vec<WorkPublications> = work
+    let publications: Vec<WorkPublications> = work
         .publications
         .clone()
         .into_iter()
         .filter(|p| p.isbn.is_some())
         .collect();
     if !publications.is_empty() {
-        // Workaround for CrossRef's limit of 6 on the number of ISBNs permissible within a deposit file.
-        // We raised this with CrossRef and they believe they should be able to increase the limit.
-        // Remove this workaround once this is done (see https://github.com/thoth-pub/thoth/issues/379).
-        // This was previously encountered with OBP works, which used to have 7 ISBNs as standard,
-        // but currently have 5 as of August 2024.
-        // So, the logic below should never be necessary with current publishers in Thoth.
-        // The least important ISBN is the HTML ISBN, so omit it.
-        if publications.len() > 6 {
-            if let Some(html_index) = publications
-                .iter()
-                .position(|p| p.publication_type == PublicationType::HTML)
-            {
-                publications.swap_remove(html_index);
-            }
-        }
-        // If there are still more than 6 ISBNs, assume they were added in decreasing order of importance.
-        while publications.len() > 6 {
-            publications.pop();
-        }
         for publication in &publications {
             XmlElementBlock::<DoiDepositCrossref>::xml_element(publication, w)?;
         }
@@ -2583,10 +2564,10 @@ mod tests {
     }
 
     #[test]
-    // Test that no more than 6 ISBNs are ever output.
-    // Remove/change this test once the CrossRef 6-ISBN limit is removed/increased -
-    // at this point, we need to remove the workaround and ensure that all ISBNs are included.
-    fn test_doideposit_crossref_isbns_workaround() {
+    // Crossref previously limited the number of ISBNs that could be included in a deposit file to 6,
+    // but this has now been increased in schema version 5.4.0 to 100 (which will never become relevant).
+    // Ensure that our own limit on the number of ISBNs output has been removed accordingly.
+    fn test_doideposit_crossref_isbns_workaround_removed() {
         let mut test_work = Work {
             work_id: Uuid::from_str("00000000-0000-0000-AAAA-000000000001").unwrap(),
             work_status: WorkStatus::ACTIVE,
@@ -2814,7 +2795,7 @@ mod tests {
             references: vec![],
         };
 
-        // 7 ISBNs are present and one is HTML - confirm that it is omitted
+        // 7 ISBNs are present - confirm that all are included regardless of type
         let output = generate_test_output(true, &test_work);
         assert!(output.contains(r#"      <isbn media_type="print">978-1-78839-908-1</isbn>"#));
         assert!(output.contains(r#"      <isbn media_type="print">978-1-7343145-0-2</isbn>"#));
@@ -2822,11 +2803,11 @@ mod tests {
         assert!(output.contains(r#"      <isbn media_type="electronic">978-1-56619-909-4</isbn>"#));
         assert!(output.contains(r#"      <isbn media_type="electronic">978-92-95055-02-5</isbn>"#));
         assert!(output.contains(r#"      <isbn media_type="electronic">978-1-4028-9462-6</isbn>"#));
-        assert!(!output.contains(r#"      <isbn media_type="electronic">978-3-16-148410-0</isbn>"#));
+        assert!(output.contains(r#"      <isbn media_type="electronic">978-3-16-148410-0</isbn>"#));
 
         // Change the HTML publication to a different format
         test_work.publications[0].publication_type = PublicationType::MOBI;
-        // 7 ISBNs are present and none are HTML - confirm that the last one is omitted
+        // 7 ISBNs are present and none are HTML - confirm that all are included regardless of type
         let output = generate_test_output(true, &test_work);
         assert!(output.contains(r#"      <isbn media_type="electronic">978-3-16-148410-0</isbn>"#));
         assert!(output.contains(r#"      <isbn media_type="print">978-1-78839-908-1</isbn>"#));
@@ -2834,7 +2815,7 @@ mod tests {
         assert!(output.contains(r#"      <isbn media_type="electronic">978-0-07-063546-3</isbn>"#));
         assert!(output.contains(r#"      <isbn media_type="electronic">978-1-56619-909-4</isbn>"#));
         assert!(output.contains(r#"      <isbn media_type="electronic">978-92-95055-02-5</isbn>"#));
-        assert!(!output.contains(r#"      <isbn media_type="electronic">978-1-4028-9462-6</isbn>"#));
+        assert!(output.contains(r#"      <isbn media_type="electronic">978-1-4028-9462-6</isbn>"#));
     }
 
     #[test]

--- a/thoth-export-server/src/xml/doideposit_crossref.rs
+++ b/thoth-export-server/src/xml/doideposit_crossref.rs
@@ -416,6 +416,7 @@ fn write_abstract_content_with_locale_code<W: Write>(
     locale_code: &str,
     w: &mut EventWriter<W>,
 ) -> ThothResult<()> {
+    let xml_lang = locale_code.replace('_', "-");
     let normalised_content = normalise_crossref_abstract_jats(abstract_content).map_err(|err| {
         ThothError::IncompleteMetadataRecord(
             DEPOSIT_ERROR.to_string(),
@@ -426,7 +427,7 @@ fn write_abstract_content_with_locale_code<W: Write>(
         "jats:abstract",
         Some(vec![
             ("abstract-type", abstract_type),
-            ("xml:lang", locale_code),
+            ("xml:lang", xml_lang.as_str()),
         ]),
         w,
         |w| write_jats_content(&normalised_content, w),
@@ -2542,6 +2543,24 @@ mod tests {
         assert!(output.contains(r#"<jats:p>First line</jats:p>"#));
         assert!(output.contains(r#"<jats:p>Second line</jats:p>"#));
         assert!(!output.contains(r#"<jats:break"#));
+
+        // Locale codes written to xml:lang should use BCP 47 hyphen separators.
+        let mut buffer = Vec::new();
+        let mut writer = xml::writer::EmitterConfig::new()
+            .perform_indent(true)
+            .create_writer(&mut buffer);
+
+        let result = write_abstract_content_with_locale_code(
+            "<p>Translated abstract.</p>",
+            "long",
+            "ZH_CN",
+            &mut writer,
+        );
+
+        assert!(result.is_ok());
+        let output = String::from_utf8(buffer).unwrap();
+        assert!(output.contains(r#"<jats:abstract abstract-type="long" xml:lang="ZH-CN">"#));
+        assert!(!output.contains(r#"xml:lang="ZH_CN""#));
     }
 
     #[test]

--- a/thoth-export-server/src/xml/onix3_thoth.rs
+++ b/thoth-export-server/src/xml/onix3_thoth.rs
@@ -2,6 +2,7 @@ use cc_license::License;
 use chrono::Utc;
 use std::io::Write;
 use thoth_api::model::language::LanguageCode as ApiLanguageCode;
+use thoth_api::model::locale::LocaleCode as ApiLocaleCode;
 use thoth_client::{
     AbstractType, AccessibilityException, AccessibilityStandard, ContactType, ContributionType,
     LanguageRelation, LocationPlatform, PublicationType, RelationType, SubjectType, Work,
@@ -10,9 +11,8 @@ use thoth_client::{
 };
 use xml::writer::{EventWriter, XmlEvent};
 
-use super::{write_element_block, XmlElement, XmlSpecification};
+use super::{write_element_block, TitleData, XmlElement, XmlSpecification};
 use crate::xml::{write_full_element_block, XmlElementBlock, ONIX3_NS};
-use thoth_api::model::locale::LocaleCode as ApiLocaleCode;
 use thoth_errors::{ThothError, ThothResult};
 
 #[derive(Copy, Clone)]
@@ -382,12 +382,13 @@ impl XmlElementBlock<Onix3Thoth> for Work {
                                 write_element_block("TitleElementLevel", w, |w| {
                                     w.write(XmlEvent::Characters("01")).map_err(|e| e.into())
                                 })?;
+                                let api_locale: ApiLocaleCode =
+                                    canonical_title.locale_code().clone().into();
+                                let lang_code: ApiLanguageCode = api_locale.into();
+                                let iso_code = lang_code.to_string().to_lowercase();
                                 write_full_element_block(
                                     "TitleText",
-                                    Some(vec![(
-                                        "language",
-                                        &canonical_title.locale_code.to_string(),
-                                    )]),
+                                    Some(vec![("language", &iso_code)]),
                                     w,
                                     |w| {
                                         w.write(XmlEvent::Characters(&canonical_title.title))
@@ -397,10 +398,7 @@ impl XmlElementBlock<Onix3Thoth> for Work {
                                 if let Some(subtitle) = &canonical_title.subtitle {
                                     write_full_element_block(
                                         "Subtitle",
-                                        Some(vec![(
-                                            "language",
-                                            &canonical_title.locale_code.to_string(),
-                                        )]),
+                                        Some(vec![("language", &iso_code)]),
                                         w,
                                         |w| {
                                             w.write(XmlEvent::Characters(subtitle))
@@ -2877,8 +2875,8 @@ mod tests {
       <TitleType>01</TitleType>
       <TitleElement>
         <TitleElementLevel>01</TitleElementLevel>
-        <TitleText language="EN">Book Title</TitleText>
-        <Subtitle language="EN">Book Subtitle</Subtitle>
+        <TitleText language="eng">Book Title</TitleText>
+        <Subtitle language="eng">Book Subtitle</Subtitle>
       </TitleElement>
     </TitleDetail>
     <EditionNumber>2</EditionNumber>
@@ -3529,11 +3527,11 @@ mod tests {
       <TitleType>01</TitleType>
       <TitleElement>
         <TitleElementLevel>01</TitleElementLevel>
-        <TitleText language="EN">Book Title</TitleText>
+        <TitleText language="eng">Book Title</TitleText>
       </TitleElement>
     </TitleDetail>"#
         ));
-        assert!(!output.contains(r#"        <Subtitle language="EN">Book Subtitle</Subtitle>"#));
+        assert!(!output.contains(r#"        <Subtitle language="eng">Book Subtitle</Subtitle>"#));
         assert!(!output.contains(r#"    <Edition>"#));
         assert!(!output.contains(r#"        <Subtitle>Book Subtitle</Subtitle>"#));
         assert!(!output.contains(r#"    <EditionNumber>1</EditionNumber>"#));


### PR DESCRIPTION
Following the multilingualism changes, @hannahhillen noticed Crossref error reports of the following type:

```
Error validating schema crossref5.3.1.xsd : Error: cvc-datatype-valid.1.2.3: 'ZH_CN' is not a valid value of union type '#AnonType_lang'.
Error: cvc-attribute.3: The value 'ZH_CN' of attribute 'xml:lang' on element 'jats:abstract' is not valid with respect to its type, 'null'.
```

For two-part locale codes in XML tag attributes, the part separator [should be a hyphen rather than an underscore](https://www.rfc-editor.org/rfc/bcp/bcp47.txt).

This PR also removes the 6-ISBN limit workaround introduced in https://github.com/thoth-pub/thoth/pull/398, as Crossref have now removed this limit in [version 5.4.0 of their schema](https://www.crossref.org/blog/version-5.4.0-metadata-schema-update-now-available/). The schema referenced in the deposit file has been updated and basic checks done to ensure this doesn't introduce regressions (but no other version-specific changes have been made).