### PR TITLE
Escape XML reserved characters when writing JATS-formatted text to database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+  - [751](https://github.com/thoth-pub/thoth/pull/751) - Escape XML reserved characters when writing JATS-formatted text to database
 
 ## [[1.3.1]](https://github.com/thoth-pub/thoth/releases/tag/v1.3.1) - 2026-05-06
 ### Security

--- a/thoth-api/src/markup/ast.rs
+++ b/thoth-api/src/markup/ast.rs
@@ -30,6 +30,19 @@ fn inline_text_to_plain_text(nodes: &[Node]) -> String {
     nodes.iter().map(ast_to_plain_text).collect()
 }
 
+fn escape_xml_text(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn escape_xml_attr(input: &str) -> String {
+    escape_xml_text(input)
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
 fn looks_like_email(text: &str) -> bool {
     regex::Regex::new(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")
         .unwrap()
@@ -680,16 +693,16 @@ pub fn plain_text_to_ast(text: &str) -> Node {
 pub fn plain_text_ast_to_jats(node: &Node) -> String {
     fn render_plain_text_inline(node: &Node) -> String {
         match node {
-            Node::Text(text) => text.clone(),
+            Node::Text(text) => escape_xml_text(text),
             Node::Break => "<break/>".to_string(),
             Node::InlineFormula(tex) => {
                 format!(
                     "<inline-formula><tex-math>{}</tex-math></inline-formula>",
-                    tex
+                    escape_xml_text(tex)
                 )
             }
-            Node::Email(email) => format!("<email>{}</email>", email),
-            Node::Uri(uri) => format!("<uri>{}</uri>", uri),
+            Node::Email(email) => format!("<email>{}</email>", escape_xml_text(email)),
+            Node::Uri(uri) => format!("<uri>{}</uri>", escape_xml_text(uri)),
             other => ast_to_jats(other),
         }
     }
@@ -712,16 +725,16 @@ pub fn plain_text_ast_to_jats(node: &Node) -> String {
             let inner: String = children.iter().map(render_plain_text_inline).collect();
             format!("<p>{}</p>", inner)
         }
-        Node::Text(text) => format!("<p>{}</p>", text),
+        Node::Text(text) => format!("<p>{}</p>", escape_xml_text(text)),
         Node::Break => "<p><break/></p>".to_string(),
         Node::InlineFormula(tex) => {
             format!(
                 "<p><inline-formula><tex-math>{}</tex-math></inline-formula></p>",
-                tex
+                escape_xml_text(tex)
             )
         }
-        Node::Email(email) => format!("<p><email>{}</email></p>", email),
-        Node::Uri(uri) => format!("<p><uri>{}</uri></p>", uri),
+        Node::Email(email) => format!("<p><email>{}</email></p>", escape_xml_text(email)),
+        Node::Uri(uri) => format!("<p><uri>{}</uri></p>", escape_xml_text(uri)),
         _ => {
             // For other nodes, use regular ast_to_jats
             ast_to_jats(node)
@@ -780,17 +793,21 @@ pub fn ast_to_jats(node: &Node) -> String {
         }
         Node::Link { url, text } => {
             let inner: String = text.iter().map(ast_to_jats).collect();
-            format!(r#"<ext-link xlink:href="{}">{}</ext-link>"#, url, inner)
+            format!(
+                r#"<ext-link xlink:href="{}">{}</ext-link>"#,
+                escape_xml_attr(url),
+                inner
+            )
         }
         Node::InlineFormula(tex) => {
             format!(
                 "<inline-formula><tex-math>{}</tex-math></inline-formula>",
-                tex
+                escape_xml_text(tex)
             )
         }
-        Node::Email(email) => format!("<email>{}</email>", email),
-        Node::Uri(uri) => format!("<uri>{}</uri>", uri),
-        Node::Text(text) => text.clone(),
+        Node::Email(email) => format!("<email>{}</email>", escape_xml_text(email)),
+        Node::Uri(uri) => format!("<uri>{}</uri>", escape_xml_text(uri)),
+        Node::Text(text) => escape_xml_text(text),
     }
 }
 
@@ -1995,6 +2012,64 @@ mod tests {
             jats,
             r#"<ext-link xlink:href="https://example.com">Link text</ext-link>"#
         );
+    }
+
+    #[test]
+    fn test_ast_to_jats_escapes_reserved_xml_chars() {
+        let ast = Node::Paragraph(vec![
+            Node::Text("x < y & z > w ".to_string()),
+            Node::InlineFormula("a < b & c".to_string()),
+            Node::Text(" ".to_string()),
+            Node::Email("user@example.org".to_string()),
+            Node::Text(" ".to_string()),
+            Node::Uri("https://example.org?a=1&b=2".to_string()),
+        ]);
+
+        let jats = ast_to_jats(&ast);
+        assert_eq!(
+            jats,
+            "<p>x &lt; y &amp; z &gt; w <inline-formula><tex-math>a &lt; b &amp; c</tex-math></inline-formula> <email>user@example.org</email> <uri>https://example.org?a=1&amp;b=2</uri></p>"
+        );
+    }
+
+    #[test]
+    fn test_ast_to_jats_escapes_link_url_attribute() {
+        let ast = Node::Link {
+            url: "https://example.com?a=1&b=2".to_string(),
+            text: vec![Node::Text("Link text".to_string())],
+        };
+
+        let jats = ast_to_jats(&ast);
+        assert_eq!(
+            jats,
+            r#"<ext-link xlink:href="https://example.com?a=1&amp;b=2">Link text</ext-link>"#
+        );
+    }
+
+    #[test]
+    fn test_ast_to_jats_preserves_generated_tags() {
+        let ast = Node::Paragraph(vec![
+            Node::Bold(vec![Node::Text("Bold".to_string())]),
+            Node::Text(" and ".to_string()),
+            Node::Italic(vec![Node::Text("italic".to_string())]),
+        ]);
+
+        let jats = ast_to_jats(&ast);
+        assert_eq!(jats, "<p><bold>Bold</bold> and <italic>italic</italic></p>");
+        assert!(!jats.contains("&lt;bold&gt;"));
+    }
+
+    #[test]
+    fn test_ast_to_jats_preserves_generated_tags_and_escapes() {
+        let ast = Node::Paragraph(vec![
+            Node::Bold(vec![Node::Text("Bo<ld".to_string())]),
+            Node::Text(" & ".to_string()),
+            Node::Italic(vec![Node::Text("ita>lic".to_string())]),
+        ]);
+
+        let jats = ast_to_jats(&ast);
+        assert_eq!(jats, "<p><bold>Bo&lt;ld</bold> &amp; <italic>ita&gt;lic</italic></p>");
+        assert!(!jats.contains("&lt;bold&gt;"));
     }
 
     #[test]

--- a/thoth-api/src/markup/ast.rs
+++ b/thoth-api/src/markup/ast.rs
@@ -2068,7 +2068,10 @@ mod tests {
         ]);
 
         let jats = ast_to_jats(&ast);
-        assert_eq!(jats, "<p><bold>Bo&lt;ld</bold> &amp; <italic>ita&gt;lic</italic></p>");
+        assert_eq!(
+            jats,
+            "<p><bold>Bo&lt;ld</bold> &amp; <italic>ita&gt;lic</italic></p>"
+        );
         assert!(!jats.contains("&lt;bold&gt;"));
     }
 

--- a/thoth-api/src/markup/mod.rs
+++ b/thoth-api/src/markup/mod.rs
@@ -315,7 +315,7 @@ pub fn convert_to_jats(
     format: MarkupFormat,
     conversion_limit: ConversionLimit,
 ) -> ThothResult<String> {
-    if format == MarkupFormat::JatsXml {
+    let output = if format == MarkupFormat::JatsXml {
         let content_looks_like_jats = looks_like_markup(&content);
         let ast = if content_looks_like_jats {
             validate_jats_subset(&content, conversion_limit)?;
@@ -332,70 +332,61 @@ pub fn convert_to_jats(
 
         validate_ast_content(&processed_ast, conversion_limit)?;
 
-        return Ok(
-            if content_looks_like_jats || conversion_limit == ConversionLimit::Title {
+        if content_looks_like_jats || conversion_limit == ConversionLimit::Title {
+            ast_to_jats(&processed_ast)
+        } else {
+            plain_text_ast_to_jats(&processed_ast)
+        }
+    } else {
+        validate_format(&content, &format)?;
+
+        match format {
+            MarkupFormat::Html => {
+                let ast = html_to_ast(&content);
+                let processed_ast = if conversion_limit == ConversionLimit::Title {
+                    strip_structural_elements_from_ast_for_conversion(&ast)
+                } else {
+                    ast
+                };
+
+                validate_ast_content(&processed_ast, conversion_limit)?;
                 ast_to_jats(&processed_ast)
-            } else {
-                plain_text_ast_to_jats(&processed_ast)
-            },
-        );
-    }
+            }
 
-    validate_format(&content, &format)?;
+            MarkupFormat::Markdown => {
+                let ast = markdown_to_ast(&content);
+                let processed_ast = if conversion_limit == ConversionLimit::Title {
+                    strip_structural_elements_from_ast_for_conversion(&ast)
+                } else {
+                    ast
+                };
 
-    match format {
-        MarkupFormat::Html => {
-            // Use ast library to parse HTML and convert to JATS
-            let ast = html_to_ast(&content);
-
-            // For title conversion, strip structural elements before validation
-            let processed_ast = if conversion_limit == ConversionLimit::Title {
-                strip_structural_elements_from_ast_for_conversion(&ast)
-            } else {
-                ast
-            };
-
-            validate_ast_content(&processed_ast, conversion_limit)?;
-            Ok(ast_to_jats(&processed_ast))
-        }
-
-        MarkupFormat::Markdown => {
-            // Use ast library to parse Markdown and convert to JATS
-            let ast = markdown_to_ast(&content);
-
-            // For title conversion, strip structural elements before validation
-            let processed_ast = if conversion_limit == ConversionLimit::Title {
-                strip_structural_elements_from_ast_for_conversion(&ast)
-            } else {
-                ast
-            };
-
-            validate_ast_content(&processed_ast, conversion_limit)?;
-            Ok(ast_to_jats(&processed_ast))
-        }
-
-        MarkupFormat::PlainText => {
-            // Use ast library to parse plain text and convert to JATS
-            let ast = plain_text_to_ast(&content);
-
-            // For title conversion, strip structural elements before validation
-            let processed_ast = if conversion_limit == ConversionLimit::Title {
-                strip_structural_elements_from_ast_for_conversion(&ast)
-            } else {
-                ast
-            };
-
-            validate_ast_content(&processed_ast, conversion_limit)?;
-            Ok(if conversion_limit == ConversionLimit::Title {
-                // Title JATS should remain inline (no paragraph wrapper)
+                validate_ast_content(&processed_ast, conversion_limit)?;
                 ast_to_jats(&processed_ast)
-            } else {
-                plain_text_ast_to_jats(&processed_ast)
-            })
-        }
+            }
 
-        MarkupFormat::JatsXml => unreachable!("handled above"),
-    }
+            MarkupFormat::PlainText => {
+                let ast = plain_text_to_ast(&content);
+                let processed_ast = if conversion_limit == ConversionLimit::Title {
+                    strip_structural_elements_from_ast_for_conversion(&ast)
+                } else {
+                    ast
+                };
+
+                validate_ast_content(&processed_ast, conversion_limit)?;
+                if conversion_limit == ConversionLimit::Title {
+                    ast_to_jats(&processed_ast)
+                } else {
+                    plain_text_ast_to_jats(&processed_ast)
+                }
+            }
+
+            MarkupFormat::JatsXml => unreachable!("handled above"),
+        }
+    };
+
+    validate_jats_subset(&output, conversion_limit)?;
+    Ok(output)
 }
 
 /// normalise stored abstract-like markup into the subset we safely emit to Crossref.
@@ -605,6 +596,64 @@ mod tests {
         )
         .unwrap();
         assert_eq!(output, "<p>Hello <uri>https://example.com</uri> world</p>");
+    }
+
+    #[test]
+    fn test_plain_text_abstract_escapes_reserved_xml_chars() {
+        let input = "x < y & z > w";
+        let output = convert_to_jats(
+            input.to_string(),
+            MarkupFormat::PlainText,
+            ConversionLimit::Abstract,
+        )
+        .unwrap();
+
+        assert_eq!(output, "<p>x &lt; y &amp; z &gt; w</p>");
+    }
+
+    #[test]
+    fn test_plain_text_jatsxml_abstract_escapes_reserved_xml_chars() {
+        let input = "x < y & z > w";
+        let output = convert_to_jats(
+            input.to_string(),
+            MarkupFormat::JatsXml,
+            ConversionLimit::Abstract,
+        )
+        .unwrap();
+
+        assert_eq!(output, "<p>x &lt; y &amp; z &gt; w</p>");
+    }
+
+    #[test]
+    fn test_plain_text_rich_content_escapes_xml_reserved_chars() {
+        let input = "x < y & user@example.org https://example.org?a=1&b=2 $a < b & c$ > w";
+        let output = convert_to_jats(
+            input.to_string(),
+            MarkupFormat::PlainText,
+            ConversionLimit::Abstract,
+        )
+        .unwrap();
+
+        assert_eq!(
+            output,
+            "<p>x &lt; y &amp; <email>user@example.org</email> <uri>https://example.org?a=1&amp;b=2</uri> <inline-formula><tex-math>a &lt; b &amp; c</tex-math></inline-formula> &gt; w</p>"
+        );
+    }
+
+    #[test]
+    fn test_html_link_url_escapes_reserved_xml_chars() {
+        let input = r#"<a href="https://example.com?a=1&amp;b=2">Link</a>"#;
+        let output = convert_to_jats(
+            input.to_string(),
+            MarkupFormat::Html,
+            ConversionLimit::Abstract,
+        )
+        .unwrap();
+
+        assert_eq!(
+            output,
+            r#"<p><ext-link xlink:href="https://example.com?a=1&amp;b=2">Link</ext-link></p>"#
+        );
     }
 
     #[test]

--- a/thoth-api/src/markup/mod.rs
+++ b/thoth-api/src/markup/mod.rs
@@ -392,6 +392,7 @@ pub fn convert_to_jats(
 /// normalise stored abstract-like markup into the subset we safely emit to Crossref.
 pub fn normalise_crossref_abstract_jats(content: &str) -> ThothResult<String> {
     let ast = if looks_like_markup(content) {
+        validate_jats_subset(content, ConversionLimit::Abstract)?;
         jats_to_ast(content)
     } else {
         plain_text_to_ast(content)
@@ -792,10 +793,16 @@ mod tests {
     }
 
     #[test]
-    fn test_normalise_crossref_abstract_jats_splits_breaks_and_removes_empty_paragraphs() {
-        let input = "<p></p><p>First line<break/>Second line</p>";
+    fn test_normalise_crossref_abstract_jats_removes_empty_paragraphs() {
+        let input = "<p></p><p>First line</p>";
         let output = normalise_crossref_abstract_jats(input).unwrap();
-        assert_eq!(output, "<p>First line</p><p>Second line</p>");
+        assert_eq!(output, "<p>First line</p>");
+    }
+
+    #[test]
+    fn test_normalise_crossref_abstract_jats_rejects_break_elements() {
+        let input = "<p>First line<break/>Second line</p>";
+        assert!(normalise_crossref_abstract_jats(input).is_err());
     }
 
     #[test]
@@ -803,6 +810,32 @@ mod tests {
         let input = "This has <bold>bold</bold> text.";
         let output = normalise_crossref_abstract_jats(input).unwrap();
         assert_eq!(output, "<p>This has <bold>bold</bold> text.</p>");
+    }
+
+    #[test]
+    fn test_normalise_crossref_abstract_jats_preserves_existing_entities_once() {
+        let input = "<p>x &amp; y &lt; z &gt; w</p>";
+        let output = normalise_crossref_abstract_jats(input).unwrap();
+        assert_eq!(output, "<p>x &amp; y &lt; z &gt; w</p>");
+    }
+
+    #[test]
+    fn test_normalise_crossref_abstract_jats_rejects_malformed_mixed_markup() {
+        let input = "<p>Range 1 < 2 and <italic>styled</italic></p>";
+        assert!(normalise_crossref_abstract_jats(input).is_err());
+    }
+
+    #[test]
+    fn test_markdown_abstract_escapes_reserved_xml_chars() {
+        let input = "x < y & z > w";
+        let output = convert_to_jats(
+            input.to_string(),
+            MarkupFormat::Markdown,
+            ConversionLimit::Abstract,
+        )
+        .unwrap();
+
+        assert_eq!(output, "<p>x &lt; y &amp; z &gt; w</p>");
     }
     // --- convert_to_jats tests end   ---
 

--- a/thoth-export-server/src/xml/doideposit_crossref.rs
+++ b/thoth-export-server/src/xml/doideposit_crossref.rs
@@ -325,16 +325,31 @@ fn write_jats_content<W: Write>(content: &str, w: &mut EventWriter<W>) -> ThothR
                 let mut event_builder = XmlEvent::start_element(&*name);
 
                 // Add attributes
-                let attrs: Vec<(String, String)> = e
+                let attrs: ThothResult<Vec<(String, String)>> = e
                     .attributes()
-                    .flatten()
                     .map(|attr| {
-                        (
+                        let attr = attr.map_err(|err| {
+                            ThothError::InternalError(format!(
+                                "Error parsing JATS content attributes: {}",
+                                err
+                            ))
+                        })?;
+                        let value = attr
+                            .decode_and_unescape_value(reader.decoder())
+                            .map_err(|err| {
+                                ThothError::InternalError(format!(
+                                    "Error decoding JATS content attributes: {}",
+                                    err
+                                ))
+                            })?
+                            .into_owned();
+                        Ok((
                             String::from_utf8_lossy(attr.key.as_ref()).to_string(),
-                            String::from_utf8_lossy(&attr.value).to_string(),
-                        )
+                            value,
+                        ))
                     })
                     .collect();
+                let attrs = attrs?;
 
                 for (key, value) in &attrs {
                     event_builder = event_builder.attr(key.as_str(), value.as_str());
@@ -357,16 +372,31 @@ fn write_jats_content<W: Write>(content: &str, w: &mut EventWriter<W>) -> ThothR
                 let mut event_builder = XmlEvent::start_element(&*name);
 
                 // Add attributes
-                let attrs: Vec<(String, String)> = e
+                let attrs: ThothResult<Vec<(String, String)>> = e
                     .attributes()
-                    .flatten()
                     .map(|attr| {
-                        (
+                        let attr = attr.map_err(|err| {
+                            ThothError::InternalError(format!(
+                                "Error parsing JATS content attributes: {}",
+                                err
+                            ))
+                        })?;
+                        let value = attr
+                            .decode_and_unescape_value(reader.decoder())
+                            .map_err(|err| {
+                                ThothError::InternalError(format!(
+                                    "Error decoding JATS content attributes: {}",
+                                    err
+                                ))
+                            })?
+                            .into_owned();
+                        Ok((
                             String::from_utf8_lossy(attr.key.as_ref()).to_string(),
-                            String::from_utf8_lossy(&attr.value).to_string(),
-                        )
+                            value,
+                        ))
                     })
                     .collect();
+                let attrs = attrs?;
 
                 for (key, value) in &attrs {
                     event_builder = event_builder.attr(key.as_str(), value.as_str());
@@ -2487,7 +2517,7 @@ mod tests {
         // Should not contain any paragraph elements
         assert!(!output.contains(r#"<jats:p>"#));
 
-        // Nested paragraph wrappers should be flattened before writing.
+        // Nested paragraph wrappers are invalid JATS and should be rejected.
         let mut buffer = Vec::new();
         let mut writer = xml::writer::EmitterConfig::new()
             .perform_indent(true)
@@ -2500,13 +2530,9 @@ mod tests {
             &mut writer,
         );
 
-        assert!(result.is_ok());
-        let output = String::from_utf8(buffer).unwrap();
-        assert!(output.contains(r#"<jats:p>Nested paragraph.</jats:p>"#));
-        assert!(!output.contains(r#"<jats:p><jats:p>"#));
-        assert!(!output.contains(r#"<jats:p />"#));
+        assert!(result.is_err());
 
-        // Break elements should be converted into sibling paragraphs.
+        // Break elements are invalid JATS and should be rejected.
         let mut buffer = Vec::new();
         let mut writer = xml::writer::EmitterConfig::new()
             .perform_indent(true)
@@ -2519,11 +2545,7 @@ mod tests {
             &mut writer,
         );
 
-        assert!(result.is_ok());
-        let output = String::from_utf8(buffer).unwrap();
-        assert!(output.contains(r#"<jats:p>First line</jats:p>"#));
-        assert!(output.contains(r#"<jats:p>Second line</jats:p>"#));
-        assert!(!output.contains(r#"<jats:break"#));
+        assert!(result.is_err());
 
         // Locale codes written to xml:lang should use BCP 47 hyphen separators.
         let mut buffer = Vec::new();
@@ -2561,6 +2583,32 @@ mod tests {
         assert!(result.is_err());
         let error = result.unwrap_err().to_string();
         assert!(error.contains("Invalid Crossref abstract markup"));
+    }
+
+    #[test]
+    fn test_write_abstract_content_with_locale_code_escapes_link_attributes_once() {
+        let mut buffer = Vec::new();
+        let mut writer = xml::writer::EmitterConfig::new()
+            .perform_indent(true)
+            .create_writer(&mut buffer);
+
+        let result = write_abstract_content_with_locale_code(
+            r#"<p><ext-link xlink:href="https://example.org?a=1&amp;b=2&amp;quote=&quot;hi&quot;&amp;apos=&apos;ok&apos;">link</ext-link></p>"#,
+            "long",
+            "EN",
+            &mut writer,
+        );
+
+        assert!(result.is_ok());
+        let output = String::from_utf8(buffer).unwrap();
+        assert!(
+            output.contains(
+                r#"<jats:ext-link xlink:href="https://example.org?a=1&amp;b=2&amp;quote=&quot;hi&quot;&amp;apos=&apos;ok&apos;">link</jats:ext-link>"#
+            )
+        );
+        assert!(!output.contains("&amp;amp;"));
+        assert!(!output.contains("&amp;quot;"));
+        assert!(!output.contains("&amp;apos;"));
     }
 
     #[test]


### PR DESCRIPTION
Raw characters `<`, `>`, `&` etc were not previously being escaped when writing JATS fields such as `abstract`, leading to bugs downstream such as https://help.thoth.pub/#ticket/zoom/363 (where a stray `<` character used as a "from" symbol caused truncation/malformation of the Crossref XML output).