### PR TITLE
Prevent orphaned file records/objects when completing a publication u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+  - [763](https://github.com/thoth-pub/thoth/pull/763) - Validate a publication upload's canonical location before copying the object to its final key and inserting the file record in `complete_file_upload`, so a `LocationUrlError` (e.g. a work with no landing page) no longer leaves an orphaned file record and S3 object behind (`FileUpload::precheck_related_metadata`)
 
 ## [[1.6.0]](https://github.com/thoth-pub/thoth/releases/tag/v1.6.0) - 2026-07-21
 ### Fixed

--- a/thoth-api/src/graphql/mutation.rs
+++ b/thoth-api/src/graphql/mutation.rs
@@ -1471,6 +1471,13 @@ impl MutationRoot {
         };
 
         let canonical_key = file_upload.canonical_key(doi)?;
+        let cdn_url = build_cdn_url(&storage_config.cdn_domain, &canonical_key);
+
+        // Validate related metadata BEFORE the irreversible S3 copy and the file
+        // record insert. persist_file_record and sync_related_metadata are not in
+        // a single transaction, so letting sync_related_metadata fail here would
+        // leave an orphaned file record and final S3 object behind.
+        file_upload.precheck_related_metadata(context, &work, &cdn_url)?;
 
         copy_temp_object_to_final(
             s3_client,
@@ -1480,7 +1487,6 @@ impl MutationRoot {
         )
         .await?;
 
-        let cdn_url = build_cdn_url(&storage_config.cdn_domain, &canonical_key);
         let (file, old_object_key) = file_upload.persist_file_record(
             context,
             &canonical_key,

--- a/thoth-api/src/model/file/crud.rs
+++ b/thoth-api/src/model/file/crud.rs
@@ -716,6 +716,45 @@ impl FileUpload {
         Ok((file, old_object_key))
     }
 
+    /// Validate, WITHOUT writing, everything `sync_related_metadata` will later
+    /// enforce, so a predictable validation failure aborts the upload before any
+    /// irreversible side effect (copying the temp object to its final canonical
+    /// key, inserting the file record). Without this, such a failure leaves an
+    /// orphaned file record and/or S3 object while reporting failure, because
+    /// `complete_file_upload` copies the object and persists the record before
+    /// `sync_related_metadata` runs, and the two are not in one transaction.
+    ///
+    /// Only publication uploads currently have a pre-commit check to mirror: the
+    /// canonical Thoth location that `sync_related_metadata` upserts must, for a
+    /// digital publication, carry both a landing page and a full-text URL. The
+    /// landing page comes from `work.landing_page` and the full-text URL is the
+    /// CDN URL, so both are known here.
+    pub(crate) fn precheck_related_metadata<C: PolicyContext>(
+        &self,
+        ctx: &C,
+        work: &Work,
+        cdn_url: &str,
+    ) -> ThothResult<()> {
+        if let FileType::Publication = self.file_type {
+            let publication_id = self
+                .publication_id
+                .ok_or(ThothError::PublicationFileUploadMissingPublicationId)?;
+            // The upserted Thoth location is always canonical; reuse its
+            // read-only completeness check with the exact URLs the upsert uses.
+            let probe = NewLocation {
+                publication_id,
+                landing_page: work.landing_page.clone(),
+                full_text_url: Some(cdn_url.to_string()),
+                location_platform: LocationPlatform::Thoth,
+                canonical: true,
+                checksum: None,
+                checksum_algorithm: None,
+            };
+            probe.canonical_record_complete(ctx.db())?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn sync_related_metadata<C: PolicyContext>(
         &self,
         ctx: &C,

--- a/thoth-api/src/model/file/tests.rs
+++ b/thoth-api/src/model/file/tests.rs
@@ -1601,4 +1601,45 @@ mod crud {
             .iter()
             .any(|c| c.object_key == temp_key(&featured_video_upload.file_upload_id)));
     }
+
+    // A digital publication's canonical Thoth location needs both a landing page
+    // and a full-text URL. The landing page is taken from work.landing_page, so a
+    // null there must make precheck_related_metadata reject the upload BEFORE any
+    // S3 copy or file-record insert, rather than letting complete_file_upload
+    // leave an orphaned record/object when the later location upsert fails.
+    #[test]
+    fn crud_precheck_related_metadata_requires_landing_page_for_digital_publication() {
+        let (_guard, pool) = setup_test_db();
+
+        let publisher = create_publisher(pool.as_ref());
+        let imprint = create_imprint(pool.as_ref(), &publisher);
+        let work = create_work(pool.as_ref(), &imprint); // landing_page: None
+        let publication = create_pdf_publication(pool.as_ref(), work.work_id);
+
+        let org_id = publisher
+            .zitadel_id
+            .clone()
+            .expect("publisher missing zitadel id");
+        let user = test_user_with_role("file-user", Role::CdnWrite, &org_id);
+        let ctx = test_context_with_user(pool.clone(), user);
+
+        let upload = FileUpload::create(
+            pool.as_ref(),
+            &make_new_publication_upload(publication.publication_id, "pdf"),
+        )
+        .expect("Failed to create publication upload");
+
+        let cdn_url = "https://cdn.example.org/10.1234/abc/def.pdf";
+
+        // No landing page -> incomplete canonical location -> reject up front.
+        let result = upload.precheck_related_metadata(&ctx, &work, cdn_url);
+        assert!(matches!(result, Err(ThothError::LocationUrlError)));
+
+        // With a landing page present, precheck passes (both URLs available).
+        let mut work_with_landing_page = work.clone();
+        work_with_landing_page.landing_page = Some("https://example.org/landing".to_string());
+        upload
+            .precheck_related_metadata(&ctx, &work_with_landing_page, cdn_url)
+            .expect("precheck should pass once a landing page is present");
+    }
 }


### PR DESCRIPTION
…pload

`complete_file_upload` copies the temp object to its final canonical key and inserts the file record before `sync_related_metadata` upserts and validates the canonical Thoth location, and the two are not in one transaction. So when that validation fails — most commonly `LocationUrlError` for a digital publication whose work has no landing page — the mutation reports failure while leaving a committed file record and a final S3 object behind.

Add `FileUpload::precheck_related_metadata`, which runs the same (read-only) canonical-location completeness check up front, and call it before the S3 copy and file-record insert. A predictable validation failure now aborts the upload with no side effects; a retry after the metadata is fixed succeeds cleanly.