### PR TITLE
CTRL-FOUNDATION-01: add AI-led engineering controls and programme foundations

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md - GitHub Actions workflows
+
+This file extends the repository-root `AGENTS.md`.
+
+Workflow changes can affect CI, releases, external services and production data. Classify the risk from actual effects, not from the size of the YAML diff.
+
+## 1. Prohibited actions
+
+An implementing agent must not:
+
+- dispatch a production or write-capable workflow;
+- approve a protected environment;
+- retrieve or print production secrets;
+- publish a release or container;
+- change production deployment behaviour without explicit authorization;
+- remove safety confirmations, environment protection or concurrency controls to make a test pass.
+
+Use static validation, unit tests, forks, mocks or explicitly approved non-production environments.
+
+## 2. Permissions and credentials
+
+Use least-privilege `permissions`.
+
+Prefer:
+
+- GitHub OIDC and short-lived credentials;
+- protected environments for write paths;
+- environment-scoped secrets;
+- read-only jobs for discovery and dry runs;
+- separate jobs for selection and mutation.
+
+Never echo secrets, tokens or complete credential-bearing URLs.
+
+A read-only/dry-run mode should not receive write credentials.
+
+## 3. Branch and trigger safety
+
+Use the repository's actual branch topology:
+
+```text
+develop -> master
+```
+
+Before changing filters, verify:
+
+- PR checks still run on feature and programme branches;
+- release jobs run only from the approved release mechanism;
+- manual write jobs enforce the intended source branch;
+- scheduled jobs cannot accidentally run from an unreviewed branch.
+
+Do not use branch normalization as an incidental part of a workflow feature task.
+
+## 4. Durable state and concurrency
+
+GitHub Actions is not a durable job ledger, lock manager or source of truth.
+
+For operational workflows:
+
+- keep durable jobs/checkpoints in Thoth;
+- use explicit concurrency groups to prevent unsafe overlap;
+- set `cancel-in-progress` deliberately;
+- bound retries and matrices;
+- ensure repeat execution is idempotent;
+- report overflow rather than silently dropping work;
+- keep matrix sizes within GitHub limits;
+- preserve complete diagnostic artifacts where safe.
+
+## 5. Manual mutation controls
+
+A write-capable manual workflow should normally require:
+
+- an explicit typed confirmation value;
+- a protected environment;
+- bounded scope;
+- a reviewed dry run;
+- fail-closed configuration;
+- sanitized logs;
+- a final summary;
+- a documented rollback or reconciliation path.
+
+An empty publisher/work/platform selection must never broaden to all records.
+
+## 6. Validation
+
+For YAML-only changes, run the repository's established actionlint procedure.
+
+Also run any unit tests that parse or assert workflow behaviour.
+
+At minimum:
+
+```bash
+git diff --check
+```
+
+Inspect:
+
+- triggers;
+- permissions;
+- environments;
+- secrets/variables;
+- conditionals;
+- concurrency;
+- matrix size;
+- failure propagation;
+- artifact retention;
+- branch guards.
+
+CI success does not prove that a production write path is safe.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,333 @@
+# AGENTS.md
+
+These instructions apply to the complete `thoth-pub/thoth` repository.
+
+A more deeply nested `AGENTS.md` adds or narrows instructions for its directory. Read this file and every applicable nested file before editing.
+
+## 1. Required task identity
+
+Before changing anything, record:
+
+```text
+Programme:
+Repository: thoth-pub/thoth
+Task ID:
+Approved specification:
+Risk: LOW | MEDIUM | HIGH | CRITICAL
+Base branch and commit:
+PR target:
+Task branch:
+Dependencies:
+Implementing agent/model:
+Independent reviewer/model:
+```
+
+Do not implement without an approved written specification. A GitHub issue is sufficient only when it contains the information required by `docs/engineering/ai-delivery/task-specification-template.md`.
+
+If any item is unknown, treat it as missing work.
+
+## 2. Authority
+
+Use this order when sources conflict:
+
+1. merged code, migrations and generated contracts;
+2. approved ADRs and technical designs;
+3. approved task specifications;
+4. GitHub issues, pull requests, review threads and CI evidence;
+5. programme-control and rollout documents;
+6. agent reports and conversations.
+
+Do not allow chat history or memory to silently override repository evidence.
+
+Stop and escalate when authoritative sources conflict.
+
+## 3. Mandatory control documents
+
+Read as applicable:
+
+- `docs/engineering/ai-delivery/operating-model.md`
+- `docs/engineering/ai-delivery/branching-and-release-workflow.md`
+- `docs/engineering/ai-delivery/risk-classification.md`
+- `docs/engineering/ai-delivery/release-gates.md`
+- `docs/engineering/repository-map/repositories/thoth.md`
+- the task specification;
+- the relevant programme README, ADRs and design references.
+
+## 4. Repository responsibilities
+
+This repository owns:
+
+- the canonical PostgreSQL domain;
+- database migrations;
+- the GraphQL API and authorization policy;
+- metadata validation and write rules;
+- the internal Rust GraphQL client;
+- metadata export endpoints and formats;
+- release container construction.
+
+Workspace members:
+
+- `thoth-api`
+- `thoth-api-server`
+- `thoth-client`
+- `thoth-errors`
+- `thoth-export-server`
+
+Keep domain rules in the owning domain layer. Do not duplicate validation or authorization across transports and clients.
+
+## 5. Branch and pull-request workflow
+
+Normal work:
+
+```text
+develop -> feature/<area>/<task> -> develop
+```
+
+Approved large programme work:
+
+```text
+develop
+  -> feature/<programme>
+  -> feature/<programme>/<slice>
+  -> feature/<programme>
+  -> develop
+```
+
+Release:
+
+```text
+develop -> master
+```
+
+Rules:
+
+- verify the actual base before branching;
+- use one bounded task per slice branch and PR;
+- do not target normal implementation directly at `master`;
+- do not merge or approve your own work;
+- delete a task/slice branch after merge;
+- keep programme branches current at approved checkpoints;
+- do not rewrite shared branch history after others depend on it.
+
+## 6. Allowed and prohibited actions
+
+An implementing agent may:
+
+- inspect the repository and relevant history;
+- edit within approved scope;
+- add tests and documentation;
+- run local checks against local or disposable services;
+- commit, push and open/update a draft PR.
+
+An implementing agent must not:
+
+- merge a PR;
+- publish a release;
+- deploy or activate production behaviour;
+- access production secrets;
+- run commands against production databases or services;
+- dispatch write-capable production workflows;
+- perform destructive production operations;
+- broaden scope without an approved specification update;
+- change approved architecture silently.
+
+## 7. Standard local checks
+
+The repository Makefile is the preferred interface:
+
+```bash
+make build
+make test
+make check
+make clippy
+make check-format
+make check-all
+```
+
+Equivalent full gate:
+
+```bash
+cargo test --workspace
+cargo check --workspace
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Record the exact commands and concise results. Do not report only "tests passed".
+
+Use local PostgreSQL and Redis services where required. Never point test commands at production.
+
+## 8. Change-specific evidence
+
+### Documentation-only
+
+At minimum:
+
+```bash
+git diff --check
+```
+
+Also verify:
+
+- internal links and paths;
+- terminology and repository names;
+- no stale duplicate source;
+- the required changelog entry;
+- repository CI.
+
+### Rust/domain change
+
+Run the full workspace gate unless the approved specification explicitly narrows it.
+
+### Database change
+
+Also follow `thoth-api/AGENTS.md` and prove:
+
+- forward migration;
+- revert or approved forward-repair strategy;
+- empty-database result;
+- populated-database result;
+- constraints and indexes;
+- locking/downtime;
+- generated schema handling;
+- compatibility with existing data.
+
+### GraphQL contract change
+
+Also prove:
+
+- authorization;
+- negative authorization cases;
+- nullability and enum compatibility;
+- pagination and bounded query behaviour;
+- internal client compatibility;
+- downstream generated-client impact.
+
+### Export change
+
+Also follow `thoth-export-server/AGENTS.md` and prove output compatibility with representative fixtures.
+
+### Workflow change
+
+Also follow `.github/workflows/AGENTS.md`. Do not dispatch production workflows for verification.
+
+## 9. Authorization and security
+
+The current policy layer is in `thoth-api/src/policy.rs`.
+
+Do not rely on UI restrictions for authorization.
+
+For every protected operation, test as applicable:
+
+- anonymous caller;
+- authenticated caller without the role;
+- caller scoped to another publisher;
+- correctly scoped publisher role;
+- superuser;
+- machine/service role.
+
+Authorization failures must fail closed.
+
+Do not log:
+
+- tokens;
+- secrets;
+- raw credentials;
+- sensitive object URLs;
+- personal source data;
+- unbounded upstream response bodies.
+
+## 10. Database and durable-state rules
+
+PostgreSQL is canonical.
+
+Do not introduce local files, GitHub Actions, S3 objects, browser state or an external service as the sole durable owner of:
+
+- jobs;
+- leases;
+- checkpoints;
+- canonical records;
+- reconciliation outcomes;
+- audit history.
+
+Prefer transactional writes, unique constraints, leases, idempotency keys and explicit state transitions.
+
+Backfills must be dry-run capable and idempotent where repeat execution is possible.
+
+## 11. API and compatibility
+
+Prefer additive and backwards-compatible changes.
+
+Do not:
+
+- rename stable enum values or API identifiers casually;
+- change field meaning while retaining the same name;
+- remove an API field without an approved deprecation path;
+- expose service credentials to browser clients;
+- allow downstream repositories to guess an unmerged schema.
+
+When a downstream repository needs a new contract, use the exact merged contract or an explicitly pinned preview.
+
+## 12. Generated and derived files
+
+Do not hand-edit generated output unless the repository convention explicitly requires it.
+
+Relevant generated/derived surfaces include:
+
+- Diesel schema output under `thoth-api`;
+- the GraphQL schema generated by `thoth-client/build.rs`;
+- GraphQL client types generated in downstream repositories;
+- API/OpenAPI output derived from export-server route definitions.
+
+Record the generation command and resulting diff.
+
+The Diesel schema-generation procedure has an open control gap. A schema-changing task must resolve or explicitly account for that gap before implementation proceeds.
+
+## 13. Changelog
+
+Every PR must update `CHANGELOG.md` under `## [Unreleased]`.
+
+Use the appropriate heading:
+
+- `### Added`
+- `### Changed`
+- `### Fixed`
+- `### Deprecated`
+- `### Removed`
+- `### Security`
+
+Reference the PR number when available. Do not create duplicate headings in the same Unreleased section.
+
+## 14. Implementation report
+
+Before review, complete the structure in:
+
+```text
+docs/engineering/ai-delivery/implementation-report-template.md
+```
+
+Include:
+
+- exact base and head commits;
+- actual files changed;
+- migrations and operational effects;
+- authorization effects;
+- exact test commands/results;
+- CI status;
+- rollout and rollback;
+- known limitations and deferred work.
+
+The implementing agent may provide a self-assessment but may not issue the approval decision.
+
+## 15. Stop conditions
+
+Stop and return `BLOCKED` when:
+
+- the approved specification is absent;
+- the requested base branch does not exist;
+- implementation conflicts with an approved design;
+- a required migration or authorization path cannot be tested;
+- production credentials or destructive production access would be required;
+- a downstream contract is unavailable and would need to be guessed;
+- repository state differs materially from the task premise;
+- a cross-programme decision is required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  - [764](https://github.com/thoth-pub/thoth/pull/764) - Add the AI-led engineering operating model, task and review templates, risk classification, release gates, and GitHub Flow controls
 
 ## [[1.6.1]](https://github.com/thoth-pub/thoth/releases/tag/v1.6.1) - 2026-07-23
 ### Fixed

--- a/docs/engineering/AGENTS.md
+++ b/docs/engineering/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS.md - Engineering documentation
+
+This file extends the repository-root `AGENTS.md`.
+
+It applies to engineering control, architecture, ADR, task, repository-map, rollout and review documents.
+
+## 1. Documentation authority
+
+Do not describe a proposal as deployed or approved.
+
+Use explicit status terms:
+
+- `DRAFT`
+- `PROPOSED`
+- `APPROVED`
+- `ACTIVE`
+- `SUPERSEDED`
+- `BLOCKED`
+
+Separate:
+
+- observed repository/runtime state;
+- approved target policy;
+- planned future architecture;
+- unresolved decisions.
+
+## 2. No silent duplication
+
+Prefer links and indexes over independent copies of authoritative designs.
+
+When a Project source or document is superseded:
+
+- replace it;
+- mark it superseded; or
+- remove it from the active source set.
+
+Do not leave two apparently current control indexes or designs.
+
+## 3. Required document content
+
+A task specification must include:
+
+- programme;
+- repository;
+- task ID;
+- risk;
+- approved base and PR target;
+- dependencies;
+- objective;
+- scope;
+- non-goals;
+- invariants;
+- acceptance criteria;
+- required tests;
+- migration effect;
+- rollout;
+- rollback;
+- stop conditions;
+- approval.
+
+An ADR must identify all affected programmes and repositories.
+
+A repository map must distinguish verified facts from gaps.
+
+## 4. Completion claims
+
+Do not mark a task complete because:
+
+- documents were written;
+- code exists;
+- an agent says tests passed;
+- CI is green.
+
+Completion requires the evidence and independent decision defined by the operating model.
+
+## 5. Terminology
+
+Use canonical repository and component names.
+
+Current canonical metrics orchestrator:
+
+```text
+thoth-pub/thoth-sphinx
+Sphinx
+```
+
+Avoid obsolete or variant spellings even when explaining historical errors.
+
+## 6. Verification
+
+For documentation changes:
+
+```bash
+git diff --check
+```
+
+Also check:
+
+- relative paths;
+- headings and file indexes;
+- stale status statements;
+- duplicate definitions;
+- repository names;
+- branch names;
+- references to superseded sources;
+- changelog entry.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -1,0 +1,88 @@
+# Thoth Engineering Control
+
+Status: ACTIVE AFTER MERGE  
+Owner: CTO  
+Foundation task: `CTRL-FOUNDATION-01`  
+Foundation pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
+
+## 1. Purpose
+
+This is the repository entry point for Thoth's AI-led engineering delivery controls. It is an index; linked documents, approved designs, ADRs, task specifications, repository state, pull requests and CI remain authoritative.
+
+## 2. Authority order
+
+1. merged code, migrations and generated contracts;
+2. approved ADRs and technical designs;
+3. approved task specifications;
+4. GitHub issues, PRs, review threads and CI;
+5. programme-control and rollout documents;
+6. agent reports and conversations.
+
+Stop when authoritative sources conflict. Record cross-programme resolutions in an ADR or approved programme decision.
+
+## 3. Mandatory delivery controls
+
+- [AI-led engineering delivery](./ai-delivery/README.md)
+- [Operating model](./ai-delivery/operating-model.md)
+- [Branching and release workflow](./ai-delivery/branching-and-release-workflow.md)
+- [Risk classification](./ai-delivery/risk-classification.md)
+- [Model selection](./ai-delivery/model-selection.md)
+- [Release gates](./ai-delivery/release-gates.md)
+- [Task specification template](./ai-delivery/task-specification-template.md)
+- [Implementation report template](./ai-delivery/implementation-report-template.md)
+- [Independent review template](./ai-delivery/independent-review-template.md)
+
+## 4. Repository and environment orientation
+
+- [Repository map](./repository-map/README.md)
+- [Branch topology](./repository-map/branch-topology.md)
+- [Environment boundaries](./repository-map/environments.md)
+- [Control gaps](./repository-map/control-gaps.md)
+- [Agent-instruction rollout](./agent-instructions/rollout-plan.md)
+
+Agents must use observed repository state until an approved normalization task changes it.
+
+## 5. Cross-programme decisions
+
+- [Decision process](./decisions/README.md)
+- [Decision register](./decisions/decision-register.md)
+- [ADR-0001: publisher package capabilities](./decisions/ADR-0001-publisher-package-capability-model.md) - `PROPOSED`
+- [ADR-0002: platform domain boundaries](./decisions/ADR-0002-platform-domain-boundaries.md) - `PROPOSED`
+
+A committed proposed ADR is not approved. Dependent implementation remains blocked until the CTO decision is recorded and independently reviewed.
+
+## 6. Active programmes
+
+### Publisher Services
+
+- [Programme controls](../publisher-services/README.md)
+- [Task tracker](../publisher-services/task-status.md)
+- [Master issue #765](https://github.com/thoth-pub/thoth/issues/765)
+
+Current implementation decision: `BLOCKED`.
+
+### Thoth Metrics
+
+- [Programme controls](../metrics/README.md)
+- [Task tracker](../metrics/task-status.md)
+- [Master issue #766](https://github.com/thoth-pub/thoth/issues/766)
+
+Current implementation decision: `BLOCKED`.
+
+## 7. Canonical names
+
+```text
+thoth-pub/thoth-sphinx
+Sphinx
+```
+
+## 8. Current foundation gate
+
+- [ ] complete final repository consistency checks;
+- [ ] obtain independent review of the complete PR diff and CI;
+- [ ] resolve blocking findings;
+- [ ] obtain CTO merge approval;
+- [ ] merge PR #764 into `develop`;
+- [ ] replace stale Project sources with merged repository versions.
+
+The implementing conversation cannot approve its own work.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -32,7 +32,13 @@ Stop when authoritative sources conflict. Record cross-programme resolutions in 
 - [Implementation report template](./ai-delivery/implementation-report-template.md)
 - [Independent review template](./ai-delivery/independent-review-template.md)
 
-## 4. Repository and environment orientation
+## 4. Approved design references
+
+- [Private approved-design references](./design-references.md)
+
+Reviewers must use the snapshots committed at the exact PR head. The mutable Google Drive documents remain provenance sources, not substitutes for immutable review inputs.
+
+## 5. Repository and environment orientation
 
 - [Repository map](./repository-map/README.md)
 - [Branch topology](./repository-map/branch-topology.md)
@@ -42,7 +48,7 @@ Stop when authoritative sources conflict. Record cross-programme resolutions in 
 
 Agents must use observed repository state until an approved normalization task changes it.
 
-## 5. Cross-programme decisions
+## 6. Cross-programme decisions
 
 - [Decision process](./decisions/README.md)
 - [Decision register](./decisions/decision-register.md)
@@ -51,7 +57,7 @@ Agents must use observed repository state until an approved normalization task c
 
 A committed proposed ADR is not approved. Dependent implementation remains blocked until the CTO decision is recorded and independently reviewed.
 
-## 6. Active programmes
+## 7. Active programmes
 
 ### Publisher Services
 
@@ -69,14 +75,14 @@ Current implementation decision: `BLOCKED`.
 
 Current implementation decision: `BLOCKED`.
 
-## 7. Canonical names
+## 8. Canonical names
 
 ```text
 thoth-pub/thoth-sphinx
 Sphinx
 ```
 
-## 8. Current foundation gate
+## 9. Current foundation gate
 
 - [ ] complete final repository consistency checks;
 - [ ] obtain independent review of the complete PR diff and CI;

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -1,8 +1,8 @@
 # Thoth Engineering Control
 
-Status: ACTIVE AFTER MERGE  
-Owner: CTO  
-Foundation task: `CTRL-FOUNDATION-01`  
+Status: ACTIVE AFTER MERGE
+Owner: CTO
+Foundation task: `CTRL-FOUNDATION-01`
 Foundation pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
 
 ## 1. Purpose

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -36,7 +36,7 @@ Stop when authoritative sources conflict. Record cross-programme resolutions in 
 
 - [Private approved-design references](./design-references.md)
 
-Reviewers must use the snapshots committed at the exact PR head. The mutable Google Drive documents remain provenance sources, not substitutes for immutable review inputs.
+Reviewers must use the exact Google Drive file and revision metadata recorded in `design-references.md` and must have authorized access to those private revisions. The repository intentionally does not contain the design bodies.
 
 ## 5. Repository and environment orientation
 

--- a/docs/engineering/agent-instructions/README.md
+++ b/docs/engineering/agent-instructions/README.md
@@ -1,6 +1,6 @@
 # Repository-local Agent Instructions
 
-Status: ACTIVE after the containing PR is approved and merged  
+Status: ACTIVE after the containing PR is approved and merged
 Owner: CTO
 
 ## Purpose

--- a/docs/engineering/agent-instructions/README.md
+++ b/docs/engineering/agent-instructions/README.md
@@ -1,0 +1,61 @@
+# Repository-local Agent Instructions
+
+Status: ACTIVE after the containing PR is approved and merged  
+Owner: CTO
+
+## Purpose
+
+Repository-local `AGENTS.md` files give implementing and reviewing agents the exact constraints, commands, generated-file rules and safety boundaries for the directory they are editing.
+
+They do not replace:
+
+- approved technical designs;
+- ADRs;
+- task specifications;
+- live repository state;
+- independent review.
+
+## Thoth hierarchy
+
+The `thoth` repository uses:
+
+```text
+AGENTS.md
+├── .github/workflows/AGENTS.md
+├── docs/engineering/AGENTS.md
+├── thoth-api/AGENTS.md
+├── thoth-api-server/AGENTS.md
+├── thoth-client/AGENTS.md
+├── thoth-errors/AGENTS.md
+└── thoth-export-server/AGENTS.md
+```
+
+The root file provides repository-wide controls. Nested files add directory-specific requirements.
+
+## Rule for agents
+
+Before editing a file, read:
+
+1. the root `AGENTS.md`;
+2. each applicable nested `AGENTS.md`;
+3. the approved task specification;
+4. the relevant design and ADR;
+5. current code and tests.
+
+The closest applicable instruction file may narrow the required checks but may not weaken repository-wide safety rules.
+
+## Maintenance
+
+Update an instruction file when durable repository behaviour changes, including:
+
+- branch topology;
+- standard commands;
+- code-generation procedure;
+- CI gates;
+- deployment/release mechanism;
+- authorization architecture;
+- ownership boundaries.
+
+Do not update it for temporary task details.
+
+Every update requires normal review and a changelog entry.

--- a/docs/engineering/agent-instructions/rollout-plan.md
+++ b/docs/engineering/agent-instructions/rollout-plan.md
@@ -10,7 +10,7 @@ Owner: CTO
 | `thoth` | root and scoped hierarchy added by the engineering-control foundation PR | independently review and merge |
 | `thoth-app` | no verified root `AGENTS.md` | create from approved repository map |
 | `thoth-dissemination` | existing root `AGENTS.md`, incomplete control coverage | revise without losing useful local guidance |
-| `thoth-sphinx` | empty repository | add `AGENTS.md` during bootstrap |
+| `thoth-sphinx` | placeholder-only README; no verified `AGENTS.md` | add `AGENTS.md` and replace or expand the README during bootstrap |
 | `metrics-dashboard` | no verified root `AGENTS.md` | create before metrics client migration |
 | `metrics-widget` | no verified root `AGENTS.md` | create before metrics API migration/release |
 | `cc-license` | no verified root `AGENTS.md` | create before LIC-01 |

--- a/docs/engineering/agent-instructions/rollout-plan.md
+++ b/docs/engineering/agent-instructions/rollout-plan.md
@@ -1,0 +1,67 @@
+# Agent Instruction Rollout Plan
+
+Status: IN PROGRESS  
+Owner: CTO
+
+## 1. Current state
+
+| Repository | Current instruction state | Required action |
+|---|---|---|
+| `thoth` | root and scoped hierarchy added by the engineering-control foundation PR | independently review and merge |
+| `thoth-app` | no verified root `AGENTS.md` | create from approved repository map |
+| `thoth-dissemination` | existing root `AGENTS.md`, incomplete control coverage | revise without losing useful local guidance |
+| `thoth-sphinx` | empty repository | add `AGENTS.md` during bootstrap |
+| `metrics-dashboard` | no verified root `AGENTS.md` | create before metrics client migration |
+| `metrics-widget` | no verified root `AGENTS.md` | create before metrics API migration/release |
+| `cc-license` | no verified root `AGENTS.md` | create before LIC-01 |
+
+## 2. Rollout sequence
+
+1. Approve and merge the `thoth` control foundation.
+2. Update `thoth-dissemination`, because it already performs production-capable workflows.
+3. Add `thoth-app` instructions before Publisher Services or metrics upload UI implementation.
+4. Add `thoth-sphinx` instructions as part of its no-production bootstrap task.
+5. Add dashboard and widget instructions before client cutover work.
+6. Add `cc-license` instructions before changing the supported licence contract.
+
+## 3. Per-repository minimum content
+
+Each root `AGENTS.md` must record:
+
+- repository responsibility and non-responsibilities;
+- actual branch and release topology;
+- required task metadata;
+- standard install/build/test/lint commands;
+- generated files and how to regenerate them;
+- CI and release gates;
+- authorization/security boundaries;
+- deployment or package-publishing effects;
+- prohibited production actions;
+- completion report and independent review requirements;
+- stop conditions.
+
+## 4. Delivery model
+
+Instruction rollout to other repositories requires repository-local PRs.
+
+Use the repository's current verified development branch until an approved branch-normalization task completes.
+
+Do not combine:
+
+- branch normalization;
+- CI modernization;
+- functional implementation;
+- agent-instruction rollout
+
+unless the approved specification proves they are inseparable.
+
+## 5. Source authority
+
+Generate each file from:
+
+- the merged repository/environment map;
+- live repository code and workflows;
+- the approved operating model;
+- current deployment/release evidence.
+
+Do not copy the `thoth` root file verbatim into another repository.

--- a/docs/engineering/agent-instructions/rollout-plan.md
+++ b/docs/engineering/agent-instructions/rollout-plan.md
@@ -1,6 +1,6 @@
 # Agent Instruction Rollout Plan
 
-Status: IN PROGRESS  
+Status: IN PROGRESS
 Owner: CTO
 
 ## 1. Current state

--- a/docs/engineering/ai-delivery/README.md
+++ b/docs/engineering/ai-delivery/README.md
@@ -12,7 +12,7 @@ These documents apply across Thoth engineering programmes unless a stricter appr
 - `model-selection.md` - implementation and review model guidance.
 - `task-specification-template.md` - required specification before implementation.
 - `implementation-report-template.md` - required agent completion report.
-- `reports/` - completed task-specific implementation evidence.
+- `implementation-reports/` - completed task-specific implementation evidence.
 - `independent-review-template.md` - evidence-based review format.
 - `release-gates.md` - merge, staging, production and closure gates.
 - `decision-record-template.md` - lightweight ADR/programme decision template.

--- a/docs/engineering/ai-delivery/README.md
+++ b/docs/engineering/ai-delivery/README.md
@@ -1,0 +1,58 @@
+# AI-led Engineering Delivery
+
+This directory defines the mandatory delivery controls for engineering tasks implemented or substantially assisted by AI agents.
+
+These documents apply across Thoth engineering programmes unless a stricter approved programme specification overrides them.
+
+## Documents
+
+- `operating-model.md` - roles, authority, lifecycle and task boundaries.
+- `branching-and-release-workflow.md` - GitHub Flow, `develop`/`master`, programme integration branches and releases.
+- `risk-classification.md` - task risk levels and mandatory controls.
+- `model-selection.md` - implementation and review model guidance.
+- `task-specification-template.md` - required specification before implementation.
+- `implementation-report-template.md` - required agent completion report.
+- `independent-review-template.md` - evidence-based review format.
+- `release-gates.md` - merge, staging, production and closure gates.
+- `decision-record-template.md` - lightweight ADR/programme decision template.
+
+## Core rule
+
+A task is not complete because code exists or CI passes.
+
+A task is complete only when:
+
+1. its approved scope and acceptance criteria are satisfied;
+2. actual diffs and tests have been independently reviewed;
+3. migration, authorization and operational effects have evidence;
+4. the appropriate merge and release gates have passed;
+5. repository status and follow-up work are current.
+
+## Branching summary
+
+Thoth uses GitHub Flow (`ghf`):
+
+```text
+feature/* -> develop -> master
+```
+
+For approved large programmes:
+
+```text
+feature/<programme>/<slice> -> feature/<programme> -> develop -> master
+```
+
+Implementation branches normally start from `develop`. `master` is the release branch.
+
+## Authority
+
+In descending order:
+
+1. Merged repository state.
+2. Approved ADRs and designs.
+3. Approved task specifications.
+4. Pull requests, review threads and CI evidence.
+5. Programme control documents.
+6. Conversations and agent reports.
+
+Missing evidence is missing work.

--- a/docs/engineering/ai-delivery/README.md
+++ b/docs/engineering/ai-delivery/README.md
@@ -12,9 +12,12 @@ These documents apply across Thoth engineering programmes unless a stricter appr
 - `model-selection.md` - implementation and review model guidance.
 - `task-specification-template.md` - required specification before implementation.
 - `implementation-report-template.md` - required agent completion report.
+- `reports/` - completed task-specific implementation evidence.
 - `independent-review-template.md` - evidence-based review format.
 - `release-gates.md` - merge, staging, production and closure gates.
 - `decision-record-template.md` - lightweight ADR/programme decision template.
+- `tasks/CTRL-FOUNDATION-01.md` - approved foundation specification.
+- `reviews/CTRL-FOUNDATION-01-review-brief.md` - independent review requirements.
 
 ## Core rule
 

--- a/docs/engineering/ai-delivery/branching-and-release-workflow.md
+++ b/docs/engineering/ai-delivery/branching-and-release-workflow.md
@@ -57,8 +57,8 @@ from the latest `develop`.
 Examples:
 
 ```text
-feature/publisher-services
 feature/metrics
+feature/large-programme
 ```
 
 Each independently reviewable slice then branches from the programme integration branch:
@@ -70,10 +70,9 @@ feature/<programme>/<task-id-or-slice>
 Examples:
 
 ```text
-feature/publisher-services/be-01
-feature/publisher-services/be-02
 feature/metrics/db-foundation
 feature/metrics/ingestion-core
+feature/large-programme/slice-01
 ```
 
 Each slice pull request targets the programme integration branch, not `develop`.
@@ -120,7 +119,32 @@ Use a programme integration branch when:
 
 Do not create a programme integration branch merely because a programme is large. Prefer direct-to-`develop`, additive, inactive slices when they are independently safe. Long-lived branches increase divergence and integration risk.
 
-## 5. Multi-repository programmes
+
+## 5. Programme-specific workflow authority
+
+An approved programme design may require either the standard flow or the programme-integration flow. Record the selected flow in the programme controls and every task specification.
+
+### Publisher Services
+
+The approved Publisher Services design requires:
+
+```text
+development branch -> feature/publisher-services/<task> -> development branch
+```
+
+Every task uses a fresh branch and one PR. Do not create a long-lived `feature/publisher-services` integration branch.
+
+### Thoth Metrics
+
+The Metrics design requires repository-local integration branches after branch readiness:
+
+```text
+develop -> feature/metrics -> feature/metrics/<slice> -> feature/metrics -> develop
+```
+
+Each affected repository owns its own branch and final PR. No physical branch spans repositories.
+
+## 6. Multi-repository programmes
 
 Branches are repository-local.
 
@@ -130,7 +154,7 @@ For example:
 
 ```text
 thoth:             feature/metrics
-thoth-sphinx:      feature/metrics
+thoth-sphinx:       feature/metrics
 thoth-app:         feature/metrics
 metrics-dashboard: feature/metrics
 ```
@@ -151,7 +175,7 @@ Where a downstream repository needs an API contract before the upstream final PR
 
 Do not allow downstream code to guess an unmerged contract.
 
-## 6. Keeping integration branches current
+## 7. Keeping integration branches current
 
 For programme integration branches:
 
@@ -164,7 +188,7 @@ For programme integration branches:
 
 The task specification must state whether the repository convention uses merge or rebase for refreshing the programme branch.
 
-## 7. Pull-request review boundaries
+## 8. Pull-request review boundaries
 
 Every slice PR must still be independently reviewable.
 
@@ -189,7 +213,7 @@ The final programme PR must additionally verify:
 - programme-wide acceptance criteria pass;
 - rollout, rollback and observation are approved.
 
-## 8. Release flow
+## 9. Release flow
 
 The normal release path is:
 
@@ -213,7 +237,7 @@ A release from `develop` to `master` must:
 - receive required CTO approval;
 - preserve traceability from release to tasks and PRs.
 
-## 9. Prohibited branch patterns
+## 10. Prohibited branch patterns
 
 Do not:
 

--- a/docs/engineering/ai-delivery/branching-and-release-workflow.md
+++ b/docs/engineering/ai-delivery/branching-and-release-workflow.md
@@ -1,0 +1,226 @@
+# Branching and Release Workflow
+
+Status: Proposed until merged and approved  
+Owner: CTO  
+Workflow: GitHub Flow (`ghf`)
+
+## 1. Standard delivery flow
+
+Thoth repositories use the following normal workflow:
+
+1. Start from the latest `develop` branch.
+2. Create a short-lived branch under `feature/`.
+3. Implement one bounded task.
+4. Open a pull request from the feature branch into `develop`.
+5. Complete independent review and required checks.
+6. Merge the pull request into `develop`.
+7. Delete the feature branch.
+8. When `develop` contains a coherent, production-ready release, create a release that merges `develop` into `master`.
+9. Deploy or activate production behaviour only under the applicable release controls.
+
+`master` is the release branch. It is not the normal base branch for implementation work.
+
+## 2. Standard task branch naming
+
+Use:
+
+```text
+feature/<programme-or-area>/<task-id-or-short-name>
+```
+
+Examples:
+
+```text
+feature/publisher-services/be-01
+feature/metrics/record-schema
+feature/auth/service-role-tests
+```
+
+A normal task branch:
+
+- branches from `develop`;
+- targets `develop`;
+- is deleted after merge.
+
+## 3. Large programme integration branches
+
+For a large, multi-slice programme that must be validated as one coherent feature before entering `develop`, use a dedicated programme integration branch.
+
+Create:
+
+```text
+feature/<programme>
+```
+
+from the latest `develop`.
+
+Examples:
+
+```text
+feature/publisher-services
+feature/metrics
+```
+
+Each independently reviewable slice then branches from the programme integration branch:
+
+```text
+feature/<programme>/<task-id-or-slice>
+```
+
+Examples:
+
+```text
+feature/publisher-services/be-01
+feature/publisher-services/be-02
+feature/metrics/db-foundation
+feature/metrics/ingestion-core
+```
+
+Each slice pull request targets the programme integration branch, not `develop`.
+
+After a slice PR is approved and merged:
+
+1. delete the slice branch;
+2. update the programme tracker;
+3. verify the integration branch remains green;
+4. rebase or merge the latest `develop` into the programme integration branch at agreed checkpoints;
+5. resolve integration conflicts before additional dependent slices proceed.
+
+When the entire programme feature satisfies its integrated acceptance criteria, open one final pull request:
+
+```text
+feature/<programme> -> develop
+```
+
+That final PR is the programme integration and release-candidate gate.
+
+After it is merged:
+
+- delete the programme integration branch;
+- retain the task specifications, PRs and review evidence;
+- prepare the normal `develop` to `master` release when the release is approved.
+
+## 4. Choosing standard versus programme integration flow
+
+Use the standard direct-to-`develop` flow when:
+
+- the task is independently useful or safely inert;
+- it can merge without requiring incomplete sibling changes;
+- compatibility can be maintained;
+- the change can be hidden behind a feature flag or remain unused;
+- merging early reduces branch divergence.
+
+Use a programme integration branch when:
+
+- several slices must be tested together before entering `develop`;
+- intermediate states would break builds, generated contracts or consumers;
+- multiple repositories must coordinate around a pinned feature contract;
+- the feature requires a final integrated acceptance environment;
+- the CTO has explicitly approved the integration-branch approach.
+
+Do not create a programme integration branch merely because a programme is large. Prefer direct-to-`develop`, additive, inactive slices when they are independently safe. Long-lived branches increase divergence and integration risk.
+
+## 5. Multi-repository programmes
+
+Branches are repository-local.
+
+A coordinated programme may use the same branch naming convention in multiple repositories, but there is no single Git branch spanning repositories.
+
+For example:
+
+```text
+thoth:             feature/metrics
+thoth-sphynx:      feature/metrics
+thoth-app:         feature/metrics
+metrics-dashboard: feature/metrics
+```
+
+Each repository has:
+
+- its own integration branch from that repository's `develop`;
+- its own slice branches;
+- its own final `feature/<programme> -> develop` PR.
+
+Final PRs are merged in the documented dependency order.
+
+Where a downstream repository needs an API contract before the upstream final PR merges, use one of:
+
+- a pinned preview environment;
+- a versioned generated schema from the integration branch;
+- a temporary branch reference explicitly recorded in the task specification.
+
+Do not allow downstream code to guess an unmerged contract.
+
+## 6. Keeping integration branches current
+
+For programme integration branches:
+
+- record the original `develop` base commit;
+- update from `develop` at defined checkpoints;
+- update before high-risk database or API slices;
+- update before the final integration review;
+- rerun integrated CI after every update;
+- avoid arbitrary history rewriting after other agents or reviewers depend on the branch.
+
+The task specification must state whether the repository convention uses merge or rebase for refreshing the programme branch.
+
+## 7. Pull-request review boundaries
+
+Every slice PR must still be independently reviewable.
+
+A slice PR must include:
+
+- one approved task specification;
+- a bounded diff;
+- task-level tests;
+- migration and compatibility evidence;
+- an implementation report;
+- an independent review decision.
+
+Approval of a slice PR does not approve the overall programme for production.
+
+The final programme PR must additionally verify:
+
+- all accepted slices are present;
+- cross-slice behaviour works;
+- integrated migrations apply in order;
+- generated contracts are consistent;
+- no temporary test scaffolding or unsafe bypass remains;
+- programme-wide acceptance criteria pass;
+- rollout, rollback and observation are approved.
+
+## 8. Release flow
+
+The normal release path is:
+
+```text
+feature branch -> develop -> master
+```
+
+For a programme integration branch:
+
+```text
+slice branch -> feature/<programme> -> develop -> master
+```
+
+A release from `develop` to `master` must:
+
+- identify the included PRs and migrations;
+- verify `develop` is green;
+- include release notes;
+- include deployment and rollback instructions;
+- identify feature flags or post-deploy activation;
+- receive required CTO approval;
+- preserve traceability from release to tasks and PRs.
+
+## 9. Prohibited branch patterns
+
+Do not:
+
+- branch normal implementation work from `master`;
+- target normal feature PRs directly at `master`;
+- keep merged slice branches indefinitely;
+- mix unrelated programmes in one integration branch;
+- use an integration branch as a substitute for task specifications or review;
+- allow an implementing agent to merge its own PR;
+- activate production behaviour merely because a programme branch merged into `develop`.

--- a/docs/engineering/ai-delivery/branching-and-release-workflow.md
+++ b/docs/engineering/ai-delivery/branching-and-release-workflow.md
@@ -130,7 +130,7 @@ For example:
 
 ```text
 thoth:             feature/metrics
-thoth-sphynx:      feature/metrics
+thoth-sphinx:      feature/metrics
 thoth-app:         feature/metrics
 metrics-dashboard: feature/metrics
 ```

--- a/docs/engineering/ai-delivery/branching-and-release-workflow.md
+++ b/docs/engineering/ai-delivery/branching-and-release-workflow.md
@@ -1,7 +1,7 @@
 # Branching and Release Workflow
 
-Status: Proposed until merged and approved  
-Owner: CTO  
+Status: Proposed until merged and approved
+Owner: CTO
 Workflow: GitHub Flow (`ghf`)
 
 ## 1. Standard delivery flow

--- a/docs/engineering/ai-delivery/decision-record-template.md
+++ b/docs/engineering/ai-delivery/decision-record-template.md
@@ -4,12 +4,12 @@ Use for an ADR or programme decision that constrains implementation.
 
 # ADR-[NUMBER] - [Decision title]
 
-Status: PROPOSED | APPROVED | SUPERSEDED | REJECTED  
-Date:  
-Decision owner:  
-Programmes affected:  
-Repositories affected:  
-Supersedes:  
+Status: PROPOSED | APPROVED | SUPERSEDED | REJECTED
+Date:
+Decision owner:
+Programmes affected:
+Repositories affected:
+Supersedes:
 Superseded by:
 
 ## 1. Context
@@ -26,16 +26,16 @@ Describe the problem, current state, constraints and why a decision is required.
 
 ### Option A - [name]
 
-Description:  
-Advantages:  
-Disadvantages:  
+Description:
+Advantages:
+Disadvantages:
 Operational implications:
 
 ### Option B - [name]
 
-Description:  
-Advantages:  
-Disadvantages:  
+Description:
+Advantages:
+Disadvantages:
 Operational implications:
 
 ## 4. Decision
@@ -76,10 +76,10 @@ Include:
 
 ## 7. Implementation impact
 
-Affected tasks:  
-Required sequencing:  
-Required migrations:  
-Required client changes:  
+Affected tasks:
+Required sequencing:
+Required migrations:
+Required client changes:
 Required operational changes:
 
 ## 8. Validation
@@ -91,6 +91,6 @@ Evidence required to prove the decision works:
 
 ## 9. Approval
 
-Approved by:  
-Approval date:  
+Approved by:
+Approval date:
 Notes:

--- a/docs/engineering/ai-delivery/decision-record-template.md
+++ b/docs/engineering/ai-delivery/decision-record-template.md
@@ -1,0 +1,96 @@
+# Decision Record Template
+
+Use for an ADR or programme decision that constrains implementation.
+
+# ADR-[NUMBER] - [Decision title]
+
+Status: PROPOSED | APPROVED | SUPERSEDED | REJECTED  
+Date:  
+Decision owner:  
+Programmes affected:  
+Repositories affected:  
+Supersedes:  
+Superseded by:
+
+## 1. Context
+
+Describe the problem, current state, constraints and why a decision is required.
+
+## 2. Decision drivers
+
+- [...]
+- [...]
+- [...]
+
+## 3. Options considered
+
+### Option A - [name]
+
+Description:  
+Advantages:  
+Disadvantages:  
+Operational implications:
+
+### Option B - [name]
+
+Description:  
+Advantages:  
+Disadvantages:  
+Operational implications:
+
+## 4. Decision
+
+State the chosen option precisely.
+
+Include:
+
+- ownership;
+- data model;
+- API boundary;
+- authorization;
+- compatibility;
+- migration;
+- rollout;
+- extension points;
+- explicit exclusions.
+
+## 5. Consequences
+
+### Positive
+
+- [...]
+
+### Negative
+
+- [...]
+
+### Risks
+
+- [...]
+
+## 6. Invariants created by this decision
+
+1. [...]
+2. [...]
+3. [...]
+
+## 7. Implementation impact
+
+Affected tasks:  
+Required sequencing:  
+Required migrations:  
+Required client changes:  
+Required operational changes:
+
+## 8. Validation
+
+Evidence required to prove the decision works:
+
+- [...]
+- [...]
+
+## 9. Approval
+
+Approved by:  
+Approval date:  
+Notes:

--- a/docs/engineering/ai-delivery/implementation-report-template.md
+++ b/docs/engineering/ai-delivery/implementation-report-template.md
@@ -8,24 +8,24 @@ Do not write `passed` without the exact command and result.
 
 ## 1. Repository state
 
-Repository:  
-Workflow: STANDARD | PROGRAMME_INTEGRATION  
-Base branch:  
-Base commit:  
-PR target:  
-Programme integration branch:  
-Task branch:  
-Head commit:  
-Pull request:  
-Expected branch deletion after merge: YES  
-Final programme PR required: YES | NO  
-Implementing model:  
+Repository:
+Workflow: STANDARD | PROGRAMME_INTEGRATION
+Base branch:
+Base commit:
+PR target:
+Programme integration branch:
+Task branch:
+Head commit:
+Pull request:
+Expected branch deletion after merge: YES
+Final programme PR required: YES | NO
+Implementing model:
 Reasoning level:
 
 ## 2. Scope confirmation
 
-Approved specification:  
-Implemented objective:  
+Approved specification:
+Implemented objective:
 
 Out-of-scope changes made: NONE | [explain and link to approval]
 
@@ -71,18 +71,18 @@ If yes:
 
 ## 7. API and compatibility effects
 
-GraphQL/API changes:  
-Generated schema/client updates:  
-Backwards compatibility:  
-Deprecations:  
+GraphQL/API changes:
+Generated schema/client updates:
+Backwards compatibility:
+Deprecations:
 Cross-repository dependencies:
 
 ## 8. Authorization and security
 
-Authorization paths changed:  
-Roles/scopes involved:  
-Negative authorization tests:  
-Secret or personal-data handling:  
+Authorization paths changed:
+Roles/scopes involved:
+Negative authorization tests:
+Secret or personal-data handling:
 Security limitations:
 
 ## 9. Tests and checks
@@ -151,24 +151,24 @@ Result:
 
 ## 10. Manual verification
 
-Environment:  
-Steps:  
-Observed result:  
+Environment:
+Steps:
+Observed result:
 Evidence link/screenshot/log reference:
 
 ## 11. CI
 
-CI status: PASSING | FAILING | PENDING | NOT AVAILABLE  
-Checks:  
+CI status: PASSING | FAILING | PENDING | NOT AVAILABLE
+Checks:
 Failures or warnings:
 
 ## 12. Rollout and rollback
 
-Initial state after merge:  
-Activation required:  
-Feature flag/configuration:  
-Migration sequence:  
-Rollback/disable procedure:  
+Initial state after merge:
+Activation required:
+Feature flag/configuration:
+Migration sequence:
+Rollback/disable procedure:
 Monitoring required:
 
 ## 13. Known limitations and deferred work

--- a/docs/engineering/ai-delivery/implementation-report-template.md
+++ b/docs/engineering/ai-delivery/implementation-report-template.md
@@ -1,0 +1,191 @@
+# Implementation Report Template
+
+The implementing agent completes this report after pushing the task branch and opening or updating the draft PR.
+
+Do not write `passed` without the exact command and result.
+
+# [TASK-ID] Implementation Report
+
+## 1. Repository state
+
+Repository:  
+Workflow: STANDARD | PROGRAMME_INTEGRATION  
+Base branch:  
+Base commit:  
+PR target:  
+Programme integration branch:  
+Task branch:  
+Head commit:  
+Pull request:  
+Expected branch deletion after merge: YES  
+Final programme PR required: YES | NO  
+Implementing model:  
+Reasoning level:
+
+## 2. Scope confirmation
+
+Approved specification:  
+Implemented objective:  
+
+Out-of-scope changes made: NONE | [explain and link to approval]
+
+## 3. Commits
+
+- `[sha]` - [message]
+- [...]
+
+## 4. Files changed
+
+For each material file:
+
+- `path`
+  - reason:
+  - behavioural effect:
+
+## 5. Implementation decisions
+
+List decisions made within the approved design:
+
+1. [...]
+2. [...]
+
+List any deviation from the specification:
+
+- NONE; or
+- [deviation, reason, approval status]
+
+## 6. Database and migration effects
+
+Migration added: YES | NO
+
+If yes:
+
+- migration files:
+- schema effect:
+- existing-data effect:
+- locking/downtime:
+- empty database result:
+- populated database result:
+- rollback/forward repair:
+- idempotency:
+
+## 7. API and compatibility effects
+
+GraphQL/API changes:  
+Generated schema/client updates:  
+Backwards compatibility:  
+Deprecations:  
+Cross-repository dependencies:
+
+## 8. Authorization and security
+
+Authorization paths changed:  
+Roles/scopes involved:  
+Negative authorization tests:  
+Secret or personal-data handling:  
+Security limitations:
+
+## 9. Tests and checks
+
+Record exact commands and outcomes.
+
+### Formatting
+
+Command:
+
+```text
+[command]
+```
+
+Result:
+
+```text
+[exact concise result]
+```
+
+### Unit tests
+
+Command:
+
+```text
+[command]
+```
+
+Result:
+
+```text
+[exact concise result]
+```
+
+### Integration/database tests
+
+Command:
+
+```text
+[command]
+```
+
+Result:
+
+```text
+[exact concise result]
+```
+
+### Lint/static analysis
+
+Command:
+
+```text
+[command]
+```
+
+Result:
+
+```text
+[exact concise result]
+```
+
+### Other required checks
+
+[...]
+
+## 10. Manual verification
+
+Environment:  
+Steps:  
+Observed result:  
+Evidence link/screenshot/log reference:
+
+## 11. CI
+
+CI status: PASSING | FAILING | PENDING | NOT AVAILABLE  
+Checks:  
+Failures or warnings:
+
+## 12. Rollout and rollback
+
+Initial state after merge:  
+Activation required:  
+Feature flag/configuration:  
+Migration sequence:  
+Rollback/disable procedure:  
+Monitoring required:
+
+## 13. Known limitations and deferred work
+
+- [...]
+- [...]
+
+## 14. Unresolved issues
+
+- NONE; or
+- [...]
+
+## 15. Agent self-assessment
+
+The agent may identify risks but may not approve the task.
+
+Suggested review focus:
+
+- [...]
+- [...]

--- a/docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md
@@ -8,7 +8,7 @@ Base commit: `652a499dfdfbaa7594537e0865c41ec617f52dc2`
 PR target: `develop`
 Programme integration branch: None
 Task branch: `feature/ai-delivery-operating-model`
-Implementation and remediation head: `104ffaa16b2436cea2b4e2779c241b016916f083`
+Implementation and remediation head: `a7634bf9dbb2a0573826053be6d73e19eb2b4ca2`
 Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
 Expected branch deletion after merge: YES
 Final programme PR required: NO
@@ -17,7 +17,7 @@ Reasoning level: high
 
 The final review head is the report commit that contains this file. Git commits
 cannot embed their own hash. The independent reviewer must record the exact PR
-head and verify that the delta after `104ffaa16b2436cea2b4e2779c241b016916f083` contains only this
+head and verify that the delta after `a7634bf9dbb2a0573826053be6d73e19eb2b4ca2` contains only this
 report and the associated evidence-status updates.
 
 ## 1. Scope confirmation
@@ -35,7 +35,7 @@ metadata, and review/release gates.
 
 Out-of-scope changes made: NONE
 
-## 2. Commits through the remediation head
+## 2. Commits through the dashboard remediation head
 
 - `2bc1c9e3436c87b9969b093b2af72ff2bd7a9d2a` - docs: add AI-led engineering delivery controls
 - `ce9d5a1fc22884b6acdcc7ec43d2b5edb38def2a` - Update changelog
@@ -49,6 +49,9 @@ Out-of-scope changes made: NONE
 - `fb38b2f5d85247d7d05ddf799dfe5191df2471e4` - docs: remove trailing whitespace from control documents
 - `ea687e88330aea3a9e44c69448c20b2d34422b3a` - docs: address foundation review blockers
 - `104ffaa16b2436cea2b4e2779c241b016916f083` - docs: correct foundation review evidence
+- `b502532735a734895aa17c0922163f85596abbf2` - docs: add foundation implementation report
+- `330f101dae870fe4b583eead3eb1bd3a27a25208` - docs: correct foundation verification evidence
+- `a7634bf9dbb2a0573826053be6d73e19eb2b4ca2` - docs: correct metrics dashboard branch map
 
 ## 3. Actual files changed through the remediation head
 
@@ -64,6 +67,7 @@ docs/engineering/ai-delivery/README.md
 docs/engineering/ai-delivery/branching-and-release-workflow.md
 docs/engineering/ai-delivery/decision-record-template.md
 docs/engineering/ai-delivery/implementation-report-template.md
+docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md
 docs/engineering/ai-delivery/independent-review-template.md
 docs/engineering/ai-delivery/model-selection.md
 docs/engineering/ai-delivery/operating-model.md
@@ -125,7 +129,8 @@ Diff summary:
  docs/engineering/ai-delivery/README.md             |  61 ++++
  .../ai-delivery/branching-and-release-workflow.md  | 250 +++++++++++++++
  .../ai-delivery/decision-record-template.md        |  96 ++++++
- .../ai-delivery/implementation-report-template.md  | 191 ++++++++++++
+ .../ai-delivery/implementation-report-template.md  | 191 +++++++++++
+ .../CTRL-FOUNDATION-01-implementation-report.md    | 363 +++++++++++++++++++++
  .../ai-delivery/independent-review-template.md     | 180 +++++++++++
  docs/engineering/ai-delivery/model-selection.md    |  83 +++++
  docs/engineering/ai-delivery/operating-model.md    | 248 +++++++++++++++
@@ -141,11 +146,11 @@ Diff summary:
  .../decisions/package-capability-matrix.md         | 157 ++++++++++
  docs/engineering/design-references.md              |  41 +++
  docs/engineering/repository-map/README.md          |  31 ++
- docs/engineering/repository-map/branch-topology.md | 135 ++++++++
+ docs/engineering/repository-map/branch-topology.md | 142 ++++++++
  docs/engineering/repository-map/control-gaps.md    |  66 ++++
- docs/engineering/repository-map/environments.md    |  97 ++++++
+ docs/engineering/repository-map/environments.md    | 103 ++++++
  .../repository-map/repositories/cc-license.md      |  52 ++++
- .../repositories/metrics-dashboard.md              |  75 +++++
+ .../repositories/metrics-dashboard.md              |  90 +++++
  .../repository-map/repositories/metrics-widget.md  |  64 ++++
  .../repository-map/repositories/thoth-app.md       | 108 +++++++
  .../repositories/thoth-dissemination.md            |  97 ++++++
@@ -159,7 +164,7 @@ Diff summary:
  docs/metrics/migration-inventory.md                |  50 +++
  docs/metrics/rollout-plan.md                       |  57 ++++
  docs/metrics/source-inventory.md                   |  79 +++++
- docs/metrics/task-status.md                        |  59 ++++
+ docs/metrics/task-status.md                        |  64 ++++
  docs/publisher-services/README.md                  | 119 ++++++++
  docs/publisher-services/acceptance-matrix.md       | 104 +++++++
  docs/publisher-services/decisions.md               | 148 +++++++++
@@ -172,7 +177,7 @@ Diff summary:
  thoth-client/AGENTS.md                             |  60 ++++
  thoth-errors/AGENTS.md                             |  39 +++
  thoth-export-server/AGENTS.md                      |  77 +++++
- 57 files changed, 6621 insertions(+)
+ 58 files changed, 7017 insertions(+)
 ```
 
 All changed files are documentation, `AGENTS.md` instruction files, or the
@@ -211,6 +216,9 @@ Behavioural effect: documentation and engineering-control evidence only.
    README, but no workspace, implementation, CI, protections or runtime.
 7. Store completed implementation reports under `implementation-reports/`,
    avoiding the repository's broad ignored `reports/` pattern.
+8. Correct the observed `metrics-dashboard` branch map to record `dev` as active
+   development, `main` as default/release and `develop` as a stale legacy
+   branch. BR-DASH-01 remains a separate HIGH-risk normalization task.
 
 Deviation from the approved specification: NONE after review remediation.
 
@@ -233,7 +241,7 @@ Backwards compatibility: unaffected
 Command:
 
 ```text
-git diff --check 652a499dfdfbaa7594537e0865c41ec617f52dc2...104ffaa16b2436cea2b4e2779c241b016916f083
+git diff --check 652a499dfdfbaa7594537e0865c41ec617f52dc2...a7634bf9dbb2a0573826053be6d73e19eb2b4ca2
 ```
 
 Result: no output; PASS.
@@ -287,7 +295,7 @@ Result: no output; PASS.
 Command:
 
 ```text
-git diff --name-only 652a499dfdfbaa7594537e0865c41ec617f52dc2...104ffaa16b2436cea2b4e2779c241b016916f083
+git diff --name-only 652a499dfdfbaa7594537e0865c41ec617f52dc2...a7634bf9dbb2a0573826053be6d73e19eb2b4ca2
 ```
 
 Result: only the files recorded in section 3; PASS.
@@ -297,14 +305,29 @@ Result: only the files recorded in section 3; PASS.
 No executable behaviour or migration was changed. Existing build, tests, lint,
 formatting and migrations were exercised by current-head GitHub Actions.
 
+### Metrics Dashboard branch verification
+
+Authenticated GitHub evidence on 2026-07-24:
+
+- default/release `main`: `92d90380e948b3f11f88821054fbad9a5a07f387`;
+- active development `dev`: `1f81745e6d9e812baab62a19e41a0c0f3b9ff0c9`;
+- stale legacy `develop`: `1619899076d16de81abf5c2c6abdd40d985512e6`;
+- `dev` is 10 commits ahead of `develop` and zero commits behind;
+- recent merged pull requests use `dev -> main`.
+
+PR #764 changed documentation only. It did not alter any
+`metrics-dashboard` branch, GitHub setting, protection or Vercel configuration.
+BR-DASH-01 remains a separate HIGH-risk normalization task.
+
 ## 8. CI at the implementation/remediation head
 
-All required workflows completed successfully for `104ffaa16b2436cea2b4e2779c241b016916f083`:
+All required workflows completed successfully for
+`a7634bf9dbb2a0573826053be6d73e19eb2b4ca2`:
 
-- `build-test-and-check`: `completed/success`, run `30106043628`, https://github.com/thoth-pub/thoth/actions/runs/30106043628
-- `check-changelog`: `completed/success`, run `30106043479`, https://github.com/thoth-pub/thoth/actions/runs/30106043479
-- `publish-to-dockerhub`: `completed/success`, run `30106043646`, https://github.com/thoth-pub/thoth/actions/runs/30106043646
-- `run-migrations`: `completed/success`, run `30106043610`, https://github.com/thoth-pub/thoth/actions/runs/30106043610
+- `build-test-and-check`: `completed/success`, run `30110290679`, https://github.com/thoth-pub/thoth/actions/runs/30110290679
+- `check-changelog`: `completed/success`, run `30110290690`, https://github.com/thoth-pub/thoth/actions/runs/30110290690
+- `publish-to-dockerhub`: `completed/success`, run `30110290733`, https://github.com/thoth-pub/thoth/actions/runs/30110290733
+- `run-migrations`: `completed/success`, run `30110290632`, https://github.com/thoth-pub/thoth/actions/runs/30110290632
 
 The independent reviewer must also verify all required CI on the final
 report-containing review head.
@@ -317,6 +340,9 @@ report-containing review head.
 - ADR-0001 and ADR-0002 remain `PROPOSED`.
 - `thoth-sphinx` `main` and `develop` contain only a placeholder README; no
   workflow, protection or runtime evidence exists.
+- `metrics-dashboard` uses active `dev -> main`; stale `develop` requires
+  reconciliation under BR-DASH-01 before it can become the target development
+  branch.
 - Repository-relative control links were checked during the independent review.
 
 ## 10. Rollout and rollback
@@ -334,6 +360,8 @@ Monitoring: none for this documentation-only task.
 
 - ADR-0001 and ADR-0002 remain proposed.
 - Sphinx normalization and bootstrap are separate tasks.
+- Metrics Dashboard branch and Vercel normalization remains the separate
+  HIGH-risk BR-DASH-01 task.
 - Related repositories still require complete `AGENTS.md` rollout.
 - Client CI, Thoth Diesel generation and runtime operations remain incomplete or
   unverified as recorded in the control-gap register.

--- a/docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md
@@ -1,0 +1,349 @@
+# CTRL-FOUNDATION-01 Implementation Report
+
+Report status: COMPLETE FOR INDEPENDENT REVIEW
+Repository: `thoth-pub/thoth`
+Workflow: STANDARD
+Base branch: `develop`
+Base commit: `652a499dfdfbaa7594537e0865c41ec617f52dc2`
+PR target: `develop`
+Programme integration branch: None
+Task branch: `feature/ai-delivery-operating-model`
+Implementation and remediation head: `104ffaa16b2436cea2b4e2779c241b016916f083`
+Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
+Expected branch deletion after merge: YES
+Final programme PR required: NO
+Implementing model: GPT-5.6 Thinking control conversation with manual repository application
+Reasoning level: high
+
+The final review head is the report commit that contains this file. Git commits
+cannot embed their own hash. The independent reviewer must record the exact PR
+head and verify that the delta after `104ffaa16b2436cea2b4e2779c241b016916f083` contains only this
+report and the associated evidence-status updates.
+
+## 1. Scope confirmation
+
+Approved specification:
+
+`docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md`
+
+Implemented objective:
+
+Establish the repository-backed AI-led engineering operating model, repository
+orientation, local agent instructions, proposed cross-programme decisions,
+Publisher Services controls, Thoth Metrics controls, private design-reference
+metadata, and review/release gates.
+
+Out-of-scope changes made: NONE
+
+## 2. Commits through the remediation head
+
+- `2bc1c9e3436c87b9969b093b2af72ff2bd7a9d2a` - docs: add AI-led engineering delivery controls
+- `ce9d5a1fc22884b6acdcc7ec43d2b5edb38def2a` - Update changelog
+- `aba9333e1d52ab62c69c784ffb4856656a3a3de9` - Fix typo
+- `1a0cffa5b26668437acce67818031acb1330cb2b` - docs: add repository and environment map
+- `7365d67a322c7256b0bd040017442c763b87af5a` - docs: add repository-local agent instructions
+- `2ddf5113a72fcb3c200045f444b938bc5f6942f5` - docs: propose shared package and platform decisions
+- `deb041e90c50eb19457a5fc4c0d7f0c28bcb2351` - docs: add Publisher Services programme controls
+- `bd1046e7183c926c78bfffbd912e12e0902b63a4` - docs: add Thoth Metrics programme controls
+- `4b21cd2b580854affcdc3be9c7b53daf448c35e1` - docs: consolidate engineering control foundation
+- `fb38b2f5d85247d7d05ddf799dfe5191df2471e4` - docs: remove trailing whitespace from control documents
+- `ea687e88330aea3a9e44c69448c20b2d34422b3a` - docs: address foundation review blockers
+- `104ffaa16b2436cea2b4e2779c241b016916f083` - docs: correct foundation review evidence
+
+## 3. Actual files changed through the remediation head
+
+```text
+.github/workflows/AGENTS.md
+AGENTS.md
+CHANGELOG.md
+docs/engineering/AGENTS.md
+docs/engineering/README.md
+docs/engineering/agent-instructions/README.md
+docs/engineering/agent-instructions/rollout-plan.md
+docs/engineering/ai-delivery/README.md
+docs/engineering/ai-delivery/branching-and-release-workflow.md
+docs/engineering/ai-delivery/decision-record-template.md
+docs/engineering/ai-delivery/implementation-report-template.md
+docs/engineering/ai-delivery/independent-review-template.md
+docs/engineering/ai-delivery/model-selection.md
+docs/engineering/ai-delivery/operating-model.md
+docs/engineering/ai-delivery/release-gates.md
+docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
+docs/engineering/ai-delivery/risk-classification.md
+docs/engineering/ai-delivery/task-specification-template.md
+docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
+docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
+docs/engineering/decisions/README.md
+docs/engineering/decisions/decision-register.md
+docs/engineering/decisions/package-capability-matrix.md
+docs/engineering/design-references.md
+docs/engineering/repository-map/README.md
+docs/engineering/repository-map/branch-topology.md
+docs/engineering/repository-map/control-gaps.md
+docs/engineering/repository-map/environments.md
+docs/engineering/repository-map/repositories/cc-license.md
+docs/engineering/repository-map/repositories/metrics-dashboard.md
+docs/engineering/repository-map/repositories/metrics-widget.md
+docs/engineering/repository-map/repositories/thoth-app.md
+docs/engineering/repository-map/repositories/thoth-dissemination.md
+docs/engineering/repository-map/repositories/thoth-sphinx.md
+docs/engineering/repository-map/repositories/thoth.md
+docs/metrics/README.md
+docs/metrics/acceptance-matrix.md
+docs/metrics/contract-register.md
+docs/metrics/decisions.md
+docs/metrics/master-issue.md
+docs/metrics/migration-inventory.md
+docs/metrics/rollout-plan.md
+docs/metrics/source-inventory.md
+docs/metrics/task-status.md
+docs/publisher-services/README.md
+docs/publisher-services/acceptance-matrix.md
+docs/publisher-services/decisions.md
+docs/publisher-services/master-issue.md
+docs/publisher-services/platform-inventory.md
+docs/publisher-services/rollout-plan.md
+docs/publisher-services/task-status.md
+thoth-api-server/AGENTS.md
+thoth-api/AGENTS.md
+thoth-client/AGENTS.md
+thoth-errors/AGENTS.md
+thoth-export-server/AGENTS.md
+```
+
+Diff summary:
+
+```text
+.github/workflows/AGENTS.md                        | 108 +++++++
+ AGENTS.md                                          | 333 ++++++++++++++++++++
+ CHANGELOG.md                                       |   2 +
+ docs/engineering/AGENTS.md                         | 106 +++++++
+ docs/engineering/README.md                         |  94 ++++++
+ docs/engineering/agent-instructions/README.md      |  61 ++++
+ .../engineering/agent-instructions/rollout-plan.md |  67 ++++
+ docs/engineering/ai-delivery/README.md             |  61 ++++
+ .../ai-delivery/branching-and-release-workflow.md  | 250 +++++++++++++++
+ .../ai-delivery/decision-record-template.md        |  96 ++++++
+ .../ai-delivery/implementation-report-template.md  | 191 ++++++++++++
+ .../ai-delivery/independent-review-template.md     | 180 +++++++++++
+ docs/engineering/ai-delivery/model-selection.md    |  83 +++++
+ docs/engineering/ai-delivery/operating-model.md    | 248 +++++++++++++++
+ docs/engineering/ai-delivery/release-gates.md      | 149 +++++++++
+ .../reviews/CTRL-FOUNDATION-01-review-brief.md     | 126 ++++++++
+ .../engineering/ai-delivery/risk-classification.md | 112 +++++++
+ .../ai-delivery/task-specification-template.md     | 202 ++++++++++++
+ .../ai-delivery/tasks/CTRL-FOUNDATION-01.md        | 326 ++++++++++++++++++++
+ .../ADR-0001-publisher-package-capability-model.md | 339 +++++++++++++++++++++
+ .../ADR-0002-platform-domain-boundaries.md         | 298 ++++++++++++++++++
+ docs/engineering/decisions/README.md               |  64 ++++
+ docs/engineering/decisions/decision-register.md    |  37 +++
+ .../decisions/package-capability-matrix.md         | 157 ++++++++++
+ docs/engineering/design-references.md              |  41 +++
+ docs/engineering/repository-map/README.md          |  31 ++
+ docs/engineering/repository-map/branch-topology.md | 135 ++++++++
+ docs/engineering/repository-map/control-gaps.md    |  66 ++++
+ docs/engineering/repository-map/environments.md    |  97 ++++++
+ .../repository-map/repositories/cc-license.md      |  52 ++++
+ .../repositories/metrics-dashboard.md              |  75 +++++
+ .../repository-map/repositories/metrics-widget.md  |  64 ++++
+ .../repository-map/repositories/thoth-app.md       | 108 +++++++
+ .../repositories/thoth-dissemination.md            |  97 ++++++
+ .../repository-map/repositories/thoth-sphinx.md    |  92 ++++++
+ .../repository-map/repositories/thoth.md           | 152 +++++++++
+ docs/metrics/README.md                             | 131 ++++++++
+ docs/metrics/acceptance-matrix.md                  |  33 ++
+ docs/metrics/contract-register.md                  |  62 ++++
+ docs/metrics/decisions.md                          |  97 ++++++
+ docs/metrics/master-issue.md                       |  23 ++
+ docs/metrics/migration-inventory.md                |  50 +++
+ docs/metrics/rollout-plan.md                       |  57 ++++
+ docs/metrics/source-inventory.md                   |  79 +++++
+ docs/metrics/task-status.md                        |  59 ++++
+ docs/publisher-services/README.md                  | 119 ++++++++
+ docs/publisher-services/acceptance-matrix.md       | 104 +++++++
+ docs/publisher-services/decisions.md               | 148 +++++++++
+ docs/publisher-services/master-issue.md            |  21 ++
+ docs/publisher-services/platform-inventory.md      | 136 +++++++++
+ docs/publisher-services/rollout-plan.md            | 310 +++++++++++++++++++
+ docs/publisher-services/task-status.md             |  57 ++++
+ thoth-api-server/AGENTS.md                         |  72 +++++
+ thoth-api/AGENTS.md                                | 187 ++++++++++++
+ thoth-client/AGENTS.md                             |  60 ++++
+ thoth-errors/AGENTS.md                             |  39 +++
+ thoth-export-server/AGENTS.md                      |  77 +++++
+ 57 files changed, 6621 insertions(+)
+```
+
+All changed files are documentation, `AGENTS.md` instruction files, or the
+changelog. No Rust, SQL, migration, package manifest, workflow YAML, deployment
+configuration, generated contract, runtime configuration, or secret changed.
+
+## 4. Material effects
+
+- `AGENTS.md` and scoped instruction files define agent permissions and stop
+  conditions; they do not change runtime behaviour.
+- `docs/engineering/ai-delivery/**` defines task, review, branching, risk and
+  release controls.
+- `docs/engineering/repository-map/**` records verified repository state and
+  explicit gaps.
+- `docs/engineering/design-references.md` records private Google Drive file and
+  revision metadata without publishing either design body.
+- `docs/publisher-services/**` records the direct one-task/one-branch/one-PR
+  workflow and programme gates.
+- `docs/metrics/**` records repository-local Metrics integration branches after
+  readiness and the Metrics programme gates.
+- `docs/engineering/decisions/**` proposes ADR-0001 and ADR-0002 without
+  approving them.
+- `CHANGELOG.md` records PR #764 under Unreleased.
+
+Behavioural effect: documentation and engineering-control evidence only.
+
+## 5. Implementation decisions
+
+1. Keep the private programme specifications in access-controlled Google Drive.
+2. Record exact Drive file IDs, revision IDs and modification timestamps in the
+   repository.
+3. Use direct task branches for Publisher Services.
+4. Use repository-local integration branches for Metrics only after readiness.
+5. Keep ADR-0001 and ADR-0002 `PROPOSED` pending separate approval.
+6. Describe `thoth-sphinx` as placeholder-only: `main` and `develop` contain a
+   README, but no workspace, implementation, CI, protections or runtime.
+7. Store completed implementation reports under `implementation-reports/`,
+   avoiding the repository's broad ignored `reports/` pattern.
+
+Deviation from the approved specification: NONE after review remediation.
+
+## 6. Database, API, authorization and compatibility effects
+
+Migration added: NO
+Database or existing-data effect: none
+Locking/downtime: none
+GraphQL/API changes: none
+Generated schema/client changes: none
+Authorization paths changed: none
+Roles/scopes changed: none
+Secrets or personal data added: none
+Backwards compatibility: unaffected
+
+## 7. Exact checks and results
+
+### Diff whitespace
+
+Command:
+
+```text
+git diff --check 652a499dfdfbaa7594537e0865c41ec617f52dc2...104ffaa16b2436cea2b4e2779c241b016916f083
+```
+
+Result: no output; PASS.
+
+### Stale control references
+
+Command:
+
+```text
+grep -RniE '(^|[^[:alnum:]_-])CTRL-(01|02)([^[:digit:]]|$)|CG-(05|06|09)|NOT YET CREATE[D]' docs || true
+```
+
+Result: no output; PASS.
+
+### Canonical Sphinx spelling
+
+Command:
+
+```text
+grep -Rni 'sph[y]nx' AGENTS.md .github thoth-* docs || true
+```
+
+Result: no output; PASS.
+
+### Sphinx repository-state wording
+
+Command:
+
+```text
+grep -RniE 'thoth-sphinx.*empty|Sphinx.*empty|repository empty|empty repository' docs/engineering docs/metrics || true
+```
+
+Result: no output; PASS.
+
+### Repository scope
+
+Command:
+
+```text
+git diff --name-only 652a499dfdfbaa7594537e0865c41ec617f52dc2...104ffaa16b2436cea2b4e2779c241b016916f083
+```
+
+Result: only the files recorded in section 3; PASS.
+
+### Unit and integration tests
+
+No executable behaviour or migration was changed. Existing build, tests, lint,
+formatting and migrations were exercised by current-head GitHub Actions.
+
+## 8. CI at the implementation/remediation head
+
+All required workflows completed successfully for `104ffaa16b2436cea2b4e2779c241b016916f083`:
+
+- `build-test-and-check`: `completed/success`, run `30106043628`, https://github.com/thoth-pub/thoth/actions/runs/30106043628
+- `check-changelog`: `completed/success`, run `30106043479`, https://github.com/thoth-pub/thoth/actions/runs/30106043479
+- `publish-to-dockerhub`: `completed/success`, run `30106043646`, https://github.com/thoth-pub/thoth/actions/runs/30106043646
+- `run-migrations`: `completed/success`, run `30106043610`, https://github.com/thoth-pub/thoth/actions/runs/30106043610
+
+The independent reviewer must also verify all required CI on the final
+report-containing review head.
+
+## 9. Manual verification
+
+- Both private Google Docs were identified by exact file ID and Drive revision.
+- No private design body or export is committed.
+- Issues #765 and #766 exist.
+- ADR-0001 and ADR-0002 remain `PROPOSED`.
+- `thoth-sphinx` `main` and `develop` contain only a placeholder README; no
+  workflow, protection or runtime evidence exists.
+- Repository-relative control links were checked during the independent review.
+
+## 10. Rollout and rollback
+
+Initial state after merge: the documentation becomes authoritative on
+`develop`; programme implementation remains blocked by each recorded gate.
+
+Activation required: no runtime activation.
+Feature flag/configuration: none.
+Migration sequence: none.
+Rollback: revert PR #764.
+Monitoring: none for this documentation-only task.
+
+## 11. Known limitations and deferred work
+
+- ADR-0001 and ADR-0002 remain proposed.
+- Sphinx normalization and bootstrap are separate tasks.
+- Related repositories still require complete `AGENTS.md` rollout.
+- Client CI, Thoth Diesel generation and runtime operations remain incomplete or
+  unverified as recorded in the control-gap register.
+- Metrics source fixtures, COUNTER mappings, service-role codes and complete
+  OPERAS inbound discovery remain programme dependencies.
+- The private Metrics design retains an obsolete spelling; committed repository
+  documents use the canonical `thoth-sphinx` / `Sphinx` terminology.
+
+## 12. Unresolved review gates
+
+- final-head CI after committing this report;
+- independent complete-diff review at the exact final head;
+- final independent decision `APPROVED`;
+- explicit CTO merge approval.
+
+## 13. Agent self-assessment
+
+Suggested review focus:
+
+- report presence and exact evidence;
+- final-head CI and head stability;
+- private design access and revision metadata;
+- Publisher Services versus Metrics branch workflow distinction;
+- placeholder-only Sphinx state;
+- absence of runtime, migration, workflow or deployment effects.
+
+The implementing conversation does not approve this task.

--- a/docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md
@@ -238,15 +238,29 @@ git diff --check 652a499dfdfbaa7594537e0865c41ec617f52dc2...104ffaa16b2436cea2b4
 
 Result: no output; PASS.
 
-### Stale control references
+### Stale task and placeholder references
 
 Command:
 
 ```text
-grep -RniE '(^|[^[:alnum:]_-])CTRL-(01|02)([^[:digit:]]|$)|CG-(05|06|09)|NOT YET CREATE[D]' docs || true
+grep -RniE '(^|[^[:alnum:]_-])CTRL-(01|02)([^[:digit:]]|$)|NOT YET CREATE[D]' docs || true
 ```
 
 Result: no output; PASS.
+
+### Stale control references in repository-map consumers
+
+Command:
+
+```text
+grep -RniE 'CG-(05|06|09)'   docs/engineering/repository-map/environments.md   docs/engineering/repository-map/repositories   || true
+```
+
+Result: no output; PASS.
+
+The canonical definitions of `CG-05`, `CG-06`, and `CG-09` in
+`docs/engineering/repository-map/control-gaps.md` are expected and are not
+stale references.
 
 ### Canonical Sphinx spelling
 

--- a/docs/engineering/ai-delivery/independent-review-template.md
+++ b/docs/engineering/ai-delivery/independent-review-template.md
@@ -1,0 +1,180 @@
+# Independent Review Template
+
+Review the actual diff and evidence. Do not approve from the implementation report alone.
+
+# [TASK-ID] Independent Review
+
+Reviewer model:  
+Reasoning level:  
+Reviewed commit:  
+Pull request:  
+Specification:
+
+## 1. Decision
+
+APPROVED | CHANGES REQUIRED | BLOCKED
+
+## 2. Scope and specification coverage
+
+- Does the diff implement every in-scope requirement?
+- Are any non-goals implemented?
+- Are any acceptance criteria unsupported by evidence?
+- Does the implementation silently change architecture?
+
+Findings:
+
+[...]
+
+## 3. Correctness
+
+Assess:
+
+- normal success paths;
+- failure paths;
+- boundary conditions;
+- state transitions;
+- error handling;
+- pagination and ordering where relevant;
+- partial failure;
+- restart/retry behaviour.
+
+Findings:
+
+[...]
+
+## 4. Data and migration safety
+
+Assess:
+
+- empty and populated database behaviour;
+- constraints;
+- defaults and nullability;
+- backfill effects;
+- locks and downtime;
+- idempotency;
+- rollback or forward repair;
+- accidental side effects.
+
+Findings:
+
+[...]
+
+## 5. Authorization and security
+
+Assess:
+
+- positive and negative authorization;
+- tenant/publisher isolation;
+- machine-role scope;
+- secrets and logs;
+- untrusted input;
+- personal data;
+- fail-open or scope-broadening behaviour.
+
+Findings:
+
+[...]
+
+## 6. Concurrency and idempotency
+
+Assess:
+
+- races;
+- duplicate processing;
+- leases/claim tokens;
+- stale workers;
+- retry safety;
+- uniqueness enforcement;
+- transaction boundaries.
+
+Findings:
+
+[...]
+
+## 7. API and compatibility
+
+Assess:
+
+- backwards compatibility;
+- GraphQL/schema changes;
+- generated clients;
+- cross-repository consumers;
+- error-contract changes;
+- rollout ordering.
+
+Findings:
+
+[...]
+
+## 8. Tests and CI
+
+Assess whether tests prove the required behaviour rather than merely execute code.
+
+Missing or weak evidence:
+
+[...]
+
+CI status and relevant checks:
+
+[...]
+
+## 9. Operations
+
+Assess:
+
+- initial post-merge state;
+- feature flags;
+- monitoring;
+- alerting;
+- runbooks;
+- rollback;
+- pilot and observation;
+- external side effects.
+
+Findings:
+
+[...]
+
+## 10. Findings
+
+Classify each finding.
+
+### P0 - Critical
+
+[Data loss, security breach, catastrophic side effect, invalid architecture.]
+
+### P1 - Blocking
+
+[Incorrect behaviour, missing acceptance criterion, unsafe migration, authorization defect, race, serious regression.]
+
+### P2 - Non-blocking but required follow-up
+
+[Maintainability, diagnostics, incomplete non-critical tests, operational improvement.]
+
+### P3 - Optional
+
+[Polish or future enhancement.]
+
+For every P0/P1 finding include:
+
+- location;
+- evidence;
+- impact;
+- required correction;
+- required test.
+
+## 11. Acceptance criteria matrix
+
+- [ ] Criterion 1 - PASS/FAIL - evidence
+- [ ] Criterion 2 - PASS/FAIL - evidence
+- [...]
+
+## 12. Final rationale
+
+Explain why the decision is justified.
+
+If `APPROVED`, explicitly state that no unresolved P0 or P1 findings remain.
+
+If `CHANGES REQUIRED`, list the exact blocking corrections.
+
+If `BLOCKED`, identify the missing decision, dependency or unsafe premise.

--- a/docs/engineering/ai-delivery/independent-review-template.md
+++ b/docs/engineering/ai-delivery/independent-review-template.md
@@ -4,10 +4,10 @@ Review the actual diff and evidence. Do not approve from the implementation repo
 
 # [TASK-ID] Independent Review
 
-Reviewer model:  
-Reasoning level:  
-Reviewed commit:  
-Pull request:  
+Reviewer model:
+Reasoning level:
+Reviewed commit:
+Pull request:
 Specification:
 
 ## 1. Decision

--- a/docs/engineering/ai-delivery/model-selection.md
+++ b/docs/engineering/ai-delivery/model-selection.md
@@ -1,0 +1,83 @@
+# Model and Reasoning Selection
+
+Model names evolve. Use this document as a selection policy, and record the exact model/version used in each task report.
+
+## 1. Architecture and scoping
+
+Use the strongest available general reasoning model.
+
+Recommended reasoning:
+
+- Medium: low-risk documentation or mechanical task decomposition.
+- High: normal backend/API design and multi-file task scoping.
+- Maximum: canonical data semantics, concurrency, migrations, authorization, cross-programme architecture or production cutover.
+
+The scoping model should not implement the task it later approves.
+
+## 2. Implementation
+
+Default:
+
+- strongest available Codex coding model;
+- high reasoning.
+
+Use maximum practical reasoning for:
+
+- database migrations;
+- transaction boundaries;
+- concurrency, claims and leases;
+- authorization;
+- idempotency and deduplication;
+- metrics identity, revisions and rollups;
+- production migration utilities;
+- external deposit or synchronization logic;
+- cross-repository schema contracts;
+- unexplained production defects.
+
+Medium reasoning is acceptable only for contained low-risk changes with strong existing patterns and tests.
+
+## 3. Independent review
+
+Prefer a different model family from the implementer.
+
+Example policy:
+
+- Codex implements -> strongest available Claude model reviews.
+- Claude implements -> strongest available Codex model reviews.
+
+Use high or maximum reasoning for high-risk tasks.
+
+The independent reviewer should initially receive:
+
+- the approved task specification;
+- the PR diff;
+- relevant design/ADRs;
+- test and CI evidence;
+- migration and rollout information.
+
+Do not bias the first review with the implementer's narrative justification unless required to understand an explicit deviation.
+
+## 4. Dual review
+
+Require two independent reviews for critical tasks involving:
+
+- destructive migration;
+- canonical historical recomputation;
+- mass redistribution;
+- broad authorization changes;
+- source-of-truth cutover;
+- production secrets or identity-provider configuration.
+
+At least one reviewer must be from a different model family than the implementer.
+
+## 5. Record keeping
+
+Every task specification and implementation report records:
+
+- model name;
+- model version where visible;
+- reasoning level;
+- role: scope, implementation or review;
+- material limitations encountered.
+
+Do not infer quality from model choice alone. Approval depends on evidence.

--- a/docs/engineering/ai-delivery/operating-model.md
+++ b/docs/engineering/ai-delivery/operating-model.md
@@ -1,0 +1,248 @@
+# AI-led Engineering Operating Model
+
+Status: Proposed until merged and approved  
+Owner: CTO
+
+## 1. Purpose
+
+This operating model allows AI agents to perform architecture support, implementation, testing and review while preserving human accountability, independent approval and production safety.
+
+## 2. Roles
+
+### 2.1 CTO
+
+The CTO owns:
+
+- programme priority;
+- product and business decisions;
+- architecture approval;
+- risk acceptance;
+- exceptions to this process;
+- merge approval for high-risk work;
+- production activation approval.
+
+The CTO is not expected to reproduce every test or manually inspect every line. The CTO must ensure that sufficient independent evidence exists.
+
+### 2.2 Control conversation or coordinating architect
+
+The control role:
+
+- identifies programme, repository, task ID, base branch, dependencies and risk;
+- verifies an approved written specification exists;
+- scopes one bounded task;
+- recommends implementation model and reasoning level;
+- reviews actual diffs, tests, CI and operational effects;
+- consolidates independent review;
+- returns `APPROVED`, `CHANGES REQUIRED` or `BLOCKED`;
+- escalates architecture conflicts to the CTO.
+
+The control role may not treat conversational memory as more authoritative than repository evidence.
+
+### 2.3 Programme conversation
+
+A programme conversation:
+
+- maintains programme-local context;
+- decomposes the approved design into bounded tasks;
+- prepares task specifications and prompts;
+- analyses implementation reports;
+- identifies programme dependencies and risks;
+- updates the programme status recommendation.
+
+It may not settle a cross-programme architectural conflict independently.
+
+### 2.4 Implementing agent
+
+An implementing agent may:
+
+- inspect repositories;
+- create a task branch;
+- edit code and documentation;
+- add or update tests;
+- run local checks;
+- commit changes;
+- push a branch;
+- open or update a draft pull request.
+
+An implementing agent may not:
+
+- merge its own pull request;
+- deploy or activate production behaviour;
+- access production secrets;
+- perform destructive production operations;
+- silently change approved architecture;
+- approve its own work;
+- broaden task scope without an approved specification change.
+
+### 2.5 Independent reviewer
+
+The independent reviewer:
+
+- reviews the approved task specification;
+- inspects the actual diff;
+- inspects test and CI evidence;
+- assesses migrations, authorization, compatibility and operations;
+- identifies missing acceptance evidence;
+- classifies findings by severity;
+- returns `APPROVED`, `CHANGES REQUIRED` or `BLOCKED`.
+
+The reviewer must not be the same agent instance that implemented the task.
+
+## 3. Source of truth
+
+The authority order is:
+
+1. Merged code and migrations.
+2. Approved ADRs and technical designs.
+3. Approved task specifications.
+4. GitHub issues, PRs, review threads and CI.
+5. Programme status and rollout documents.
+6. Agent reports and conversations.
+
+When authoritative sources conflict, implementation stops until the conflict is resolved and recorded.
+
+## 4. Mandatory task and branch boundary
+
+Use one bounded task per slice branch and pull request.
+
+Follow `branching-and-release-workflow.md`.
+
+Normal tasks branch from `develop` and target `develop`.
+
+For an approved large programme, create `feature/<programme>` from `develop`; each bounded slice branches from and targets that programme integration branch. The final approved programme pull request targets `develop`.
+
+A bounded task has:
+
+- one principal objective;
+- explicit scope;
+- explicit non-goals;
+- identified dependencies;
+- acceptance criteria that can be independently verified;
+- a defined merge and release effect.
+
+A programme integration branch is permitted only under the controlled large-programme workflow. It does not replace bounded slice branches, task specifications or independent review.
+
+Prefer additive, backwards-compatible and initially inactive changes that can merge directly into `develop` safely. Use an integration branch only when the programme genuinely requires integrated validation before entering `develop`.
+
+## 5. Task lifecycle
+
+### Gate 0 - Design ready
+
+Implementation may be scoped only when:
+
+- required product decisions are settled;
+- architecture is approved or the task is explicitly discovery-only;
+- dependencies are known;
+- blocking unknowns are resolved or declared stop conditions.
+
+### Gate 1 - Specification approved
+
+The task specification must be committed or attached to an authoritative GitHub issue.
+
+The specification must use `task-specification-template.md` or contain equivalent information.
+
+### Gate 2 - Implementation
+
+The implementing agent:
+
+1. confirms repository, base branch and base commit;
+2. creates a fresh task branch from the approved base (`develop` or the programme integration branch);
+3. inspects relevant code before editing;
+4. implements only the approved scope;
+5. adds required tests;
+6. runs the specified checks;
+7. opens or updates a draft PR;
+8. completes the implementation report.
+
+### Gate 3 - Evidence complete
+
+Implementation cannot enter review until:
+
+- the PR is available;
+- the actual diff is reviewable;
+- required tests have exact results;
+- migration effects are documented;
+- deviations and limitations are explicit;
+- CI evidence is available or its absence is explained.
+
+### Gate 4 - Independent review
+
+The independent reviewer applies `independent-review-template.md`.
+
+Narrative claims do not replace inspection of code, migrations and test evidence.
+
+### Gate 5 - Remediation
+
+Accepted findings are returned to the original implementing branch as a targeted remediation task.
+
+The implementing agent must:
+
+- address findings;
+- rerun relevant tests;
+- update the implementation report;
+- avoid unrelated refactoring.
+
+The reviewer verifies the changed diff and may raise new findings.
+
+### Gate 6 - Merge ready
+
+See `release-gates.md`.
+
+### Gate 7 - Production ready
+
+See `release-gates.md`.
+
+### Gate 8 - Closed
+
+A task closes only after:
+
+- required observation is complete;
+- unexpected behaviour is reconciled;
+- cleanup or follow-up tasks are recorded;
+- programme status is updated.
+
+## 6. Review decisions
+
+Use exactly one decision:
+
+### APPROVED
+
+All blocking requirements and evidence are satisfied. No unresolved P0 or P1 findings remain.
+
+### CHANGES REQUIRED
+
+The task is viable but has unresolved blocking defects, missing evidence or incomplete acceptance criteria.
+
+### BLOCKED
+
+Implementation cannot safely continue because of an unresolved design decision, dependency, repository conflict, missing environment, unsafe approach or invalid premise.
+
+## 7. Parallel work
+
+Parallel tasks are permitted only when:
+
+- their write surfaces do not conflict; or
+- a stable shared contract already exists;
+- dependencies are explicit;
+- merge order is known;
+- each task has an independent branch and PR.
+
+Do not run competing agents on alternative implementations of the same approved task unless the task is explicitly a time-boxed design spike.
+
+## 8. Production safety defaults
+
+Prefer:
+
+- additive schema;
+- inactive code paths;
+- feature flags;
+- comparison or shadow mode;
+- bounded pilots;
+- explicit service roles;
+- idempotent migrations;
+- fail-closed behaviour;
+- monitoring before activation;
+- documented rollback;
+- observation before cleanup.
+
+High-risk production activation requires explicit CTO approval.

--- a/docs/engineering/ai-delivery/operating-model.md
+++ b/docs/engineering/ai-delivery/operating-model.md
@@ -1,6 +1,6 @@
 # AI-led Engineering Operating Model
 
-Status: Proposed until merged and approved  
+Status: Proposed until merged and approved
 Owner: CTO
 
 ## 1. Purpose

--- a/docs/engineering/ai-delivery/release-gates.md
+++ b/docs/engineering/ai-delivery/release-gates.md
@@ -1,0 +1,149 @@
+# Merge and Release Gates
+
+PR approval, merge readiness, programme-integration readiness and production readiness are distinct states.
+
+Branching and releases must follow `branching-and-release-workflow.md`.
+
+## 1. Merge-ready gate
+
+A task is merge ready only when:
+
+- the task specification is approved;
+- the diff matches the approved scope;
+- all acceptance criteria have evidence;
+- no unresolved P0 or P1 review findings remain;
+- required unit, integration, database and authorization tests pass;
+- CI is green;
+- migrations are verified as required;
+- generated schemas and clients are current;
+- compatibility is assessed;
+- documentation and programme status are updated;
+- rollout and rollback are documented;
+- no unrelated changes are present.
+
+High-risk tasks require explicit CTO merge approval.
+
+For a slice targeting `feature/<programme>`, this gate approves only the slice merge into the programme integration branch. It does not approve the final programme merge into `develop` or production activation.
+
+
+## 2. Programme integration gate
+
+Before opening or approving `feature/<programme> -> develop`:
+
+- every included slice PR is approved and merged;
+- all slice branches are deleted;
+- the programme integration branch is updated with the current `develop`;
+- integrated CI is green;
+- migrations apply in the final order;
+- cross-slice and cross-repository contracts are verified;
+- programme-wide acceptance criteria have evidence;
+- temporary bypasses, mocks and feature-only schema inconsistencies are removed;
+- rollout and rollback cover the integrated feature;
+- an independent reviewer assesses the complete integration diff against `develop`.
+
+The final programme PR decision is `APPROVED`, `CHANGES REQUIRED` or `BLOCKED`.
+
+## 3. Safe post-merge state
+
+Prefer merged changes to be:
+
+- additive;
+- backwards compatible;
+- disabled by default;
+- unused by existing production paths;
+- safe before downstream repositories deploy.
+
+If merge itself changes production behaviour, the task must also satisfy the production-ready gate before merge.
+
+## 4. Staging/preview gate
+
+Before production activation:
+
+- deploy the exact candidate commit;
+- run required migrations in a production-like environment;
+- verify authorization with allowed and denied actors;
+- exercise failure and retry paths;
+- verify monitoring and logs;
+- verify rollback or disable procedures;
+- capture evidence in the release issue or PR.
+
+## 5. Production-ready gate
+
+Production activation requires:
+
+- staging/preview acceptance;
+- approved migration plan;
+- feature flag or controlled configuration where practical;
+- named pilot or bounded activation scope;
+- monitoring and alert thresholds;
+- runbook;
+- rollback/kill switch;
+- explicit activation owner;
+- observation period;
+- CTO approval for high or critical risk.
+
+## 6. Comparison-mode gate
+
+When replacing an existing source of truth or operational configuration:
+
+- run old and new paths in comparison/shadow mode;
+- define expected equivalence and permitted divergence;
+- produce a difference report;
+- resolve unexplained differences;
+- fail closed on new-source errors;
+- preserve the old path through the observation window.
+
+Do not cut over solely because the new path executes successfully.
+
+## 7. Migration gate
+
+For backfills or canonical-data migration:
+
+- dry run first;
+- record expected row/object counts;
+- validate a representative sample;
+- verify rerun behaviour;
+- verify no unintended external side effects;
+- snapshot or back up irreducible state;
+- define abort thresholds;
+- define rollback or forward-repair procedure;
+- require explicit execution approval.
+
+## 8. Observation gate
+
+During observation:
+
+- monitor correctness, errors, latency and backlog;
+- compare expected and observed counts;
+- keep rollback available;
+- record incidents and divergence;
+- do not remove compatibility paths.
+
+The observation period ends only with an explicit sign-off.
+
+## 9. Closure gate
+
+A task closes when:
+
+- observation is complete;
+- acceptance remains valid in production;
+- cleanup tasks are created or completed;
+- temporary flags and compatibility paths have owners and deadlines;
+- programme status is current;
+- operational ownership is documented.
+
+
+## 10. Release branch gate
+
+The production release path is `develop -> master`.
+
+Before merging or releasing `develop` into `master`:
+
+- identify all included task and programme PRs;
+- confirm `develop` is green at the selected commit;
+- review all migrations and required deployment ordering;
+- prepare release notes;
+- confirm feature flags and post-deploy activation;
+- confirm rollback and restore procedures;
+- obtain required CTO approval;
+- record the resulting release/tag and production observation owner.

--- a/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
+++ b/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
@@ -1,0 +1,54 @@
+# Independent Review Brief - CTRL-FOUNDATION-01
+
+Review status: READY AFTER FINAL CONSOLIDATION COMMIT  
+Task: `CTRL-FOUNDATION-01`  
+Repository: `thoth-pub/thoth`  
+Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)  
+Base: `develop` at `652a499dfdfbaa7594537e0865c41ec617f52dc2`  
+Risk: LOW, documentation-only  
+Production effect: None
+
+## Reviewer independence
+
+The reviewer must not be the ChatGPT conversation that authored these documents. Use a separate Codex or Claude instance at high reasoning.
+
+## Required inputs
+
+PR #764 final head/diff/CI; CTRL-FOUNDATION-01; approved Publisher Services and Metrics designs; repository map; ADR-0001/0002; issues #765/#766.
+
+## Review objectives
+
+Verify authority, task/review/release controls, proposed-decision status, programme separation, repository accuracy, canonical naming, agent safety, no production effects, complete trackers/issues and explicit blockers.
+
+## Required commands
+
+```bash
+git diff --check
+grep -Rni "sphynx" AGENTS.md .github thoth-* docs || true
+grep -Rni "NOT YET CREATED" docs || true
+git diff --name-only 652a499dfdfbaa7594537e0865c41ec617f52dc2...HEAD
+git diff --stat 652a499dfdfbaa7594537e0865c41ec617f52dc2...HEAD
+```
+
+Confirm only CHANGELOG, AGENTS documentation and docs changed; no workflow behavior, Rust, SQL, migration, package or deployment files changed; CI green; master issues exist; ADRs remain proposed; acceptance checkboxes match evidence.
+
+## Red-team questions
+
+1. Could any document be read as permission to merge/deploy/access secrets?
+2. Do task/PR rules conflict with programme branches?
+3. Are missing normalized branches assumed?
+4. Are package business decisions silently settled?
+5. Is OPERAS inbound completeness overstated?
+6. Is the Publisher Services inventory presented as approved?
+7. Are package and platform assignments independent?
+8. Are distribution and metrics platforms separate?
+9. Are missing CI/deployment/schema-generation controls explicit?
+10. Are links valid after merge?
+
+## Decision format
+
+Return exactly one: `APPROVED`, `CHANGES REQUIRED`, or `BLOCKED`.
+
+For each finding provide severity, file/line, requirement, evidence and required change.
+
+Approval requires no unresolved P0/P1, complete evidence, green final CI and no unreviewed head movement. The reviewer must not merge.

--- a/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
+++ b/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
@@ -1,6 +1,6 @@
 # Independent Review Brief - CTRL-FOUNDATION-01
 
-Review status: READY AFTER FINAL CONSOLIDATION COMMIT
+Review status: READY AFTER REVIEW-BLOCKER REMEDIATION
 Task: `CTRL-FOUNDATION-01`
 Repository: `thoth-pub/thoth`
 Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
@@ -14,41 +14,113 @@ The reviewer must not be the ChatGPT conversation that authored these documents.
 
 ## Required inputs
 
-PR #764 final head/diff/CI; CTRL-FOUNDATION-01; approved Publisher Services and Metrics designs; repository map; ADR-0001/0002; issues #765/#766.
+Review the versions at the exact PR head:
+
+1. [`../tasks/CTRL-FOUNDATION-01.md`](../tasks/CTRL-FOUNDATION-01.md)
+2. [`../reports/CTRL-FOUNDATION-01-implementation-report.md`](../reports/CTRL-FOUNDATION-01-implementation-report.md)
+3. [Private Publisher Services design](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit), Drive revision `3`
+4. [Private Thoth Metrics design](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit), Drive revision `6`
+5. [`../../design-references.md`](../../design-references.md)
+6. repository/environment map;
+7. ADR-0001 and ADR-0002;
+8. issues #765 and #766;
+9. complete PR diff and current-head CI.
+
+The reviewer must have explicit Google Drive access to both private designs.
+The repository intentionally does not contain their contents.
 
 ## Review objectives
 
-Verify authority, task/review/release controls, proposed-decision status, programme separation, repository accuracy, canonical naming, agent safety, no production effects, complete trackers/issues and explicit blockers.
+Verify:
+
+- approved task specification completeness;
+- implementation-report evidence;
+- fidelity to both private approved designs at the recorded Drive revisions;
+- authority, task, review and release controls;
+- proposed-decision status;
+- Publisher Services direct task-branch workflow;
+- Metrics repository-local integration workflow;
+- live repository/branch accuracy;
+- canonical naming and the recorded private-source spelling discrepancy;
+- agent safety and no production effects;
+- complete trackers/issues and explicit blockers;
+- valid control identifiers and links.
 
 ## Required commands
 
 ```bash
-git diff --check
-grep -Rni "sphynx" AGENTS.md .github thoth-* docs || true
-grep -Rni "NOT YET CREATED" docs || true
-git diff --name-only 652a499dfdfbaa7594537e0865c41ec617f52dc2...HEAD
-git diff --stat 652a499dfdfbaa7594537e0865c41ec617f52dc2...HEAD
+base=652a499dfdfbaa7594537e0865c41ec617f52dc2
+
+git diff --check "$base"...HEAD
+
+git diff --name-only "$base"...HEAD
+
+git diff --stat "$base"...HEAD
+
+grep -RniE \
+  '(^|[^[:alnum:]_-])CTRL-(01|02)([^[:digit:]]|$)' \
+  docs \
+  || true
+
+grep -RniE \
+  'CG-(05|06|09)' \
+  docs/engineering/repository-map/environments.md \
+  docs/engineering/repository-map/repositories \
+  || true
+
+grep -Rni 'Publisher Services integration bran[c]h' docs || true
+
+grep -Rni 'NOT YET CREATE[D]' docs || true
+
+grep -Rni 'sph[y]nx' AGENTS.md .github thoth-* docs || true
 ```
 
-Confirm only CHANGELOG, AGENTS documentation and docs changed; no workflow behavior, Rust, SQL, migration, package or deployment files changed; CI green; master issues exist; ADRs remain proposed; acceptance checkboxes match evidence.
+Confirm:
+
+- only `CHANGELOG.md`, AGENTS instruction files and `docs/**` changed;
+- no workflow behaviour, Rust, SQL, migration, package or deployment files changed;
+- all current-head required CI is green;
+- both private design file IDs, revision IDs and modification times match `design-references.md`;
+- master issues exist and link to the exact reviewed commit;
+- ADRs remain proposed;
+- acceptance checkboxes match evidence;
+- no unreviewed head movement occurs after evidence capture.
 
 ## Red-team questions
 
-1. Could any document be read as permission to merge/deploy/access secrets?
-2. Do task/PR rules conflict with programme branches?
-3. Are missing normalized branches assumed?
-4. Are package business decisions silently settled?
-5. Is OPERAS inbound completeness overstated?
-6. Is the Publisher Services inventory presented as approved?
-7. Are package and platform assignments independent?
-8. Are distribution and metrics platforms separate?
-9. Are missing CI/deployment/schema-generation controls explicit?
-10. Are links valid after merge?
+1. Could any document be read as permission to merge, deploy or access secrets?
+2. Is the task specification actually approved and complete?
+3. Does the implementation report contain exact evidence rather than narrative claims?
+4. Does Publisher Services incorrectly use a programme integration branch?
+5. Does Metrics correctly use repository-local integration branches only after readiness?
+6. Are missing or normalized branches accurately represented?
+7. Are package business decisions silently settled?
+8. Is OPERAS inbound completeness overstated?
+9. Is the Publisher Services inventory presented as approved?
+10. Are package and platform assignments independent?
+11. Are distribution and metrics platforms separate?
+12. Are missing CI, deployment and schema-generation controls explicit?
+13. Are the private design revision records exact, and does the reviewer have authorized access?
+14. Are all links valid at the exact review head and after merge?
 
 ## Decision format
 
-Return exactly one: `APPROVED`, `CHANGES REQUIRED`, or `BLOCKED`.
+Return exactly one:
 
-For each finding provide severity, file/line, requirement, evidence and required change.
+```text
+APPROVED
+CHANGES REQUIRED
+BLOCKED
+```
 
-Approval requires no unresolved P0/P1, complete evidence, green final CI and no unreviewed head movement. The reviewer must not merge.
+For every finding provide:
+
+```text
+Severity:
+File and line:
+Requirement:
+Evidence:
+Required change:
+```
+
+Approval requires no unresolved P0/P1 findings, complete specification/report evidence, passing required commands, green final CI and no unreviewed head movement. The reviewer must not merge the PR.

--- a/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
+++ b/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
@@ -1,11 +1,11 @@
 # Independent Review Brief - CTRL-FOUNDATION-01
 
-Review status: READY AFTER FINAL CONSOLIDATION COMMIT  
-Task: `CTRL-FOUNDATION-01`  
-Repository: `thoth-pub/thoth`  
-Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)  
-Base: `develop` at `652a499dfdfbaa7594537e0865c41ec617f52dc2`  
-Risk: LOW, documentation-only  
+Review status: READY AFTER FINAL CONSOLIDATION COMMIT
+Task: `CTRL-FOUNDATION-01`
+Repository: `thoth-pub/thoth`
+Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
+Base: `develop` at `652a499dfdfbaa7594537e0865c41ec617f52dc2`
+Risk: LOW, documentation-only
 Production effect: None
 
 ## Reviewer independence

--- a/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
+++ b/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
@@ -17,7 +17,7 @@ The reviewer must not be the ChatGPT conversation that authored these documents.
 Review the versions at the exact PR head:
 
 1. [`../tasks/CTRL-FOUNDATION-01.md`](../tasks/CTRL-FOUNDATION-01.md)
-2. [`../reports/CTRL-FOUNDATION-01-implementation-report.md`](../reports/CTRL-FOUNDATION-01-implementation-report.md)
+2. [`../implementation-reports/CTRL-FOUNDATION-01-implementation-report.md`](../implementation-reports/CTRL-FOUNDATION-01-implementation-report.md)
 3. [Private Publisher Services design](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit), Drive revision `3`
 4. [Private Thoth Metrics design](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit), Drive revision `6`
 5. [`../../design-references.md`](../../design-references.md)

--- a/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
+++ b/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md
@@ -1,6 +1,6 @@
 # Independent Review Brief - CTRL-FOUNDATION-01
 
-Review status: READY AFTER REVIEW-BLOCKER REMEDIATION
+Review status: READY FOR FRESH INDEPENDENT REVIEW
 Task: `CTRL-FOUNDATION-01`
 Repository: `thoth-pub/thoth`
 Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)

--- a/docs/engineering/ai-delivery/risk-classification.md
+++ b/docs/engineering/ai-delivery/risk-classification.md
@@ -1,0 +1,112 @@
+# Engineering Task Risk Classification
+
+Classify every task before selecting an implementation model or approving execution.
+
+Use the highest applicable risk level.
+
+## Low risk
+
+Typical characteristics:
+
+- documentation-only changes;
+- test-only additions;
+- local refactors with no behaviour change;
+- generated-code refresh from an unchanged contract;
+- isolated UI copy or styling;
+- no authorization, migration, data or operational effect.
+
+Required controls:
+
+- approved task scope;
+- focused branch and PR;
+- standard tests and CI;
+- independent review may be lightweight.
+
+## Medium risk
+
+Typical characteristics:
+
+- bounded API additions;
+- non-sensitive UI behaviour;
+- backwards-compatible schema additions with no backfill;
+- internal tooling that cannot affect production automatically;
+- feature-flagged behaviour with limited data effect.
+
+Required controls:
+
+- complete task specification;
+- unit and integration tests;
+- compatibility assessment;
+- independent review;
+- rollout note if behaviour will later be activated.
+
+## High risk
+
+Any of:
+
+- database migration on populated tables;
+- authorization or role enforcement;
+- machine-to-machine credentials or service roles;
+- job claiming, retries, leases or concurrency;
+- idempotency or deduplication;
+- backfill or bulk mutation;
+- external deposits or write-back;
+- package entitlements;
+- changes to canonical data semantics;
+- production feature activation;
+- cross-repository API contract change;
+- user uploads or untrusted file parsing;
+- personal-data handling;
+- changes capable of broadening processing scope.
+
+Required controls:
+
+- approved design and task specification;
+- high or maximum implementation reasoning;
+- independent cross-model review;
+- migration tests on empty and populated databases where applicable;
+- failure-path and authorization tests;
+- rollout and rollback plan;
+- feature flag, comparison mode or controlled pilot where possible;
+- explicit CTO merge or activation approval.
+
+## Critical risk
+
+Any of:
+
+- destructive or irreversible production migration;
+- canonical data rewrite at scale;
+- change capable of mass redistribution or external publication;
+- security boundary affecting all publishers;
+- secrets, credential rotation or identity-provider reconfiguration;
+- historical metrics recomputation replacing existing canonical totals;
+- cutover from one source of truth to another without immediate rollback;
+- operation with material legal, privacy or contractual consequences.
+
+Required controls:
+
+- explicit CTO-approved specification;
+- architecture review;
+- implementation by the strongest appropriate coding model at maximum practical reasoning;
+- at least one independent cross-model review;
+- rehearsal in a production-like environment;
+- verified backup/restore or recovery path;
+- dry run and comparison report;
+- named pilot;
+- monitoring and kill switch;
+- explicit production change window;
+- observation period;
+- no simultaneous unrelated critical cutover.
+
+## Escalation rules
+
+Raise the risk level when:
+
+- evidence about the current system is incomplete;
+- the affected production data volume is unknown;
+- rollback is uncertain;
+- multiple repositories or external systems must change atomically;
+- tests cannot reproduce the operational path;
+- an external API has weak idempotency or correction support.
+
+Uncertainty increases risk. It does not justify reducing controls.

--- a/docs/engineering/ai-delivery/task-specification-template.md
+++ b/docs/engineering/ai-delivery/task-specification-template.md
@@ -1,0 +1,202 @@
+# Task Specification Template
+
+Copy this file to the relevant programme task directory and replace every bracketed field.
+
+A task may not enter implementation with unresolved required fields.
+
+---
+
+# [TASK-ID] - [Task title]
+
+Status: DRAFT | APPROVED | IMPLEMENTING | IN REVIEW | MERGE READY | RELEASED | CLOSED  
+Programme: [programme]  
+Repository: [owner/repository]  
+Workflow: STANDARD | PROGRAMME_INTEGRATION  
+Base branch: [normally `develop`; otherwise approved `feature/<programme>`]  
+PR target: [`develop` or approved `feature/<programme>`]  
+Programme integration branch: [branch or `None`]  
+Risk: LOW | MEDIUM | HIGH | CRITICAL  
+Owner: [role/person]  
+Approved by: [CTO/approver]  
+Dependencies: [task IDs, PRs, releases or `None`]  
+Target branch name: `feature/[programme-or-area]/[task-id-or-short-name]`
+
+## 1. Objective
+
+[One paragraph describing the outcome, not the implementation method.]
+
+## 2. Background and authority
+
+Authoritative sources:
+
+- [design/ADR/link]
+- [related issue/link]
+- [relevant repository path]
+
+Current behaviour:
+
+[Brief evidence-based description.]
+
+## 3. Explicit scope
+
+The task must:
+
+1. [...]
+2. [...]
+3. [...]
+
+## 4. Non-goals
+
+The task must not:
+
+1. [...]
+2. [...]
+3. [...]
+
+## 5. Invariants
+
+The implementation must preserve:
+
+1. [...]
+2. [...]
+3. [...]
+
+## 6. Required behaviour
+
+### 6.1 Success behaviour
+
+[...]
+
+### 6.2 Failure behaviour
+
+[...]
+
+### 6.3 Authorization
+
+[...]
+
+### 6.4 Concurrency and idempotency
+
+[State requirements or `Not applicable`.]
+
+### 6.5 Compatibility
+
+[API, database, client, deployment and backwards-compatibility requirements.]
+
+## 7. Data and migration requirements
+
+Migration required: YES | NO
+
+If yes:
+
+- schema changes:
+- populated database behaviour:
+- locking/downtime assessment:
+- data backfill:
+- idempotency:
+- rollback or forward-repair strategy:
+- empty database test:
+- populated database test:
+
+## 8. Observability and operations
+
+Required logs:
+
+[...]
+
+Required metrics/alerts:
+
+[...]
+
+Operational runbook changes:
+
+[...]
+
+## 9. Acceptance criteria
+
+Use verifiable statements.
+
+- [ ] [...]
+- [ ] [...]
+- [ ] [...]
+
+## 10. Required tests
+
+### Unit
+
+- [...]
+
+### Integration/database
+
+- [...]
+
+### Authorization/security
+
+- [...]
+
+### Regression
+
+- [...]
+
+### Manual verification
+
+- [...]
+
+### Performance
+
+[Required target or `Not applicable`.]
+
+## 11. Rollout
+
+- initial state after merge:
+- feature flag/configuration:
+- staging/preview validation:
+- pilot:
+- activation approval:
+- observation period:
+
+## 12. Rollback
+
+- code rollback:
+- data rollback or forward repair:
+- feature disable/kill switch:
+- external side-effect handling:
+
+## 13. Stop conditions
+
+The implementing agent must stop and report `BLOCKED` if:
+
+- [...]
+- [...]
+- approved architecture would need to change;
+- required production information or secrets are unavailable;
+- scope cannot be completed without unrelated changes.
+
+## 14. Expected implementation report
+
+The agent must use:
+
+`docs/engineering/ai-delivery/implementation-report-template.md`
+
+## 15. Recommended execution
+
+Implementation model: [model]  
+Reasoning level: [level]  
+Independent reviewer: [model/family]  
+Review reasoning level: [level]
+
+## 16. Branch and integration plan
+
+- branch source:
+- pull-request target:
+- expected merge order:
+- parent programme branch refresh requirement:
+- branch deletion after merge: YES
+- final programme PR required: YES | NO
+- final release path: `develop -> master`
+
+## 17. Approval
+
+Approved for implementation by:  
+Date:  
+Notes:

--- a/docs/engineering/ai-delivery/task-specification-template.md
+++ b/docs/engineering/ai-delivery/task-specification-template.md
@@ -8,17 +8,17 @@ A task may not enter implementation with unresolved required fields.
 
 # [TASK-ID] - [Task title]
 
-Status: DRAFT | APPROVED | IMPLEMENTING | IN REVIEW | MERGE READY | RELEASED | CLOSED  
-Programme: [programme]  
-Repository: [owner/repository]  
-Workflow: STANDARD | PROGRAMME_INTEGRATION  
-Base branch: [normally `develop`; otherwise approved `feature/<programme>`]  
-PR target: [`develop` or approved `feature/<programme>`]  
-Programme integration branch: [branch or `None`]  
-Risk: LOW | MEDIUM | HIGH | CRITICAL  
-Owner: [role/person]  
-Approved by: [CTO/approver]  
-Dependencies: [task IDs, PRs, releases or `None`]  
+Status: DRAFT | APPROVED | IMPLEMENTING | IN REVIEW | MERGE READY | RELEASED | CLOSED
+Programme: [programme]
+Repository: [owner/repository]
+Workflow: STANDARD | PROGRAMME_INTEGRATION
+Base branch: [normally `develop`; otherwise approved `feature/<programme>`]
+PR target: [`develop` or approved `feature/<programme>`]
+Programme integration branch: [branch or `None`]
+Risk: LOW | MEDIUM | HIGH | CRITICAL
+Owner: [role/person]
+Approved by: [CTO/approver]
+Dependencies: [task IDs, PRs, releases or `None`]
 Target branch name: `feature/[programme-or-area]/[task-id-or-short-name]`
 
 ## 1. Objective
@@ -180,9 +180,9 @@ The agent must use:
 
 ## 15. Recommended execution
 
-Implementation model: [model]  
-Reasoning level: [level]  
-Independent reviewer: [model/family]  
+Implementation model: [model]
+Reasoning level: [level]
+Independent reviewer: [model/family]
 Review reasoning level: [level]
 
 ## 16. Branch and integration plan
@@ -197,6 +197,6 @@ Review reasoning level: [level]
 
 ## 17. Approval
 
-Approved for implementation by:  
-Date:  
+Approved for implementation by:
+Date:
 Notes:

--- a/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
+++ b/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
@@ -1,186 +1,109 @@
 # CTRL-FOUNDATION-01 - Engineering Control Foundation
 
-Status: APPROVED FOR DOCUMENTATION IMPLEMENTATION; MERGE APPROVAL PENDING  
+Status: IMPLEMENTATION COMPLETE; INDEPENDENT REVIEW REQUIRED  
 Programme: Shared Engineering Control  
 Repository: `thoth-pub/thoth`  
 Risk: LOW  
 Workflow: STANDARD  
 Base branch: `develop`  
-Base commit at branch creation: `652a499dfdfbaa7594537e0865c41ec617f52dc2`  
+Base commit: `652a499dfdfbaa7594537e0865c41ec617f52dc2`  
 Task branch: `feature/ai-delivery-operating-model`  
 PR target: `develop`  
-Pull request: `thoth-pub/thoth#764`  
-Dependencies: None  
+Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)  
+Publisher Services issue: [#765](https://github.com/thoth-pub/thoth/issues/765)  
+Thoth Metrics issue: [#766](https://github.com/thoth-pub/thoth/issues/766)  
 Production effect: None
 
 ## 1. Objective
 
 Establish the complete repository-backed control and orientation foundation required before AI agents implement Publisher Services or Thoth Metrics.
 
-The foundation must make authority, task boundaries, review independence, branch flow, repository context, risk, release gates and programme prerequisites explicit.
+## 2. Scope delivered
 
-## 2. Scope
-
-The task includes documentation only:
-
-1. AI-led engineering operating model.
-2. GitHub Flow and large-programme integration-branch rules.
-3. Risk classification and model-selection guidance.
-4. Task, implementation-report, independent-review and decision templates.
-5. Merge, release, production and closure gates.
-6. Verified repository, branch, CI, release and environment map.
-7. Root and scoped `AGENTS.md` instructions for `thoth`.
-8. Agent-instruction rollout plan for related repositories.
-9. Publisher Services programme-control documents.
-10. Thoth Metrics programme-control documents.
-11. Cross-programme decisions or ADRs required before shared implementation.
-12. Final terminology, link, source-authority and consistency review.
-13. One consolidated changelog entry.
-
-Items 9-11 may remain explicitly blocked on a named CTO decision, but the blocker and required decision record must be present.
+1. operating model;
+2. branching and programme integration workflow;
+3. risk/model guidance;
+4. task/report/review/decision templates;
+5. release gates;
+6. repository/environment map;
+7. root and scoped Thoth agent instructions;
+8. related-repository instruction rollout;
+9. Publisher Services controls and issue;
+10. Metrics controls and issue;
+11. proposed cross-programme ADRs;
+12. top-level engineering index;
+13. changelog entry;
+14. independent-review brief.
 
 ## 3. Non-goals
 
-This task does not:
+No application code, database migration, GraphQL/export API, CI workflow, branch setting, Vercel setting, Sphinx bootstrap, AWS resource, deployment, release, production secret or production behavior is changed.
 
-- implement application behaviour;
-- add or alter database migrations;
-- change GraphQL or export APIs;
-- change CI workflow YAML;
-- rename branches or change GitHub settings;
-- modify Vercel configuration;
-- bootstrap `thoth-sphinx`;
-- create AWS resources;
-- deploy, publish or release;
-- access production secrets;
-- modify the approved product designs except through a separately approved source correction.
+The external Metrics design spelling correction remains a source-owner action outside this PR.
 
-## 4. Invariants
-
-1. GitHub and committed designs remain authoritative.
-2. Observed state and target policy are distinct.
-3. The canonical repository name is `thoth-pub/thoth-sphinx`.
-4. One implementing agent cannot approve its own work.
-5. Missing evidence is missing work.
-6. No document claims planned infrastructure is deployed.
-7. No secret values are committed.
-8. Programme scopes remain distinct.
-9. Cross-programme decisions require a shared ADR or programme decision.
-10. The documentation does not activate production behaviour.
-
-## 5. Acceptance criteria
+## 4. Acceptance status
 
 ### Operating model
 
-- [ ] Roles and authority are explicit.
-- [ ] Task lifecycle and decisions use `APPROVED`, `CHANGES REQUIRED` or `BLOCKED`.
-- [ ] Implementers cannot merge, deploy or self-approve.
-- [ ] Production activation requires appropriate CTO approval.
+- [x] roles and authority explicit;
+- [x] task lifecycle and decisions explicit;
+- [x] no self-approval/merge/deploy;
+- [x] CTO approval for high-risk activation.
 
-### Branching
+### Branching and repository context
 
-- [ ] Normal `develop -> feature -> develop -> master` flow is documented.
-- [ ] Large-programme slice/integration flow is documented.
-- [ ] Repository-specific branch deviations are recorded.
-- [ ] No document assumes a missing branch exists.
+- [x] normal and programme workflows documented;
+- [x] repository deviations recorded;
+- [x] affected repositories mapped;
+- [x] missing environment/deployment evidence explicit;
+- [x] Sphinx recorded as empty.
 
-### Repository context
+### Agent and programme controls
 
-- [ ] Every affected repository has a verified map entry.
-- [ ] Build/test/generation commands are recorded.
-- [ ] CI, release and deployment boundaries are recorded.
-- [ ] Missing deployment and branch-protection evidence is explicit.
-- [ ] Sphinx is recorded as empty until bootstrapped.
-
-### Agent instructions
-
-- [ ] `thoth` has a root `AGENTS.md`.
-- [ ] High-risk directories have scoped instructions.
-- [ ] The instructions link to the operating model and repository map.
-- [ ] Migration, authorization, generated-contract and workflow safety are explicit.
-- [ ] Related-repository rollout is tracked without claiming it is complete.
-
-### Programme readiness
-
-- [ ] Publisher Services control documents exist or have a precise completion plan.
-- [ ] Metrics control documents exist or have a precise completion plan.
-- [ ] Shared package/capability decisions are recorded or explicitly blocked for CTO decision.
-- [ ] No production implementation is described as ready while a required foundation is absent.
+- [x] root/scoped Thoth instructions exist;
+- [x] related rollout tracked;
+- [x] Publisher Services controls and issue exist;
+- [x] Metrics controls and issue exist;
+- [x] shared ADRs remain proposed CTO gates;
+- [x] dependent implementation remains blocked.
 
 ### Quality
 
-- [ ] No obsolete Sphinx spelling appears in added files.
-- [ ] Internal paths and indexes are valid.
-- [ ] No duplicate active control index/design is introduced.
-- [ ] `CHANGELOG.md` has one consolidated entry.
-- [ ] `git diff --check` passes.
-- [ ] Repository CI is green.
-- [ ] An independent reviewer inspects the complete final diff.
-- [ ] Final decision is `APPROVED`.
+- [x] canonical Sphinx spelling used in repository additions;
+- [x] one top-level engineering index;
+- [x] programme tracker links present;
+- [x] consolidated changelog entry present;
+- [ ] final `git diff --check` at review head;
+- [ ] final CI green at review head;
+- [ ] independent complete-diff review;
+- [ ] independent decision `APPROVED`.
 
-## 6. Required verification
+## 5. Final verification
 
 ```bash
 git diff --check
-grep -Rni "sphynx" AGENTS.md .github thoth-* docs/engineering || true
+grep -Rni "sphynx" AGENTS.md .github thoth-* docs || true
+grep -Rni "NOT YET CREATED" docs || true
 find . -name AGENTS.md -print | sort
 ```
 
-Also:
+Also verify the full final changed-file set, no source/migration/workflow behavior changes, repository links, ADR statuses, issues #765/#766, changelog, CI and absence of secrets.
 
-- inspect every changed file;
-- validate relative links and referenced paths;
-- compare the repository map with live GitHub/Vercel evidence;
-- inspect PR CI at the final head;
-- verify no workflow, migration or application source was changed;
-- verify the changelog check passes.
+## 6. Rollout and rollback
 
-## 7. Migration requirements
+1. independent review;
+2. remediation on this branch;
+3. CTO merge approval;
+4. merge into `develop`;
+5. replace stale Project sources;
+6. begin separately specified readiness tasks.
 
-None.
+Rollback is reverting PR #764. There is no runtime/data rollback.
 
-No SQL, schema or existing data changes are permitted.
+## 7. Review model
 
-## 8. Rollout
+Implementation: ChatGPT control conversation, GPT-5.6 Thinking.
 
-1. Keep PR #764 open while documentation chunks are completed.
-2. Request independent review only after the complete foundation is present.
-3. Resolve findings on the same branch.
-4. Obtain CTO merge approval.
-5. Merge into `develop`.
-6. Replace uploaded Project sources with the final approved versions.
-7. Begin repository-local rollout and programme tasks only after the merged foundation is authoritative.
+Independent review: separate Codex or Claude reviewer at high reasoning inspecting actual GitHub diff and CI.
 
-## 9. Rollback
-
-Revert PR #764.
-
-There is no runtime or data rollback.
-
-## 10. Stop conditions
-
-Return `BLOCKED` if:
-
-- the foundation contradicts an approved design;
-- a cross-programme decision is presented as settled without CTO approval;
-- repository facts cannot be verified;
-- the task expands into runtime, CI, branch-setting or deployment changes;
-- independent review cannot be obtained;
-- the final diff contains secrets or production configuration.
-
-## 11. Implementation and review model
-
-Documentation implementation:
-
-- ChatGPT control conversation, GPT-5.6 Thinking;
-- Codex may apply repository edits at medium reasoning.
-
-Independent review:
-
-- a separate Claude or Codex reviewer at high reasoning;
-- reviewer must inspect the final GitHub diff and CI;
-- the implementing conversation cannot approve the task.
-
-Merge approval:
-
-- CTO.
+Merge approval: CTO.

--- a/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
+++ b/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
@@ -1,0 +1,186 @@
+# CTRL-FOUNDATION-01 - Engineering Control Foundation
+
+Status: APPROVED FOR DOCUMENTATION IMPLEMENTATION; MERGE APPROVAL PENDING  
+Programme: Shared Engineering Control  
+Repository: `thoth-pub/thoth`  
+Risk: LOW  
+Workflow: STANDARD  
+Base branch: `develop`  
+Base commit at branch creation: `652a499dfdfbaa7594537e0865c41ec617f52dc2`  
+Task branch: `feature/ai-delivery-operating-model`  
+PR target: `develop`  
+Pull request: `thoth-pub/thoth#764`  
+Dependencies: None  
+Production effect: None
+
+## 1. Objective
+
+Establish the complete repository-backed control and orientation foundation required before AI agents implement Publisher Services or Thoth Metrics.
+
+The foundation must make authority, task boundaries, review independence, branch flow, repository context, risk, release gates and programme prerequisites explicit.
+
+## 2. Scope
+
+The task includes documentation only:
+
+1. AI-led engineering operating model.
+2. GitHub Flow and large-programme integration-branch rules.
+3. Risk classification and model-selection guidance.
+4. Task, implementation-report, independent-review and decision templates.
+5. Merge, release, production and closure gates.
+6. Verified repository, branch, CI, release and environment map.
+7. Root and scoped `AGENTS.md` instructions for `thoth`.
+8. Agent-instruction rollout plan for related repositories.
+9. Publisher Services programme-control documents.
+10. Thoth Metrics programme-control documents.
+11. Cross-programme decisions or ADRs required before shared implementation.
+12. Final terminology, link, source-authority and consistency review.
+13. One consolidated changelog entry.
+
+Items 9-11 may remain explicitly blocked on a named CTO decision, but the blocker and required decision record must be present.
+
+## 3. Non-goals
+
+This task does not:
+
+- implement application behaviour;
+- add or alter database migrations;
+- change GraphQL or export APIs;
+- change CI workflow YAML;
+- rename branches or change GitHub settings;
+- modify Vercel configuration;
+- bootstrap `thoth-sphinx`;
+- create AWS resources;
+- deploy, publish or release;
+- access production secrets;
+- modify the approved product designs except through a separately approved source correction.
+
+## 4. Invariants
+
+1. GitHub and committed designs remain authoritative.
+2. Observed state and target policy are distinct.
+3. The canonical repository name is `thoth-pub/thoth-sphinx`.
+4. One implementing agent cannot approve its own work.
+5. Missing evidence is missing work.
+6. No document claims planned infrastructure is deployed.
+7. No secret values are committed.
+8. Programme scopes remain distinct.
+9. Cross-programme decisions require a shared ADR or programme decision.
+10. The documentation does not activate production behaviour.
+
+## 5. Acceptance criteria
+
+### Operating model
+
+- [ ] Roles and authority are explicit.
+- [ ] Task lifecycle and decisions use `APPROVED`, `CHANGES REQUIRED` or `BLOCKED`.
+- [ ] Implementers cannot merge, deploy or self-approve.
+- [ ] Production activation requires appropriate CTO approval.
+
+### Branching
+
+- [ ] Normal `develop -> feature -> develop -> master` flow is documented.
+- [ ] Large-programme slice/integration flow is documented.
+- [ ] Repository-specific branch deviations are recorded.
+- [ ] No document assumes a missing branch exists.
+
+### Repository context
+
+- [ ] Every affected repository has a verified map entry.
+- [ ] Build/test/generation commands are recorded.
+- [ ] CI, release and deployment boundaries are recorded.
+- [ ] Missing deployment and branch-protection evidence is explicit.
+- [ ] Sphinx is recorded as empty until bootstrapped.
+
+### Agent instructions
+
+- [ ] `thoth` has a root `AGENTS.md`.
+- [ ] High-risk directories have scoped instructions.
+- [ ] The instructions link to the operating model and repository map.
+- [ ] Migration, authorization, generated-contract and workflow safety are explicit.
+- [ ] Related-repository rollout is tracked without claiming it is complete.
+
+### Programme readiness
+
+- [ ] Publisher Services control documents exist or have a precise completion plan.
+- [ ] Metrics control documents exist or have a precise completion plan.
+- [ ] Shared package/capability decisions are recorded or explicitly blocked for CTO decision.
+- [ ] No production implementation is described as ready while a required foundation is absent.
+
+### Quality
+
+- [ ] No obsolete Sphinx spelling appears in added files.
+- [ ] Internal paths and indexes are valid.
+- [ ] No duplicate active control index/design is introduced.
+- [ ] `CHANGELOG.md` has one consolidated entry.
+- [ ] `git diff --check` passes.
+- [ ] Repository CI is green.
+- [ ] An independent reviewer inspects the complete final diff.
+- [ ] Final decision is `APPROVED`.
+
+## 6. Required verification
+
+```bash
+git diff --check
+grep -Rni "sphynx" AGENTS.md .github thoth-* docs/engineering || true
+find . -name AGENTS.md -print | sort
+```
+
+Also:
+
+- inspect every changed file;
+- validate relative links and referenced paths;
+- compare the repository map with live GitHub/Vercel evidence;
+- inspect PR CI at the final head;
+- verify no workflow, migration or application source was changed;
+- verify the changelog check passes.
+
+## 7. Migration requirements
+
+None.
+
+No SQL, schema or existing data changes are permitted.
+
+## 8. Rollout
+
+1. Keep PR #764 open while documentation chunks are completed.
+2. Request independent review only after the complete foundation is present.
+3. Resolve findings on the same branch.
+4. Obtain CTO merge approval.
+5. Merge into `develop`.
+6. Replace uploaded Project sources with the final approved versions.
+7. Begin repository-local rollout and programme tasks only after the merged foundation is authoritative.
+
+## 9. Rollback
+
+Revert PR #764.
+
+There is no runtime or data rollback.
+
+## 10. Stop conditions
+
+Return `BLOCKED` if:
+
+- the foundation contradicts an approved design;
+- a cross-programme decision is presented as settled without CTO approval;
+- repository facts cannot be verified;
+- the task expands into runtime, CI, branch-setting or deployment changes;
+- independent review cannot be obtained;
+- the final diff contains secrets or production configuration.
+
+## 11. Implementation and review model
+
+Documentation implementation:
+
+- ChatGPT control conversation, GPT-5.6 Thinking;
+- Codex may apply repository edits at medium reasoning.
+
+Independent review:
+
+- a separate Claude or Codex reviewer at high reasoning;
+- reviewer must inspect the final GitHub diff and CI;
+- the implementing conversation cannot approve the task.
+
+Merge approval:
+
+- CTO.

--- a/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
+++ b/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
@@ -1,14 +1,18 @@
 # CTRL-FOUNDATION-01 - Engineering Control Foundation
 
-Status: IMPLEMENTATION COMPLETE; INDEPENDENT REVIEW REQUIRED
+Status: IN REVIEW
 Programme: Shared Engineering Control
 Repository: `thoth-pub/thoth`
-Risk: LOW
 Workflow: STANDARD
 Base branch: `develop`
-Base commit: `652a499dfdfbaa7594537e0865c41ec617f52dc2`
-Task branch: `feature/ai-delivery-operating-model`
 PR target: `develop`
+Programme integration branch: None
+Risk: LOW
+Owner: Javier Arias, CTO
+Approved by: Javier Arias, CTO
+Approval date: 2026-07-24
+Dependencies: None for documentation implementation; final review depends on authorized access to the private approved designs at the revisions recorded in `docs/engineering/design-references.md`, issues #765/#766 and current PR CI
+Target branch: `feature/ai-delivery-operating-model`
 Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
 Publisher Services issue: [#765](https://github.com/thoth-pub/thoth/issues/765)
 Thoth Metrics issue: [#766](https://github.com/thoth-pub/thoth/issues/766)
@@ -16,94 +20,307 @@ Production effect: None
 
 ## 1. Objective
 
-Establish the complete repository-backed control and orientation foundation required before AI agents implement Publisher Services or Thoth Metrics.
+Establish a complete repository-backed control and orientation foundation for AI-assisted engineering delivery before implementation begins for Publisher Services or Thoth Metrics.
 
-## 2. Scope delivered
+The outcome must make authority, task boundaries, review independence, repository state, branch flow, risk, release controls, programme prerequisites and missing evidence explicit.
 
-1. operating model;
-2. branching and programme integration workflow;
-3. risk/model guidance;
-4. task/report/review/decision templates;
-5. release gates;
-6. repository/environment map;
-7. root and scoped Thoth agent instructions;
-8. related-repository instruction rollout;
-9. Publisher Services controls and issue;
-10. Metrics controls and issue;
-11. proposed cross-programme ADRs;
-12. top-level engineering index;
-13. changelog entry;
-14. independent-review brief.
+## 2. Background and authority
 
-## 3. Non-goals
+Authoritative inputs:
 
-No application code, database migration, GraphQL/export API, CI workflow, branch setting, Vercel setting, Sphinx bootstrap, AWS resource, deployment, release, production secret or production behavior is changed.
+1. [Private Publisher Services design](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit), Drive revision `3`
+2. [Private Thoth Metrics design](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit), Drive revision `6`
+3. [`docs/engineering/design-references.md`](../../design-references.md)
+4. current repository state, migrations, workflows and generated contracts;
+5. PR #764, issues #765/#766 and their CI evidence.
 
-The external Metrics design spelling correction remains a source-owner action outside this PR.
+The Publisher Services design is approved for phased implementation and requires one fresh task branch and one PR per task, without a long-lived programme branch.
 
-## 4. Acceptance status
+The Metrics design fixes the canonical architecture and requires repository-local `feature/metrics` integration branches after branch readiness; named source mappings, fixtures, capability assignments and complete OPERAS discovery remain dependencies.
 
-### Operating model
+The private Metrics design contains an obsolete spelling. Repository controls use `thoth-pub/thoth-sphinx` and `Sphinx`, while correction of the private source remains separately controlled.
 
-- [x] roles and authority explicit;
-- [x] task lifecycle and decisions explicit;
-- [x] no self-approval/merge/deploy;
-- [x] CTO approval for high-risk activation.
+## 3. Explicit scope
 
-### Branching and repository context
+The task must add and reconcile:
 
-- [x] normal and programme workflows documented;
-- [x] repository deviations recorded;
-- [x] affected repositories mapped;
-- [x] missing environment/deployment evidence explicit;
-- [x] Sphinx recorded as empty.
+1. the AI-led engineering operating model;
+2. standard and approved programme-integration branch workflows;
+3. risk classification and model-selection guidance;
+4. task, implementation-report, review and decision templates;
+5. merge, release, production and closure gates;
+6. a verified repository, branch, CI, release and environment map;
+7. root and scoped `AGENTS.md` instructions for `thoth`;
+8. a rollout plan for related-repository agent instructions;
+9. proposed cross-programme package/capability and platform-boundary ADRs;
+10. Publisher Services programme controls and master issue;
+11. Thoth Metrics programme controls and master issue;
+12. private approved-design links and exact Drive revision metadata used for review;
+13. a top-level engineering index, consolidated changelog entry and independent-review brief;
+14. explicit control gaps for all unverified or deferred work.
 
-### Agent and programme controls
+## 4. Non-goals
 
-- [x] root/scoped Thoth instructions exist;
-- [x] related rollout tracked;
-- [x] Publisher Services controls and issue exist;
-- [x] Metrics controls and issue exist;
-- [x] shared ADRs remain proposed CTO gates;
+The task must not:
+
+1. change Rust application behaviour;
+2. change GraphQL or export APIs;
+3. add or alter database migrations or persisted data;
+4. change GitHub Actions workflow behaviour;
+5. change branch settings or protections;
+6. change Vercel, AWS or runtime configuration;
+7. bootstrap `thoth-sphinx`;
+8. deploy, publish, release or activate production behaviour;
+9. access or commit production secrets;
+10. approve ADR-0001 or ADR-0002 merely by committing them;
+11. publish, copy or silently alter the private approved designs.
+
+## 5. Invariants
+
+The implementation must preserve:
+
+1. merged repository evidence outranks conversation and memory;
+2. approved designs and ADRs outrank programme summaries;
+3. proposed ADRs are not implementation authority;
+4. one implementing agent cannot approve or merge its own work;
+5. missing evidence is missing work;
+6. observed state, approved target policy and planned architecture remain distinct;
+7. Publisher Services uses one task branch and one PR per task;
+8. Metrics may use repository-local integration branches only after readiness gates;
+9. package selection never implicitly changes distribution assignments;
+10. distribution and metrics platform domains remain separate;
+11. no document describes planned infrastructure as deployed;
+12. this PR remains documentation-only and has no production effect.
+
+## 6. Required behaviour
+
+### 6.1 Success behaviour
+
+The merged foundation provides one navigable control surface that allows an independent implementer or reviewer to identify:
+
+- programme, repository, task, base and target;
+- approved specification and design inputs;
+- risk, permissions and stop conditions;
+- actual repository/branch/environment state;
+- required tests and evidence;
+- release, rollout and rollback controls;
+- programme dependencies and blocked decisions.
+
+### 6.2 Failure behaviour
+
+The documents must require `BLOCKED` when an approved specification, design dependency, repository base, authorization path, migration evidence, production control or cross-programme decision is absent.
+
+No failure to retrieve configuration or evidence may be interpreted as permission to broaden scope or continue production work.
+
+### 6.3 Authorization
+
+Not applicable to runtime behaviour.
+
+The control documents must prohibit implementing agents from merging, deploying, accessing production secrets or approving their own work.
+
+### 6.4 Concurrency and idempotency
+
+Not applicable to this documentation-only task.
+
+The programme controls must nevertheless require future operational tasks to specify concurrency, leases, retries and idempotency where relevant.
+
+### 6.5 Compatibility
+
+The task must be additive and documentation-only.
+
+Existing source, API, schema, migration, package, deployment and release behaviour must remain unchanged.
+
+## 7. Data and migration requirements
+
+Migration required: NO
+
+- schema changes: none;
+- existing-data effect: none;
+- locking/downtime: none;
+- rollback: revert PR #764;
+- empty/populated database tests: not applicable to the diff, while existing repository migration CI must remain green.
+
+## 8. Observability and operations
+
+Required logs/metrics/alerts: none for this documentation-only change.
+
+Required operational evidence:
+
+- repository CI at the exact reviewed head;
+- no runtime or production configuration changes;
+- issues #765/#766 available;
+- all deferred operational controls explicitly recorded.
+
+Operational runbook changes: none.
+
+## 9. Acceptance criteria
+
+### Operating model and authority
+
+- [x] roles, authority hierarchy and task lifecycle are explicit;
+- [x] implementers cannot self-approve, merge, deploy or access production secrets;
+- [x] review decisions use `APPROVED`, `CHANGES REQUIRED` or `BLOCKED`;
+- [x] high-risk production activation requires CTO approval.
+
+### Branching
+
+- [x] standard `feature -> develop -> master` flow is documented;
+- [x] programme integration flow is available only where an approved design requires it;
+- [x] Publisher Services is recorded as one fresh task branch/PR per task;
+- [x] Metrics is recorded as repository-local `feature/metrics` integration flow after readiness;
+- [x] repository branch deviations and normalization tasks are explicit;
+- [x] no missing branch is invented.
+
+### Repository context and instructions
+
+- [x] every affected repository has a map entry;
+- [x] build/test/generation commands are recorded where verified;
+- [x] missing CI, deployment, branch-protection and schema-generation evidence is explicit;
+- [x] root and scoped Thoth instructions exist;
+- [x] related-repository instruction rollout remains tracked as incomplete.
+
+### Programme controls
+
+- [x] Publisher Services controls and issue #765 exist;
+- [x] Metrics controls and issue #766 exist;
+- [x] private approved-design links and exact Drive revision metadata are recorded;
+- [x] ADR-0001 and ADR-0002 remain `PROPOSED`;
 - [x] dependent implementation remains blocked.
 
-### Quality
+### Quality and review
 
-- [x] canonical Sphinx spelling used in repository additions;
-- [x] one top-level engineering index;
-- [x] programme tracker links present;
-- [x] consolidated changelog entry present;
-- [ ] final `git diff --check` at review head;
-- [ ] final CI green at review head;
-- [ ] independent complete-diff review;
-- [ ] independent decision `APPROVED`.
+- [x] canonical `thoth-sphinx` / `Sphinx` spelling is used in committed repository documents;
+- [x] stale CTRL/CG references identified by review are corrected;
+- [x] one top-level engineering index exists;
+- [x] changelog entry exists;
+- [ ] final `git diff --check` passes at the remediation review head;
+- [ ] all required CI succeeds at the remediation review head;
+- [ ] the implementation report records exact evidence;
+- [ ] an independent reviewer inspects the complete final diff;
+- [ ] final independent decision is `APPROVED`.
 
-## 5. Final verification
+## 10. Required tests and verification
+
+### Documentation/static checks
 
 ```bash
-git diff --check
-grep -Rni "sphynx" AGENTS.md .github thoth-* docs || true
-grep -Rni "NOT YET CREATED" docs || true
+git diff --check 652a499dfdfbaa7594537e0865c41ec617f52dc2...HEAD
+
+grep -RniE \
+  '(^|[^[:alnum:]_-])CTRL-(01|02)([^[:digit:]]|$)' \
+  docs \
+  || true
+
+grep -RniE \
+  'CG-(05|06|09)' \
+  docs/engineering/repository-map/environments.md \
+  docs/engineering/repository-map/repositories \
+  || true
+
+grep -Rni 'Publisher Services integration bran[c]h' docs || true
+
+grep -Rni 'NOT YET CREATE[D]' docs || true
+
+grep -Rni 'sph[y]nx' AGENTS.md .github thoth-* docs || true
+
 find . -name AGENTS.md -print | sort
 ```
 
-Also verify the full final changed-file set, no source/migration/workflow behavior changes, repository links, ADR statuses, issues #765/#766, changelog, CI and absence of secrets.
+Expected:
 
-## 6. Rollout and rollback
+- no whitespace errors;
+- no stale task/control IDs or obsolete Publisher Services integration-branch references;
+- no obsolete Sphinx spelling in committed repository documents;
+- expected instruction hierarchy present.
 
-1. independent review;
-2. remediation on this branch;
-3. CTO merge approval;
-4. merge into `develop`;
-5. replace stale Project sources;
-6. begin separately specified readiness tasks.
+### Repository scope
 
-Rollback is reverting PR #764. There is no runtime/data rollback.
+```bash
+git diff --name-only 652a499dfdfbaa7594537e0865c41ec617f52dc2...HEAD
+```
 
-## 7. Review model
+Only `CHANGELOG.md`, `AGENTS.md` instruction documents and `docs/**` may change.
 
-Implementation: ChatGPT control conversation, GPT-5.6 Thinking.
+### CI
 
-Independent review: separate Codex or Claude reviewer at high reasoning inspecting actual GitHub diff and CI.
+Required current-head workflows:
 
-Merge approval: CTO.
+- `check-changelog`;
+- `build-test-and-check`;
+- `run-migrations`;
+- any additional branch-required workflow that runs at the final head.
+
+### Manual review
+
+- verify repository-relative links;
+- verify both private design file IDs, revision IDs and modification times through authorized Google Drive access;
+- verify issue #765/#766 links;
+- verify ADR statuses;
+- verify no secrets or production configuration;
+- verify the Sphinx branch map against authenticated GitHub evidence.
+
+### Performance
+
+Not applicable.
+
+## 11. Rollout
+
+- initial state after merge: documentation becomes authoritative in `develop`;
+- feature flag/configuration: none;
+- staging/preview validation: not applicable;
+- pilot: not applicable;
+- activation approval: CTO merge approval;
+- observation: use the controls on the first bounded readiness/implementation tasks and correct defects through normal PRs.
+
+After merge, replace stale ChatGPT Project sources with the merged repository copies.
+
+## 12. Rollback
+
+- code rollback: revert PR #764;
+- data rollback: none;
+- feature disable: none;
+- external side effects: issue links may remain as historical records; update them if the foundation is reverted.
+
+## 13. Stop conditions
+
+Return `BLOCKED` when:
+
+- the private approved designs are inaccessible to the reviewer or do not match their recorded Drive revisions;
+- repository state materially differs from the map and cannot be resolved;
+- a proposed decision is presented as approved;
+- the diff expands beyond documentation and instruction files;
+- a required check or CI workflow fails;
+- production credentials or destructive access would be required;
+- an independent reviewer cannot inspect the exact final head;
+- an architecture conflict would need to be silently resolved.
+
+## 14. Expected implementation report
+
+Use:
+
+`docs/engineering/ai-delivery/reports/CTRL-FOUNDATION-01-implementation-report.md`
+
+The report must record the exact base, implementation/remediation head, commit list, material files, commands/results, CI run IDs, no-runtime-effect statement, known limitations and review focus.
+
+## 15. Recommended execution
+
+Implementation model: GPT-5.6 Thinking control conversation, with repository edits applied manually or by Codex
+Reasoning level: high for control consolidation
+Independent reviewer: separate Codex or Claude instance
+Review reasoning level: high
+
+## 16. Branch and integration plan
+
+- branch source: `develop` at `652a499dfdfbaa7594537e0865c41ec617f52dc2`;
+- pull-request target: `develop`;
+- programme integration branch: none;
+- expected merge order: PR #764 after independent approval and CTO merge authorization;
+- branch deletion after merge: YES;
+- final programme PR required: NO;
+- release path: normal future `develop -> master` release; this PR itself activates no runtime behaviour.
+
+## 17. Approval
+
+Approved for implementation by: Javier Arias, CTO
+Date: 2026-07-24
+Notes: Documentation-only foundation approved through the CTO control conversation. Cross-programme ADRs remain proposed and require separate approval.

--- a/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
+++ b/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
@@ -298,7 +298,7 @@ Return `BLOCKED` when:
 
 Use:
 
-`docs/engineering/ai-delivery/reports/CTRL-FOUNDATION-01-implementation-report.md`
+`docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md`
 
 The report must record the exact base, implementation/remediation head, commit list, material files, commands/results, CI run IDs, no-runtime-effect statement, known limitations and review focus.
 

--- a/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
+++ b/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
@@ -193,9 +193,9 @@ Operational runbook changes: none.
 - [x] stale CTRL/CG references identified by review are corrected;
 - [x] one top-level engineering index exists;
 - [x] changelog entry exists;
-- [ ] final `git diff --check` passes at the remediation review head;
-- [ ] all required CI succeeds at the remediation review head;
-- [ ] the implementation report records exact evidence;
+- [x] `git diff --check` passes through remediation head `104ffaa16b2436cea2b4e2779c241b016916f083`;
+- [x] all required CI succeeds at remediation head `104ffaa16b2436cea2b4e2779c241b016916f083`;
+- [x] the implementation report records exact evidence through remediation head `104ffaa16b2436cea2b4e2779c241b016916f083`;
 - [ ] an independent reviewer inspects the complete final diff;
 - [ ] final independent decision is `APPROVED`.
 

--- a/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
+++ b/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md
@@ -1,17 +1,17 @@
 # CTRL-FOUNDATION-01 - Engineering Control Foundation
 
-Status: IMPLEMENTATION COMPLETE; INDEPENDENT REVIEW REQUIRED  
-Programme: Shared Engineering Control  
-Repository: `thoth-pub/thoth`  
-Risk: LOW  
-Workflow: STANDARD  
-Base branch: `develop`  
-Base commit: `652a499dfdfbaa7594537e0865c41ec617f52dc2`  
-Task branch: `feature/ai-delivery-operating-model`  
-PR target: `develop`  
-Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)  
-Publisher Services issue: [#765](https://github.com/thoth-pub/thoth/issues/765)  
-Thoth Metrics issue: [#766](https://github.com/thoth-pub/thoth/issues/766)  
+Status: IMPLEMENTATION COMPLETE; INDEPENDENT REVIEW REQUIRED
+Programme: Shared Engineering Control
+Repository: `thoth-pub/thoth`
+Risk: LOW
+Workflow: STANDARD
+Base branch: `develop`
+Base commit: `652a499dfdfbaa7594537e0865c41ec617f52dc2`
+Task branch: `feature/ai-delivery-operating-model`
+PR target: `develop`
+Pull request: [#764](https://github.com/thoth-pub/thoth/pull/764)
+Publisher Services issue: [#765](https://github.com/thoth-pub/thoth/issues/765)
+Thoth Metrics issue: [#766](https://github.com/thoth-pub/thoth/issues/766)
 Production effect: None
 
 ## 1. Objective

--- a/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+++ b/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
@@ -1,11 +1,11 @@
 # ADR-0001 - Publisher Package Capability Model
 
-Status: PROPOSED  
-Date: 2026-07-24  
-Decision owner: CTO  
-Programmes affected: Publisher Services, Thoth Metrics, OAI-PMH  
-Repositories affected: `thoth`, `thoth-app`, `thoth-sphinx`, `metrics-dashboard`, `metrics-widget`  
-Supersedes: None  
+Status: PROPOSED
+Date: 2026-07-24
+Decision owner: CTO
+Programmes affected: Publisher Services, Thoth Metrics, OAI-PMH
+Repositories affected: `thoth`, `thoth-app`, `thoth-sphinx`, `metrics-dashboard`, `metrics-widget`
+Supersedes: None
 Superseded by: None
 
 ## 1. Context
@@ -331,9 +331,9 @@ Rollback:
 
 ## 10. Approval
 
-Approval required from: CTO  
-Approved by:  
-Approval date:  
+Approval required from: CTO
+Approved by:
+Approval date:
 Notes:
 
 The CTO must complete the checklist in `package-capability-matrix.md` before changing this ADR to `APPROVED`.

--- a/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+++ b/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
@@ -1,0 +1,339 @@
+# ADR-0001 - Publisher Package Capability Model
+
+Status: PROPOSED  
+Date: 2026-07-24  
+Decision owner: CTO  
+Programmes affected: Publisher Services, Thoth Metrics, OAI-PMH  
+Repositories affected: `thoth`, `thoth-app`, `thoth-sphinx`, `metrics-dashboard`, `metrics-widget`  
+Supersedes: None  
+Superseded by: None
+
+## 1. Context
+
+Publisher Services defines one non-null package per publisher:
+
+```text
+OASIS
+OBELISK
+SPHINX
+PYRAMID
+```
+
+OASIS is the default.
+
+Package selection does not enable or disable distribution platforms.
+
+Thoth Metrics requires collection, import, dashboard, widget and OPERAS-export entitlements. Metrics logic must not hardcode package names in multiple resolvers, workers and clients.
+
+OAI-PMH also needs package eligibility, while retaining separate work-level open-licence and lifecycle checks.
+
+Without one shared capability model, programmes could implement conflicting package checks and make future package changes unsafe.
+
+## 2. Decision drivers
+
+- One canonical entitlement interpretation.
+- Exhaustive compile-time handling of every package and capability.
+- No duplicated package-name checks across programmes.
+- Auditable changes through normal code review.
+- Simple initial implementation.
+- No runtime configuration that can silently broaden access.
+- Clear separation between product entitlement and operational configuration.
+- Safe upgrade and downgrade behaviour.
+- No coupling between package and distribution assignments.
+
+## 3. Options considered
+
+### Option A - Hardcode package checks in each feature
+
+Example:
+
+```text
+package == SPHINX || package == PYRAMID
+```
+
+Advantages:
+
+- minimal initial code.
+
+Disadvantages:
+
+- repeated business rules;
+- drift between OAI, metrics queries, imports and workers;
+- difficult auditing;
+- package changes require searching every feature;
+- high risk of inconsistent downgrade behaviour.
+
+Decision: Rejected.
+
+### Option B - Database-owned capability catalogue and package mappings
+
+Capabilities and package mappings are editable database rows.
+
+Advantages:
+
+- runtime configuration;
+- no deployment needed for mapping changes.
+
+Disadvantages:
+
+- new schema, administration and authorization surface;
+- configuration can drift across environments;
+- accidental changes can immediately broaden access;
+- requires audit, cache invalidation and migration rules before any demonstrated need;
+- conflicts with the current package enum and code-owned descriptor direction.
+
+Decision: Rejected for the initial implementation.
+
+A future ADR may introduce database-managed commercial configuration if a real operational requirement emerges.
+
+### Option C - Code-owned exhaustive capability mapping
+
+Define stable package and capability enums in Thoth and one exhaustive mapping function.
+
+Advantages:
+
+- one reviewed source of truth;
+- compile-time exhaustiveness;
+- deterministic across environments;
+- easy unit-test matrix;
+- package changes remain visible in code review and releases;
+- no runtime path can silently grant a new capability.
+
+Disadvantages:
+
+- mapping changes require a release;
+- not suitable for bespoke per-publisher overrides.
+
+Decision: Recommended.
+
+### Option D - Hybrid code defaults with per-publisher overrides
+
+Code defines defaults, but database rows may grant or revoke individual capabilities.
+
+Advantages:
+
+- flexible exceptions.
+
+Disadvantages:
+
+- creates hidden bespoke products;
+- complicates authorization and support;
+- makes effective entitlement harder to explain;
+- requires override precedence and audit semantics;
+- can silently invalidate the package model.
+
+Decision: Rejected for the initial implementation.
+
+## 4. Decision
+
+### 4.1 Ownership
+
+Thoth owns the package and capability model.
+
+Use:
+
+```text
+ThothPackage
+PublisherCapability
+```
+
+as closed Rust enums with stable GraphQL codes.
+
+The PostgreSQL package enum stores the publisher package. Capability mappings are code-owned and are not persisted as independent publisher capability rows.
+
+### 4.2 Exhaustive mapping
+
+Implement one exhaustive mapping equivalent to:
+
+```rust
+impl ThothPackage {
+    pub fn capabilities(self) -> &'static [PublisherCapability];
+    pub fn has_capability(self, capability: PublisherCapability) -> bool;
+}
+```
+
+Every package and capability pair must be covered by tests.
+
+Feature code calls `has_capability`. It must not compare package names directly except inside the mapping implementation or its tests.
+
+The normative proposed matrix is:
+
+```text
+docs/engineering/decisions/package-capability-matrix.md
+```
+
+### 4.3 Capability set
+
+The initial capabilities are:
+
+```text
+OAI_PMH
+METRICS_COLLECT
+METRICS_IMPORT
+METRICS_DASHBOARD
+METRICS_WIDGET
+METRICS_OPERAS_EXPORT
+```
+
+Distribution-platform access is intentionally not a package capability. Desired distribution platforms remain explicit publisher assignments.
+
+### 4.4 GraphQL exposure
+
+Protected publisher service configuration exposes:
+
+- current package;
+- effective capability codes;
+- enabled distribution platforms as a separate field.
+
+Publisher users may read their own package and capabilities. Superusers may read any publisher and change the package.
+
+Anonymous users and users scoped only to another publisher cannot read package or capability values.
+
+Public distribution-platform queries do not expose package values.
+
+### 4.5 Enforcement
+
+Capabilities are enforced in Thoth at the owning operation:
+
+- OAI query eligibility;
+- publisher metric import initialization and completion;
+- protected dashboard/widget metrics queries;
+- metrics collection claim/configuration;
+- OPERAS export claim and delivery.
+
+The frontend may hide controls, but UI state is not authorization.
+
+Machine roles and publisher-platform approvals remain additional checks.
+
+### 4.6 Operational configuration
+
+A capability means the package permits a feature. It does not configure or activate it.
+
+Actual operation may additionally require:
+
+- source accounts;
+- platform/measure configuration;
+- publisher-platform approval;
+- feature flags;
+- service credentials;
+- schedules;
+- rollout approval.
+
+### 4.7 Upgrade and downgrade
+
+The upgrade and downgrade semantics in `package-capability-matrix.md` are part of this decision.
+
+In particular:
+
+- retained canonical metrics may become visible when serving capability is gained;
+- a package upgrade does not automatically bulk-export historical metrics to OPERAS;
+- a downgrade does not delete canonical metrics;
+- package changes never modify distribution-platform assignments.
+
+## 5. Consequences
+
+### Positive
+
+- One entitlement source of truth.
+- Compile-time exhaustive package handling.
+- Consistent OAI and metrics behaviour.
+- Simple authorization tests.
+- Product changes are visible in reviewed releases.
+- No capability/configuration drift between environments.
+- No accidental package-to-distribution coupling.
+
+### Negative
+
+- Commercial mapping changes require code deployment.
+- No bespoke per-publisher capability overrides.
+- A future package model expansion requires enum, GraphQL and migration work.
+
+### Risks
+
+- The proposed matrix may not match final commercial packaging.
+- `METRICS_COLLECT` for all packages has storage and operational cost.
+- Treating PYRAMID as cumulative with SPHINX must be confirmed.
+- In-flight work could cross a downgrade unless entitlement is rechecked.
+
+## 6. Invariants created by this decision
+
+1. Package capability checks are centralized in Thoth.
+2. Feature code does not hardcode package-name combinations.
+3. Package changes do not change distribution assignments.
+4. Capabilities do not bypass authorization or feature-specific configuration.
+5. Canonical metrics are not deleted on downgrade.
+6. Historical OPERAS export is an explicit operation, not an upgrade side effect.
+7. Publisher users cannot mutate their package.
+8. Capability mappings are identical across environments running the same version.
+
+## 7. Implementation impact
+
+Affected tasks:
+
+- Publisher Services `BE-01`, `BE-03`, `APP-01`, `OAI-01`;
+- metrics entitlement, service-authentication and export tasks.
+
+Required sequencing:
+
+1. approve this ADR and matrix;
+2. implement package enum and capability mapping in `thoth`;
+3. expose protected effective capabilities;
+4. consume the capability checks in later programme slices;
+5. remove any temporary package-name checks before production activation.
+
+Required migrations:
+
+- `thoth_package` enum;
+- non-null publisher package column with OASIS default;
+- no capability mapping table;
+- no capability override table.
+
+Required client changes:
+
+- generate GraphQL clients after the protected capability field is merged;
+- do not duplicate the matrix in frontend code.
+
+Required operational changes:
+
+- document capability-affecting releases;
+- monitor rejected operations after upgrades/downgrades;
+- use explicit historical export backfills.
+
+## 8. Validation
+
+Required evidence:
+
+- exhaustive package/capability unit test;
+- migration tests for existing and new publishers;
+- authorization tests;
+- downgrade and upgrade tests;
+- tests proving distribution assignments are unchanged;
+- tests proving metrics and OAI call capability methods;
+- test proving no automatic historical export is created;
+- GraphQL compatibility review.
+
+## 9. Rollout and rollback
+
+Rollout:
+
+1. deploy package storage and capability mapping additively;
+2. backfill/confirm OASIS defaults;
+3. expose read-only package/capability data;
+4. introduce feature checks in inactive or comparison mode;
+5. activate each consuming feature under its own rollout.
+
+Rollback:
+
+- disable consuming feature paths;
+- retain the package column and mapping code;
+- revert mapping code only through a reviewed release;
+- do not delete package history or canonical metrics.
+
+## 10. Approval
+
+Approval required from: CTO  
+Approved by:  
+Approval date:  
+Notes:
+
+The CTO must complete the checklist in `package-capability-matrix.md` before changing this ADR to `APPROVED`.

--- a/docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
+++ b/docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
@@ -1,0 +1,298 @@
+# ADR-0002 - Distribution and Metrics Platform Domain Boundaries
+
+Status: PROPOSED  
+Date: 2026-07-24  
+Decision owner: CTO  
+Programmes affected: Publisher Services, Thoth Metrics  
+Repositories affected: `thoth`, `thoth-app`, `thoth-dissemination`, `thoth-sphinx`, `metrics-dashboard`, `metrics-widget`  
+Supersedes: None  
+Superseded by: None
+
+## 1. Context
+
+Publisher Services needs a closed set of destinations that can be enabled for a publisher and mapped exhaustively to delivery behaviour.
+
+Thoth Metrics needs a registry of services where measured activity occurred, together with supported measures, grains, dimensions and acquisition routes.
+
+Some names may appear in both domains, such as OAPEN or JSTOR. That does not make the concepts identical.
+
+Examples:
+
+- OAPEN and DOAB are separate but linked distribution destinations and currently share one delivery adapter.
+- An OAPEN metrics report may represent activity on OAPEN only.
+- A publisher website or CDN may be a metrics platform without being a distribution destination.
+- OCLC KB may be a distribution feed without supplying metrics.
+
+A universal platform enum would create false equivalence and force unrelated lifecycle rules into one type.
+
+## 2. Decision drivers
+
+- Correct domain semantics.
+- Exhaustive distribution adapter mapping.
+- Extensible metrics registry.
+- No accidental OAPEN/DOAB metrics linkage.
+- No package or UI code inferring behaviour from display names.
+- Independent evolution of delivery and measurement.
+- Explicit cross-domain relationships only when a real use case exists.
+
+## 3. Options considered
+
+### Option A - One universal platform enum
+
+Use one enum for distribution, metrics, source accounts and reporting.
+
+Advantages:
+
+- one list of names;
+- superficially simple UI reuse.
+
+Disadvantages:
+
+- conflates desired delivery with measured activity;
+- forces metrics-only and distribution-only values into every consumer;
+- makes OAPEN/DOAB linkage ambiguous;
+- encourages name-based assumptions;
+- couples migrations and release schedules;
+- cannot represent metric platform configuration cleanly.
+
+Decision: Rejected.
+
+### Option B - Shared base enum with domain-specific wrappers
+
+Create one common enum and wrap it as `DistributionPlatform` and `MetricPlatform`.
+
+Advantages:
+
+- type distinction at some call sites.
+
+Disadvantages:
+
+- still forces a single lifecycle and inventory;
+- still cannot express metrics registry data;
+- new values affect unrelated domains;
+- wrappers do not remove semantic coupling.
+
+Decision: Rejected.
+
+### Option C - Independent domain types with no inferred mapping
+
+Use a closed distribution enum and a metrics registry table with stable codes.
+
+Advantages:
+
+- each domain models its real lifecycle;
+- distribution remains exhaustive;
+- metrics remains configurable and dimension-aware;
+- overlapping names do not imply shared behaviour;
+- clear tests and ownership.
+
+Disadvantages:
+
+- two registries may use similar labels;
+- any future cross-domain report requires explicit mapping.
+
+Decision: Recommended.
+
+### Option D - Independent types plus an initial mapping table
+
+Create a cross-domain mapping immediately.
+
+Advantages:
+
+- ready for combined reporting.
+
+Disadvantages:
+
+- no approved initial use case;
+- semantics and cardinality are not yet established;
+- risks creating another premature source of truth.
+
+Decision: Rejected for the initial implementation.
+
+A later ADR may introduce a mapping after defining its concrete consumer and cardinality.
+
+## 4. Decision
+
+### 4.1 Separate types and storage
+
+Publisher Services uses:
+
+```text
+DistributionPlatform
+```
+
+as a PostgreSQL, Rust and GraphQL enum.
+
+Its code-owned descriptor defines:
+
+- display name;
+- linked distribution platforms;
+- delivery adapter;
+- back-catalogue behaviour;
+- update/withdrawal support where applicable.
+
+Thoth Metrics uses:
+
+```text
+MetricPlatform
+```
+
+backed by `metric_platform` rows with stable codes.
+
+Its registry defines:
+
+- display name;
+- ownership class;
+- enabled state;
+- supported measures through platform/measure mappings;
+- source accounts and acquisition routes.
+
+### 4.2 No name-based conversion
+
+There is no automatic conversion between the types.
+
+Do not:
+
+- cast enum names;
+- compare display labels;
+- reuse one GraphQL enum for both;
+- assume identical codes imply a relationship;
+- infer metrics ownership from distribution assignment;
+- infer distribution eligibility from metric source configuration.
+
+### 4.3 OAPEN and DOAB
+
+Within the distribution domain:
+
+- OAPEN and DOAB remain separate enum values;
+- linked normalization ensures they are enabled/disabled together initially;
+- one logical multi-target job maps to the shared adapter;
+- enabling both must not upload twice.
+
+Within the metrics domain:
+
+- an OAPEN metric platform is independent;
+- DOAB is not automatically created, linked or aggregated;
+- any DOAB metrics support requires its own verified source and metric-platform decision.
+
+### 4.4 API boundaries
+
+Use separate GraphQL surfaces:
+
+```text
+distributionPlatformOptions
+metricPlatforms
+metricMeasures
+```
+
+The frontend consumes backend descriptors for each domain.
+
+A shared visual label component may be used, but it must receive a domain-specific descriptor and must not own business rules.
+
+### 4.5 Initial cross-domain mapping
+
+No cross-domain mapping column or table is added in the initial implementation.
+
+If a future requirement needs a relationship, the new ADR/task must define:
+
+- the exact consumer;
+- one-to-one, one-to-many or many-to-many cardinality;
+- ownership and migration;
+- whether the relation is historical or current;
+- authorization and public visibility;
+- effects on jobs, metrics queries and reconciliation.
+
+Until then, the absence of a mapping is intentional.
+
+## 5. Consequences
+
+### Positive
+
+- Correct separation of desired delivery and observed activity.
+- Distribution adapter mapping remains exhaustive.
+- Metrics platforms can evolve without Rust enum migrations for every source.
+- Linked distribution behaviour cannot leak into metrics.
+- Metrics-only and distribution-only platforms are natural.
+- Cross-domain coupling requires explicit review.
+
+### Negative
+
+- Similar platform names exist in separate registries.
+- Combined administration may need two selectors.
+- Future cross-domain reports require an explicit mapping design.
+
+### Risks
+
+- Developers may still assume code-name equality.
+- UI code may accidentally duplicate descriptors.
+- A future mapping may be added informally without an ADR.
+
+## 6. Invariants created by this decision
+
+1. `DistributionPlatform` and `MetricPlatform` are different domain types.
+2. One cannot be substituted for the other.
+3. Display names are not identifiers.
+4. OAPEN/DOAB linkage exists only in distribution configuration unless separately approved.
+5. Package changes do not create or remove values in either platform registry.
+6. Distribution assignments do not authorize metrics uploads.
+7. Metrics source accounts do not enable dissemination.
+8. No initial cross-domain mapping table exists.
+
+## 7. Implementation impact
+
+Publisher Services:
+
+- finalize `DistributionPlatform` through its platform-inventory ADR;
+- implement exhaustive descriptors and adapter mapping;
+- expose separate distribution GraphQL options.
+
+Thoth Metrics:
+
+- implement `metric_platform` and `metric_platform_measure`;
+- use stable data codes;
+- keep source-account configuration separate from publisher distribution assignments.
+
+Clients:
+
+- use domain-specific generated types;
+- do not merge option arrays by matching code or label;
+- render linkage only from the relevant backend descriptor.
+
+Migrations:
+
+- distribution enum and assignment tables are separate from metric tables;
+- no cross-domain foreign key or mapping table in the initial design.
+
+## 8. Validation
+
+Required evidence:
+
+- compile-time exhaustive distribution descriptor coverage;
+- tests that OAPEN/DOAB produce one logical delivery adapter execution;
+- tests that metrics OAPEN is not automatically linked to DOAB;
+- tests that distribution assignment does not grant metric import;
+- tests that metric source configuration does not enable distribution;
+- GraphQL schema review showing separate types;
+- search proving no name-based conversion helpers were introduced.
+
+## 9. Rollout and rollback
+
+Rollout:
+
+- implement each domain independently;
+- keep new code additive and inactive;
+- compare legacy distribution configuration before cutover;
+- load metrics platform registry only with verified mappings.
+
+Rollback:
+
+- disable the affected domain feature;
+- retain separate persisted configuration;
+- do not merge registries as a rollback shortcut.
+
+## 10. Approval
+
+Approval required from: CTO  
+Approved by:  
+Approval date:  
+Notes:

--- a/docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
+++ b/docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
@@ -1,11 +1,11 @@
 # ADR-0002 - Distribution and Metrics Platform Domain Boundaries
 
-Status: PROPOSED  
-Date: 2026-07-24  
-Decision owner: CTO  
-Programmes affected: Publisher Services, Thoth Metrics  
-Repositories affected: `thoth`, `thoth-app`, `thoth-dissemination`, `thoth-sphinx`, `metrics-dashboard`, `metrics-widget`  
-Supersedes: None  
+Status: PROPOSED
+Date: 2026-07-24
+Decision owner: CTO
+Programmes affected: Publisher Services, Thoth Metrics
+Repositories affected: `thoth`, `thoth-app`, `thoth-dissemination`, `thoth-sphinx`, `metrics-dashboard`, `metrics-widget`
+Supersedes: None
 Superseded by: None
 
 ## 1. Context
@@ -292,7 +292,7 @@ Rollback:
 
 ## 10. Approval
 
-Approval required from: CTO  
-Approved by:  
-Approval date:  
+Approval required from: CTO
+Approved by:
+Approval date:
 Notes:

--- a/docs/engineering/decisions/README.md
+++ b/docs/engineering/decisions/README.md
@@ -1,0 +1,64 @@
+# Engineering Decisions
+
+Status: ACTIVE decision process  
+Owner: CTO
+
+This directory contains cross-programme Architecture Decision Records and their normative appendices.
+
+## Authority
+
+An ADR is authoritative only when its status is `APPROVED`.
+
+Statuses:
+
+- `PROPOSED` - complete recommendation awaiting the named decision owner;
+- `APPROVED` - implementation may rely on the decision;
+- `SUPERSEDED` - replaced by another approved ADR;
+- `REJECTED` - considered and not adopted.
+
+Committing a proposed ADR does not approve it.
+
+## Current decisions
+
+See `decision-register.md`.
+
+## Numbering
+
+Use:
+
+```text
+ADR-NNNN-short-title.md
+```
+
+Numbers are repository-wide and never reused.
+
+## Required content
+
+Each ADR must identify:
+
+- decision owner;
+- affected programmes and repositories;
+- context and decision drivers;
+- options considered;
+- exact decision;
+- invariants;
+- implementation impact;
+- migration, rollout and rollback effects;
+- validation evidence;
+- approval state.
+
+## Cross-programme rule
+
+A programme conversation may propose a cross-programme decision, but only the CTO control process may approve it.
+
+Implementation must stop when it depends on a proposed decision that has not been approved.
+
+## Amendments
+
+Before implementation starts, a proposed ADR may be edited in place.
+
+After approval:
+
+- material architectural changes require a new ADR that supersedes the old one;
+- factual clarifications may update the ADR only when they do not alter the decision;
+- every update follows normal review and changelog requirements.

--- a/docs/engineering/decisions/README.md
+++ b/docs/engineering/decisions/README.md
@@ -1,6 +1,6 @@
 # Engineering Decisions
 
-Status: ACTIVE decision process  
+Status: ACTIVE decision process
 Owner: CTO
 
 This directory contains cross-programme Architecture Decision Records and their normative appendices.

--- a/docs/engineering/decisions/decision-register.md
+++ b/docs/engineering/decisions/decision-register.md
@@ -1,0 +1,37 @@
+# Engineering Decision Register
+
+Status: ACTIVE  
+Owner: CTO  
+Last updated: 2026-07-24
+
+| ADR | Decision | Status | Programmes | Approval blocker |
+|---|---|---|---|---|
+| `ADR-0001` | Publisher package capability model | PROPOSED | Publisher Services, Thoth Metrics, OAI-PMH | CTO approval of ownership, matrix and upgrade/export semantics |
+| `ADR-0002` | Distribution and metrics platform domain boundaries | PROPOSED | Publisher Services, Thoth Metrics | CTO approval of strict type separation and no initial cross-domain mapping |
+
+## Merge and implementation rules
+
+These ADRs may be committed as part of the engineering-control foundation while `PROPOSED`.
+
+No implementation task may rely on them until:
+
+1. the CTO explicitly approves the relevant decision;
+2. the ADR status is changed to `APPROVED`;
+3. the approval date and approver are recorded;
+4. the changed ADR receives independent review;
+5. the approved version is merged into `develop`.
+
+## Approval sequence
+
+Approve `ADR-0001` before:
+
+- Publisher Services `BE-01`;
+- metrics entitlement implementation;
+- protected metrics serving;
+- OAI package-gating implementation.
+
+Approve `ADR-0002` before:
+
+- Publisher Services `BE-02`;
+- Thoth Metrics platform-registry implementation;
+- any shared platform abstraction or mapping.

--- a/docs/engineering/decisions/decision-register.md
+++ b/docs/engineering/decisions/decision-register.md
@@ -1,7 +1,7 @@
 # Engineering Decision Register
 
-Status: ACTIVE  
-Owner: CTO  
+Status: ACTIVE
+Owner: CTO
 Last updated: 2026-07-24
 
 | ADR | Decision | Status | Programmes | Approval blocker |

--- a/docs/engineering/decisions/package-capability-matrix.md
+++ b/docs/engineering/decisions/package-capability-matrix.md
@@ -1,7 +1,7 @@
 # Package Capability Matrix
 
-Status: PROPOSED  
-Normative owner after approval: `ADR-0001`  
+Status: PROPOSED
+Normative owner after approval: `ADR-0001`
 Decision owner: CTO
 
 ## 1. Package order

--- a/docs/engineering/decisions/package-capability-matrix.md
+++ b/docs/engineering/decisions/package-capability-matrix.md
@@ -1,0 +1,157 @@
+# Package Capability Matrix
+
+Status: PROPOSED  
+Normative owner after approval: `ADR-0001`  
+Decision owner: CTO
+
+## 1. Package order
+
+The initial packages are:
+
+```text
+OASIS
+OBELISK
+SPHINX
+PYRAMID
+```
+
+OASIS is the non-null default.
+
+This matrix does not make package selection imply distribution-platform assignments.
+
+## 2. Capability codes
+
+| Capability | Meaning |
+|---|---|
+| `OAI_PMH` | Publisher works may be considered for OAI-PMH after work-level open-licence and lifecycle checks |
+| `METRICS_COLLECT` | Thoth-managed drivers may collect and retain canonical metrics when a source account and platform/measure configuration are enabled |
+| `METRICS_IMPORT` | Publisher users may submit approved publisher-controlled usage or sales reports |
+| `METRICS_DASHBOARD` | A Thoth-owned authenticated service may serve publisher dashboard metrics |
+| `METRICS_WIDGET` | A Thoth-owned authenticated service may serve bounded work-level widget metrics |
+| `METRICS_OPERAS_EXPORT` | Eligible finalized canonical metrics may create and deliver OPERAS export claims |
+
+Capability codes are stable API identifiers. Display labels are separate.
+
+## 3. Recommended initial mapping
+
+| Package | OAI_PMH | METRICS_COLLECT | METRICS_IMPORT | METRICS_DASHBOARD | METRICS_WIDGET | METRICS_OPERAS_EXPORT |
+|---|---:|---:|---:|---:|---:|---:|
+| OASIS | No | Yes | No | No | No | No |
+| OBELISK | Yes | Yes | No | No | No | No |
+| SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
+| PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
+
+## 4. Rationale
+
+### Collection for every package
+
+`METRICS_COLLECT` is an internal collection permission, not a promise that metrics are served or exported.
+
+Collection still requires all of:
+
+- an enabled metric source account;
+- an enabled platform/measure mapping;
+- direct collection configured for that mapping;
+- an enabled operational schedule;
+- successful source-specific validation.
+
+Giving every package `METRICS_COLLECT` allows Thoth to retain history without exposing a paid service before entitlement.
+
+If this operational cost is not acceptable, the CTO may remove it from OASIS and/or OBELISK before approval.
+
+### SPHINX and PYRAMID metrics access
+
+The recommendation treats PYRAMID as including the metrics capabilities of SPHINX.
+
+If PYRAMID is intended to be a separate non-cumulative product rather than the highest package, its row must be amended before approval.
+
+### OAI-PMH
+
+OAI package eligibility follows the approved Publisher Services design:
+
+- OASIS is excluded;
+- OBELISK, SPHINX and PYRAMID may be eligible;
+- work-level licence and lifecycle rules still apply.
+
+## 5. Effective-entitlement rules
+
+A capability is effective only when:
+
+1. the publisher's current package grants it;
+2. any feature-specific configuration also permits it;
+3. the caller has the required user or service authorization;
+4. operational rollout has enabled the feature.
+
+A package capability alone must never:
+
+- enable a distribution platform;
+- create a distribution job;
+- create a metric source account;
+- activate a driver schedule;
+- bypass publisher-platform upload approval;
+- bypass work-level licence or lifecycle checks.
+
+## 6. Upgrade behaviour
+
+Recommended behaviour:
+
+- changing to SPHINX or PYRAMID enables dashboard and widget access to retained canonical history;
+- existing retained history is not rewritten;
+- future publisher imports become available after the package change;
+- new finalized eligible metric revisions may be exported to OPERAS;
+- existing historical metric revisions do not automatically create a bulk OPERAS export.
+
+Historical OPERAS export requires a separate, bounded, reviewed administrative backfill with:
+
+- explicit publisher and date scope;
+- dry run;
+- expected record count;
+- idempotency;
+- rate limits;
+- reconciliation;
+- rollback/stop procedure;
+- CTO activation approval.
+
+## 7. Downgrade behaviour
+
+Recommended behaviour:
+
+- canonical metric history is retained;
+- collection may continue while `METRICS_COLLECT` remains present;
+- new publisher imports are denied;
+- dashboard and widget service responses are denied;
+- no new OPERAS export work is created or delivered;
+- distribution assignments remain unchanged;
+- no canonical records are deleted.
+
+In-flight work must re-check entitlement at the final write/delivery boundary and fail closed.
+
+## 8. Implementation tests
+
+An implementation of this matrix must test every package/capability pair.
+
+It must also test:
+
+- OASIS default for existing and new publishers;
+- package changes do not modify distribution assignments;
+- package changes do not create distribution jobs;
+- publisher users cannot edit packages;
+- non-owner publisher users cannot read another publisher's package/capabilities;
+- superusers can read and change package configuration;
+- metrics service checks use capabilities rather than package-name comparisons;
+- OAI eligibility uses `OAI_PMH` plus licence/lifecycle checks;
+- retained metrics remain inaccessible without dashboard/widget capability;
+- upgrade does not enqueue uncontrolled historical OPERAS exports;
+- downgrade stops new protected serving/export without deleting data.
+
+## 9. Approval checklist
+
+The CTO must explicitly confirm:
+
+- [ ] OASIS has `METRICS_COLLECT`.
+- [ ] OBELISK has `METRICS_COLLECT` but no metrics serving/import/export.
+- [ ] SPHINX has all metrics capabilities.
+- [ ] PYRAMID includes all SPHINX metrics capabilities.
+- [ ] Retained history becomes visible after upgrade.
+- [ ] Historical OPERAS export requires an explicit backfill.
+- [ ] Downgrade retains canonical data and does not change distribution assignments.

--- a/docs/engineering/design-references.md
+++ b/docs/engineering/design-references.md
@@ -1,0 +1,41 @@
+
+# Approved Design References
+
+Status: PRIVATE, ACCESS-CONTROLLED SOURCES
+Owner: CTO
+Recorded: 2026-07-24
+
+The approved programme designs are not stored in this public repository.
+This index records their private Google Drive locations and the exact Drive
+revisions used by `CTRL-FOUNDATION-01`.
+
+An independent reviewer must be explicitly granted access. Lack of access is a
+review-evidence blocker and is not permission to reproduce the documents.
+
+## Publisher Services and Distribution Configuration
+
+- Private document: [Google Doc](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit)
+- Drive file ID: `1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8`
+- Reviewed revision ID: `3`
+- Revision modified: `2026-07-23T20:32:36.556Z`
+- Source status: `Approved for phased implementation`
+
+## Thoth Metrics
+
+- Private document: [Google Doc](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit)
+- Drive file ID: `11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0`
+- Reviewed revision ID: `6`
+- Revision modified: `2026-07-23T20:58:08.917Z`
+
+## Review procedure
+
+The authorized reviewer must:
+
+1. open each private document;
+2. confirm its Drive file ID;
+3. confirm the recorded revision ID and modification time through Drive
+   revision history or the connected Drive revision API;
+4. review repository controls against that exact version;
+5. report later source changes separately.
+
+No design body, export, conversion or content hash is committed.

--- a/docs/engineering/repository-map/README.md
+++ b/docs/engineering/repository-map/README.md
@@ -1,0 +1,31 @@
+# Repository and Environment Map
+
+Status: Verified 2026-07-24  
+Owner: CTO
+
+This directory records the repository, branch, build, CI, release and deployment boundaries required for AI-led delivery.
+
+## Files
+
+- `branch-topology.md` - observed branch state, desired standard and normalization gates.
+- `environments.md` - verified runtime, preview and release boundaries.
+- `control-gaps.md` - missing controls and required follow-up tasks.
+- `repositories/thoth.md`
+- `repositories/thoth-app.md`
+- `repositories/thoth-dissemination.md`
+- `repositories/thoth-sphinx.md`
+- `repositories/metrics-dashboard.md`
+- `repositories/metrics-widget.md`
+- `repositories/cc-license.md`
+
+## Usage rule
+
+At the start of every task:
+
+1. read the relevant repository file;
+2. verify the current branch and head commit directly;
+3. verify commands against the current repository;
+4. report any difference from this map;
+5. update this map through a reviewed documentation task when durable repository behaviour changes.
+
+This map is not a substitute for live GitHub state.

--- a/docs/engineering/repository-map/README.md
+++ b/docs/engineering/repository-map/README.md
@@ -1,6 +1,6 @@
 # Repository and Environment Map
 
-Status: Verified 2026-07-24  
+Status: Verified 2026-07-24
 Owner: CTO
 
 This directory records the repository, branch, build, CI, release and deployment boundaries required for AI-led delivery.

--- a/docs/engineering/repository-map/branch-topology.md
+++ b/docs/engineering/repository-map/branch-topology.md
@@ -38,7 +38,7 @@ The Metrics design requires one repository-local `feature/metrics` integration b
 | `thoth` | `master` | `develop` | `develop -> master` | conforms |
 | `thoth-app` | `main` | `dev` | `dev -> main` | normalization required |
 | `thoth-dissemination` | `main` | `develop` | `develop -> main` | release-branch normalization required |
-| `thoth-sphinx` | `main` | `develop` | none; repository empty | `master`/protection/bootstrap required |
+| `thoth-sphinx` | `main` | `develop` | none; placeholder-only README | `master`/protection/bootstrap required |
 | `metrics-dashboard` | `main` | `develop` | `develop -> main` | release/Vercel normalization required |
 | `metrics-widget` | `main` | `dev` | releases from `main` | normalization required |
 | `cc-license` | `main` | `develop` | release branch `main` | release-branch normalization required |

--- a/docs/engineering/repository-map/branch-topology.md
+++ b/docs/engineering/repository-map/branch-topology.md
@@ -1,126 +1,135 @@
 # Branch Topology
 
-Status: Verified observed state plus approved target policy
+Status: VERIFIED OBSERVED STATE PLUS APPROVED TARGET POLICY
 Evidence date: 2026-07-24
 
-## 1. Approved target policy
+## 1. Target repository policy
 
-Thoth's target GitHub Flow is:
+Normal task flow:
 
 ```text
 feature/<area>/<task> -> develop -> master
 ```
 
-Large programme flow:
+Approved programme-integration flow:
 
 ```text
 feature/<programme>/<slice> -> feature/<programme> -> develop -> master
 ```
 
-`develop` is the development integration branch.
-`master` is the release/default branch.
-Merged task and slice branches are deleted.
+`develop` is the target development branch. `master` is the target release/default branch. Merged task and slice branches are deleted.
 
-## 2. Observed state
+An approved programme design decides whether it uses direct task PRs or a programme integration branch.
 
-| Repository | GitHub default | Active development | Observed release flow | Conforms |
+## 2. Programme-specific policy
+
+### Publisher Services
+
+The approved design requires one fresh branch and one PR per task. Each task targets the repository's verified development branch. There is no long-lived `feature/publisher-services` branch.
+
+### Thoth Metrics
+
+The Metrics design requires one repository-local `feature/metrics` integration branch per affected repository after branch readiness. Bounded child branches target that integration branch, followed by a final repository-local PR to `develop`.
+
+## 3. Observed state
+
+| Repository | GitHub default | Active development | Observed release flow | Target-policy state |
 |---|---|---|---|---|
-| `thoth` | `master` | `develop` | `develop -> master` | yes |
-| `thoth-app` | `main` | `dev` | `dev -> main` | no |
-| `thoth-dissemination` | `main` | `develop` | `develop -> main` | partial |
-| `thoth-sphinx` | `main` | none | none | no |
-| `metrics-dashboard` | `main` | `develop` | `develop -> main` | partial |
-| `metrics-widget` | `main` | `dev` | releases from `main` | no |
-| `cc-license` | `main` | `develop` | release branch `main` | partial |
+| `thoth` | `master` | `develop` | `develop -> master` | conforms |
+| `thoth-app` | `main` | `dev` | `dev -> main` | normalization required |
+| `thoth-dissemination` | `main` | `develop` | `develop -> main` | release-branch normalization required |
+| `thoth-sphinx` | `main` | `develop` | none; repository empty | `master`/protection/bootstrap required |
+| `metrics-dashboard` | `main` | `develop` | `develop -> main` | release/Vercel normalization required |
+| `metrics-widget` | `main` | `dev` | releases from `main` | normalization required |
+| `cc-license` | `main` | `develop` | release branch `main` | release-branch normalization required |
 
-## 3. Control rule
+## 4. Control rule
 
-A task specification must record:
+Every task specification records:
 
-- observed base branch;
-- observed PR target;
-- desired target;
-- whether a normalization task has completed;
-- whether an approved temporary exception is being used.
+- verified existing base branch;
+- verified PR target;
+- approved target topology;
+- normalization dependency or temporary CTO exception;
+- programme workflow: `STANDARD` or `PROGRAMME_INTEGRATION`.
 
-No agent may create a branch from a name that has not been verified to exist.
+No agent creates a branch from a name that has not been verified to exist.
 
-## 4. Required normalization tasks
+## 5. Required normalization tasks
 
 ### BR-APP-01 - Normalize `thoth-app`
 
 - create `master` from current `main`;
 - create or rename `develop` from current `dev`;
-- update GitHub default branch and branch protections;
+- update default branch and protections;
 - update Vercel production branch from `main` to `master`;
-- verify previews build from feature/develop branches;
-- preserve rollback to the last `main` production deployment;
-- update documentation and CI branch filters;
-- retain `main` and `dev` temporarily until references are verified.
+- verify previews from feature/develop branches;
+- preserve rollback to the last `main` deployment;
+- retain `main` and `dev` until references are verified.
 
-Risk: High because Vercel production deployment routing changes.
+Risk: HIGH because Vercel production routing changes.
 
 ### BR-DIS-01 - Normalize `thoth-dissemination`
 
 - create `master` from current `main`;
-- keep current `develop`;
-- update GitHub default branch and protections;
-- verify release/tag workflows;
-- verify operational workflows that explicitly require `develop`;
-- retain `main` temporarily until external references are checked.
+- retain `develop`;
+- update default branch and protections;
+- verify release/tag and production-write workflows;
+- retain `main` until external references are checked.
 
-Risk: High because the repository contains production external-write workflows.
+Risk: HIGH because the repository contains production external-write workflows.
 
-### BR-SPHINX-01 - Establish `thoth-sphinx` topology
+### BR-SPHINX-01 - Complete `thoth-sphinx` topology
 
 - create `master` from current `main`;
+- retain the existing `develop` branch;
+- align `develop` with the approved bootstrap base before implementation;
 - make `master` the release/default branch;
-- create `develop` from `master`;
-- add branch protections;
-- perform repository bootstrap on a task branch from `develop`;
-- delete `main` only after references are confirmed absent.
+- add protections to `master` and `develop`;
+- perform SPHINX-BOOT-01 on a task branch from `develop`;
+- retain `main` until references are confirmed absent.
 
-Risk: Medium before runtime exists.
+Risk: MEDIUM before runtime exists.
 
 ### BR-DASH-01 - Normalize `metrics-dashboard`
 
 - create `master` from current `main`;
-- retain current `develop`;
-- update Vercel production branch to `master`;
-- update default branch and protections;
-- verify preview and production domains;
-- retain `main` temporarily through an observation window.
+- retain `develop`;
+- update Vercel production branch, default branch and protections;
+- verify preview/production domains;
+- retain `main` through an observation window.
 
-Risk: High because production deployment routing changes.
+Risk: HIGH because production deployment routing changes.
 
 ### BR-WIDGET-01 - Normalize `metrics-widget`
 
 - create `master` from current `main`;
 - create or rename `develop` from `dev`;
-- update CI branch filters;
+- update CI filters;
 - preserve GitHub-release-to-npm publishing;
-- verify release-tag checkout uses `master`;
-- retain old branches temporarily until consumers and automation are verified.
+- verify release tags use `master`;
+- retain old branches until automation/consumers are verified.
 
-Risk: High because release automation publishes a public npm package.
+Risk: HIGH because release automation publishes a public package.
 
 ### BR-LIC-01 - Normalize `cc-license`
 
 - create `master` from current `main`;
-- retain current `develop`;
-- update CI branch filters and default branch;
-- verify crate publication procedure;
-- retain `main` temporarily until release references are checked.
+- retain `develop`;
+- update CI filters and default branch;
+- verify crate publication;
+- retain `main` until release references are checked.
 
-Risk: Medium.
+Risk: MEDIUM.
 
-## 5. Programme integration branches
+## 6. Programme branch readiness
 
-Do not create `feature/publisher-services` or `feature/metrics` in a repository until:
+Publisher Services tasks may begin only when their repository's actual development branch and PR target are verified. They use standard task branches, not a programme branch.
 
-- the repository has a verified development branch;
-- branch normalization is complete or a CTO-approved exception is recorded;
-- the programme control documents exist;
+A repository-local Metrics `feature/metrics` branch may be created only when:
+
+- that repository has a verified `develop` branch;
+- normalization is complete or a CTO exception is recorded;
+- Metrics control task `MET-CTRL-01` is merged;
+- required shared ADRs are approved;
 - CI can validate the intended slices.
-
-`thoth` may create programme branches from `develop` once CTRL-01/CTRL-02 and the relevant programme-control task are approved.

--- a/docs/engineering/repository-map/branch-topology.md
+++ b/docs/engineering/repository-map/branch-topology.md
@@ -39,7 +39,7 @@ The Metrics design requires one repository-local `feature/metrics` integration b
 | `thoth-app` | `main` | `dev` | `dev -> main` | normalization required |
 | `thoth-dissemination` | `main` | `develop` | `develop -> main` | release-branch normalization required |
 | `thoth-sphinx` | `main` | `develop` | none; placeholder-only README | `master`/protection/bootstrap required |
-| `metrics-dashboard` | `main` | `develop` | `develop -> main` | release/Vercel normalization required |
+| `metrics-dashboard` | `main` | `dev` | `dev -> main` | development/release/Vercel normalization required |
 | `metrics-widget` | `main` | `dev` | releases from `main` | normalization required |
 | `cc-license` | `main` | `develop` | release branch `main` | release-branch normalization required |
 
@@ -93,11 +93,18 @@ Risk: MEDIUM before runtime exists.
 
 ### BR-DASH-01 - Normalize `metrics-dashboard`
 
-- create `master` from current `main`;
-- retain `develop`;
-- update Vercel production branch, default branch and protections;
-- verify preview/production domains;
-- retain `main` through an observation window.
+- verify `dev`, `develop`, `main`, recent merged pull requests and Vercel branch
+  settings;
+- reconcile the active `dev` history into the target `develop` branch, using a
+  fast-forward only when Git proves it is safe;
+- otherwise use a separately reviewed merge or replacement plan that preserves
+  history;
+- create `master` from the verified current `main`;
+- update the default branch, protections and Vercel production branch only under
+  this separately approved HIGH-risk task;
+- retain `main`, `dev` and the old `develop` reference until all external
+  references and rollback requirements are verified;
+- prohibit creation of `feature/metrics` from stale `develop`.
 
 Risk: HIGH because production deployment routing changes.
 

--- a/docs/engineering/repository-map/branch-topology.md
+++ b/docs/engineering/repository-map/branch-topology.md
@@ -1,0 +1,126 @@
+# Branch Topology
+
+Status: Verified observed state plus approved target policy  
+Evidence date: 2026-07-24
+
+## 1. Approved target policy
+
+Thoth's target GitHub Flow is:
+
+```text
+feature/<area>/<task> -> develop -> master
+```
+
+Large programme flow:
+
+```text
+feature/<programme>/<slice> -> feature/<programme> -> develop -> master
+```
+
+`develop` is the development integration branch.  
+`master` is the release/default branch.  
+Merged task and slice branches are deleted.
+
+## 2. Observed state
+
+| Repository | GitHub default | Active development | Observed release flow | Conforms |
+|---|---|---|---|---|
+| `thoth` | `master` | `develop` | `develop -> master` | yes |
+| `thoth-app` | `main` | `dev` | `dev -> main` | no |
+| `thoth-dissemination` | `main` | `develop` | `develop -> main` | partial |
+| `thoth-sphinx` | `main` | none | none | no |
+| `metrics-dashboard` | `main` | `develop` | `develop -> main` | partial |
+| `metrics-widget` | `main` | `dev` | releases from `main` | no |
+| `cc-license` | `main` | `develop` | release branch `main` | partial |
+
+## 3. Control rule
+
+A task specification must record:
+
+- observed base branch;
+- observed PR target;
+- desired target;
+- whether a normalization task has completed;
+- whether an approved temporary exception is being used.
+
+No agent may create a branch from a name that has not been verified to exist.
+
+## 4. Required normalization tasks
+
+### BR-APP-01 - Normalize `thoth-app`
+
+- create `master` from current `main`;
+- create or rename `develop` from current `dev`;
+- update GitHub default branch and branch protections;
+- update Vercel production branch from `main` to `master`;
+- verify previews build from feature/develop branches;
+- preserve rollback to the last `main` production deployment;
+- update documentation and CI branch filters;
+- retain `main` and `dev` temporarily until references are verified.
+
+Risk: High because Vercel production deployment routing changes.
+
+### BR-DIS-01 - Normalize `thoth-dissemination`
+
+- create `master` from current `main`;
+- keep current `develop`;
+- update GitHub default branch and protections;
+- verify release/tag workflows;
+- verify operational workflows that explicitly require `develop`;
+- retain `main` temporarily until external references are checked.
+
+Risk: High because the repository contains production external-write workflows.
+
+### BR-SPHINX-01 - Establish `thoth-sphinx` topology
+
+- create `master` from current `main`;
+- make `master` the release/default branch;
+- create `develop` from `master`;
+- add branch protections;
+- perform repository bootstrap on a task branch from `develop`;
+- delete `main` only after references are confirmed absent.
+
+Risk: Medium before runtime exists.
+
+### BR-DASH-01 - Normalize `metrics-dashboard`
+
+- create `master` from current `main`;
+- retain current `develop`;
+- update Vercel production branch to `master`;
+- update default branch and protections;
+- verify preview and production domains;
+- retain `main` temporarily through an observation window.
+
+Risk: High because production deployment routing changes.
+
+### BR-WIDGET-01 - Normalize `metrics-widget`
+
+- create `master` from current `main`;
+- create or rename `develop` from `dev`;
+- update CI branch filters;
+- preserve GitHub-release-to-npm publishing;
+- verify release-tag checkout uses `master`;
+- retain old branches temporarily until consumers and automation are verified.
+
+Risk: High because release automation publishes a public npm package.
+
+### BR-LIC-01 - Normalize `cc-license`
+
+- create `master` from current `main`;
+- retain current `develop`;
+- update CI branch filters and default branch;
+- verify crate publication procedure;
+- retain `main` temporarily until release references are checked.
+
+Risk: Medium.
+
+## 5. Programme integration branches
+
+Do not create `feature/publisher-services` or `feature/metrics` in a repository until:
+
+- the repository has a verified development branch;
+- branch normalization is complete or a CTO-approved exception is recorded;
+- the programme control documents exist;
+- CI can validate the intended slices.
+
+`thoth` may create programme branches from `develop` once CTRL-01/CTRL-02 and the relevant programme-control task are approved.

--- a/docs/engineering/repository-map/branch-topology.md
+++ b/docs/engineering/repository-map/branch-topology.md
@@ -1,6 +1,6 @@
 # Branch Topology
 
-Status: Verified observed state plus approved target policy  
+Status: Verified observed state plus approved target policy
 Evidence date: 2026-07-24
 
 ## 1. Approved target policy
@@ -17,8 +17,8 @@ Large programme flow:
 feature/<programme>/<slice> -> feature/<programme> -> develop -> master
 ```
 
-`develop` is the development integration branch.  
-`master` is the release/default branch.  
+`develop` is the development integration branch.
+`master` is the release/default branch.
 Merged task and slice branches are deleted.
 
 ## 2. Observed state

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -3,74 +3,64 @@
 Status: Active findings  
 Evidence date: 2026-07-24
 
+## Foundation closeout
+
+### CG-01 - Independent review of PR #764
+
+The engineering-control foundation is implemented but not independently approved. Required: final diff/CI review, finding resolution, CTO merge approval and merge into `develop`.
+
+### CG-02 - External Metrics design spelling
+
+Repository documents use `thoth-sphinx` / `Sphinx`. The external Metrics design source still needs correction and Project-source replacement.
+
 ## Blocking before programme implementation
 
-### CG-01 - Incorrect Sphinx naming in authoritative design
+### CG-03 - `thoth-sphinx` is empty
 
-Canonical: `thoth-sphinx` / `Sphinx`. Correct the Metrics design source and replace the Project source.
+Bootstrap before WP6 or driver work.
 
-### CG-02 - `thoth-sphinx` is empty
+### CG-04 - Branch topology differs
 
-No workspace, CI, tests, branch topology, instructions or release boundary. Bootstrap before WP6/drivers.
+Use actual branches until normalization or explicit exceptions.
 
-### CG-03 - Branch topology differs
+### CG-05 - Related repositories lack complete instructions
 
-Use actual branches until normalization/exception tasks complete.
+App, Sphinx, dashboard, widget and cc-license remain outstanding. Dissemination has incomplete controls.
 
-### CG-04 - Repository-local instructions incomplete
+### CG-06 - Shared ADRs remain proposed
 
-Thoth hierarchy is in PR #764. Dissemination has partial instructions. App, Sphinx, dashboard, widget and cc-license still need root instructions.
+ADR-0001 and ADR-0002 require CTO approval and independent review.
 
-### CG-05 - Shared ADRs unapproved
+### CG-07 - Publisher Services platform ADR open
 
-ADR-0001 and ADR-0002 remain proposed. Do not start dependent implementation.
+Issue #765 exists. ADR-01 must finalize enum, mappings and ambiguous destinations.
 
-### CG-06 - Publisher Services controls incomplete
+### CG-08 - Metrics readiness open
 
-Documents exist, but P0-01 needs master issue, recorded number, independent approval/merge and final ADR blockers. ADR-01 must finalize distribution enum.
+Issue #766 exists. Sphinx bootstrap, Diesel control, branch readiness and service-role decisions remain prerequisites.
 
-### CG-07 - Metrics controls incomplete
-
-Documents exist, but MET-CTRL-01 needs master issue, recorded number, independent approval/merge and final ADR blockers. Implementation remains blocked on Sphinx bootstrap, Diesel control and branch readiness.
-
-## Required before production slices
-
-### CG-08 - Metrics service roles unapproved
-
-Approve role codes/scope/rotation/audit before WP5. Do not use superuser as a shortcut.
+## Production-slice controls
 
 ### CG-09 - Source fixtures/mappings incomplete
 
-Representative period/dimension/regenerated files, COUNTER mappings, finalization settings and OPERAS projections are missing.
+Metrics fixtures, COUNTER mappings, finalization and OPERAS projections are missing.
 
 ### CG-10 - OPERAS inbound completeness unavailable
 
-No verified cursor, replication or complete snapshot. Rolling scans must state unverified completeness.
+No verified complete cursor, replication or snapshot route exists.
 
-### CG-11 - `thoth-app` CI incomplete
+### CG-11 - CI gaps
 
-Missing explicit lint, production build and codegen verification.
+App lacks explicit lint/build/codegen; dashboard lacks detected CI/tests; widget lacks unit tests; cc-license uses old Actions.
 
-### CG-12 - Dashboard CI/tests missing
+### CG-12 - Thoth schema generation unclear
 
-Add CI, transformation tests, lint/build and comparison fixtures.
+Resolve `thoth-api/src/schema.rs` versus root `diesel.toml` before schema changes.
 
-### CG-13 - Widget unit tests missing
+### CG-13 - Thoth runtime operations unmapped
 
-Add data/coverage/partial/rendering tests before migration/publication.
-
-### CG-14 - cc-license CI old
-
-Modernize in a bounded task.
-
-### CG-15 - Thoth schema generation unclear
-
-Resolve `thoth-api/src/schema.rs` vs root `diesel.toml` before migrations.
-
-### CG-16 - Thoth runtime operations unmapped
-
-Document runtime, deployment, migration execution, rollback, backup/restore and approvers.
+Document runtime, deployment, migration execution, rollback, restore verification and approvers.
 
 ## Verification gaps
 
-Branch protections, required checks, environment reviewers, crate publication, secret ownership, production DB config and Thoth hosting/rollback remain unverified. Missing evidence is missing work.
+Branch protections, required checks, environment reviewers, crate publication, secret ownership, production database configuration and Thoth hosting/rollback remain unverified. Missing evidence is missing work.

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -7,7 +7,7 @@ Evidence date: 2026-07-24
 
 ### CG-01 - Independent review of PR #764
 
-The engineering-control foundation has implementation and remediation work but is not independently approved. Required: completed implementation report, final diff/CI review, finding resolution, CTO merge approval and merge into `develop`.
+The engineering-control foundation has a completed implementation report through remediation head `104ffaa16b2436cea2b4e2779c241b016916f083` but is not independently approved. Required: final-head CI review, independent approval, CTO merge approval and merge into `develop`.
 
 ### CG-02 - External Metrics design spelling
 

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -1,6 +1,6 @@
 # Repository Control Gaps
 
-Status: Active findings  
+Status: Active findings
 Evidence date: 2026-07-24
 
 ## Foundation closeout

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -15,9 +15,9 @@ The private Metrics design contains an obsolete repository/component spelling. T
 
 ## Blocking before programme implementation
 
-### CG-03 - `thoth-sphinx` is empty
+### CG-03 - `thoth-sphinx` is placeholder-only
 
-`main` and `develop` exist, but the repository has no workspace, CI, protections or runtime. Complete BR-SPHINX-01 and SPHINX-BOOT-01 before WP6 or driver work.
+`main` and `develop` exist and contain only a placeholder README. The repository has no workspace, implementation, CI, protections or runtime. Complete BR-SPHINX-01 and SPHINX-BOOT-01 before WP6 or driver work.
 
 ### CG-04 - Branch topology differs
 

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -39,9 +39,25 @@ The following repositories still need root instructions:
 
 Track the rollout in `docs/engineering/agent-instructions/rollout-plan.md`.
 
+### CG-05 - Shared package and platform ADRs require CTO approval
+
+The following complete proposals exist:
+
+- `docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md`
+- `docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md`
+
+They remain `PROPOSED`.
+
+Do not start implementation that depends on either decision until the CTO:
+
+- approves or amends the package-capability matrix;
+- approves upgrade, downgrade and historical OPERAS export semantics;
+- approves strict separation of distribution and metrics platform types;
+- records the approval in the ADRs.
+
 ## Required before affected production slices
 
-### CG-05 - `thoth-app` CI is incomplete
+### CG-06 - `thoth-app` CI is incomplete
 
 Current GitHub CI runs coverage tests but does not independently run:
 
@@ -51,7 +67,7 @@ Current GitHub CI runs coverage tests but does not independently run:
 
 Vercel build success is useful evidence but is not a replacement for explicit repository CI gates.
 
-### CG-06 - `metrics-dashboard` lacks detected CI and tests
+### CG-07 - `metrics-dashboard` lacks detected CI and tests
 
 Before client migration:
 
@@ -60,23 +76,23 @@ Before client migration:
 - require lint and production build;
 - add comparison fixtures for old/new data paths.
 
-### CG-07 - `metrics-widget` lacks detected unit tests
+### CG-08 - `metrics-widget` lacks detected unit tests
 
 Current CI covers lint, build and consumer smoke only.
 
 Add tests for data fetching, coverage semantics, partial results and rendering before the canonical API migration.
 
-### CG-08 - `cc-license` CI uses old actions
+### CG-09 - `cc-license` CI uses old actions
 
 Modernize checkout/toolchain actions before or alongside LIC-01, without mixing functional licence changes into the CI-only PR.
 
-### CG-09 - Thoth schema generation is unclear
+### CG-10 - Thoth schema generation is unclear
 
 `thoth-api/src/schema.rs` exists, but the root `diesel.toml` declares `src/schema.rs`.
 
 Confirm and document the canonical command and working directory before metrics or publisher-service migrations.
 
-### CG-10 - Thoth runtime operations are not mapped
+### CG-11 - Thoth runtime operations are not mapped
 
 Document:
 

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -7,125 +7,70 @@ Evidence date: 2026-07-24
 
 ### CG-01 - Incorrect Sphinx naming in authoritative design
 
-The canonical component is `thoth-sphinx` / `Sphinx`.
-
-The Thoth Metrics design uses an obsolete spelling for the Sphinx repository and component. Correct the source document and replace the Project source rather than retaining two versions.
+Canonical: `thoth-sphinx` / `Sphinx`. Correct the Metrics design source and replace the Project source.
 
 ### CG-02 - `thoth-sphinx` is empty
 
-The repository has no workspace, CI, tests, branch topology, agent instructions or release boundary.
+No workspace, CI, tests, branch topology, instructions or release boundary. Bootstrap before WP6/drivers.
 
-A bootstrap specification is required.
+### CG-03 - Branch topology differs
 
-### CG-03 - Branch topology differs from approved policy
+Use actual branches until normalization/exception tasks complete.
 
-See `branch-topology.md`.
+### CG-04 - Repository-local instructions incomplete
 
-Agents must use actual branches until explicit normalization tasks complete.
+Thoth hierarchy is in PR #764. Dissemination has partial instructions. App, Sphinx, dashboard, widget and cc-license still need root instructions.
 
-### CG-04 - Repository-local AI instructions are incomplete
+### CG-05 - Shared ADRs unapproved
 
-The `thoth` repository instruction hierarchy is included in the engineering-control foundation PR.
+ADR-0001 and ADR-0002 remain proposed. Do not start dependent implementation.
 
-`thoth-dissemination` has an existing root `AGENTS.md`, but it does not yet include the complete control, authorization, operational and review requirements.
+### CG-06 - Publisher Services controls incomplete
 
-The following repositories still need root instructions:
+Documents exist, but P0-01 needs master issue, recorded number, independent approval/merge and final ADR blockers. ADR-01 must finalize distribution enum.
 
-- `thoth-app`
-- `thoth-sphinx`
-- `metrics-dashboard`
-- `metrics-widget`
-- `cc-license`
+### CG-07 - Metrics controls incomplete
 
-Track the rollout in `docs/engineering/agent-instructions/rollout-plan.md`.
+Documents exist, but MET-CTRL-01 needs master issue, recorded number, independent approval/merge and final ADR blockers. Implementation remains blocked on Sphinx bootstrap, Diesel control and branch readiness.
 
-### CG-05 - Shared package and platform ADRs require CTO approval
+## Required before production slices
 
-The following complete proposals exist:
+### CG-08 - Metrics service roles unapproved
 
-- `docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md`
-- `docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md`
+Approve role codes/scope/rotation/audit before WP5. Do not use superuser as a shortcut.
 
-They remain `PROPOSED`.
+### CG-09 - Source fixtures/mappings incomplete
 
-Do not start implementation that depends on either decision until the CTO:
+Representative period/dimension/regenerated files, COUNTER mappings, finalization settings and OPERAS projections are missing.
 
-- approves or amends the package-capability matrix;
-- approves upgrade, downgrade and historical OPERAS export semantics;
-- approves strict separation of distribution and metrics platform types;
-- records the approval in the ADRs.
+### CG-10 - OPERAS inbound completeness unavailable
 
-### CG-06 - Publisher Services control foundation is not complete
+No verified cursor, replication or complete snapshot. Rolling scans must state unverified completeness.
 
-The required repository documents exist under `docs/publisher-services/`.
+### CG-11 - `thoth-app` CI incomplete
 
-P0-01 remains incomplete until:
+Missing explicit lint, production build and codegen verification.
 
-- the master GitHub issue is created from `master-issue.md`;
-- its number is recorded in `task-status.md`;
-- PR #764 receives independent approval and merges;
-- ADR-0001 and ADR-0002 are approved or remain explicit implementation blockers.
+### CG-12 - Dashboard CI/tests missing
 
-Publisher Services ADR-01 must still finalize the distribution enum. The current platform inventory is a verified baseline, not an approved enum.
+Add CI, transformation tests, lint/build and comparison fixtures.
 
-## Required before affected production slices
+### CG-13 - Widget unit tests missing
 
-### CG-07 - `thoth-app` CI is incomplete
+Add data/coverage/partial/rendering tests before migration/publication.
 
-Current GitHub CI runs coverage tests but does not independently run:
+### CG-14 - cc-license CI old
 
-- lint;
-- production build;
-- GraphQL generation consistency.
+Modernize in a bounded task.
 
-Vercel build success is useful evidence but is not a replacement for explicit repository CI gates.
+### CG-15 - Thoth schema generation unclear
 
-### CG-08 - `metrics-dashboard` lacks detected CI and tests
+Resolve `thoth-api/src/schema.rs` vs root `diesel.toml` before migrations.
 
-Before client migration:
+### CG-16 - Thoth runtime operations unmapped
 
-- add CI;
-- add at least service/data transformation tests;
-- require lint and production build;
-- add comparison fixtures for old/new data paths.
-
-### CG-09 - `metrics-widget` lacks detected unit tests
-
-Current CI covers lint, build and consumer smoke only.
-
-Add tests for data fetching, coverage semantics, partial results and rendering before the canonical API migration.
-
-### CG-10 - `cc-license` CI uses old actions
-
-Modernize checkout/toolchain actions before or alongside LIC-01, without mixing functional licence changes into the CI-only PR.
-
-### CG-11 - Thoth schema generation is unclear
-
-`thoth-api/src/schema.rs` exists, but the root `diesel.toml` declares `src/schema.rs`.
-
-Confirm and document the canonical command and working directory before metrics or publisher-service migrations.
-
-### CG-12 - Thoth runtime operations are not mapped
-
-Document:
-
-- runtime platform;
-- deployment trigger;
-- database migration execution;
-- rollback;
-- backup/restore verification;
-- production approvers.
+Document runtime, deployment, migration execution, rollback, backup/restore and approvers.
 
 ## Verification gaps
 
-The connector did not verify:
-
-- branch-protection rules;
-- required GitHub checks;
-- environment reviewers;
-- current crate publication process;
-- all secret names or owners;
-- production database version/configuration;
-- Thoth API/export hosting.
-
-Missing evidence is missing work.
+Branch protections, required checks, environment reviewers, crate publication, secret ownership, production DB config and Thoth hosting/rollback remain unverified. Missing evidence is missing work.

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -23,11 +23,21 @@ See `branch-topology.md`.
 
 Agents must use actual branches until explicit normalization tasks complete.
 
-### CG-04 - Repository-local AI instructions missing
+### CG-04 - Repository-local AI instructions are incomplete
 
-Only `thoth-dissemination` has an `AGENTS.md`.
+The `thoth` repository instruction hierarchy is included in the engineering-control foundation PR.
 
-Create repository-specific files from this approved map in a separate bounded task per repository or a coordinated documentation rollout.
+`thoth-dissemination` has an existing root `AGENTS.md`, but it does not yet include the complete control, authorization, operational and review requirements.
+
+The following repositories still need root instructions:
+
+- `thoth-app`
+- `thoth-sphinx`
+- `metrics-dashboard`
+- `metrics-widget`
+- `cc-license`
+
+Track the rollout in `docs/engineering/agent-instructions/rollout-plan.md`.
 
 ## Required before affected production slices
 

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -1,0 +1,92 @@
+# Repository Control Gaps
+
+Status: Active findings  
+Evidence date: 2026-07-24
+
+## Blocking before programme implementation
+
+### CG-01 - Incorrect Sphinx naming in authoritative design
+
+The canonical component is `thoth-sphinx` / `Sphinx`.
+
+The Thoth Metrics design uses an obsolete spelling for the Sphinx repository and component. Correct the source document and replace the Project source rather than retaining two versions.
+
+### CG-02 - `thoth-sphinx` is empty
+
+The repository has no workspace, CI, tests, branch topology, agent instructions or release boundary.
+
+A bootstrap specification is required.
+
+### CG-03 - Branch topology differs from approved policy
+
+See `branch-topology.md`.
+
+Agents must use actual branches until explicit normalization tasks complete.
+
+### CG-04 - Repository-local AI instructions missing
+
+Only `thoth-dissemination` has an `AGENTS.md`.
+
+Create repository-specific files from this approved map in a separate bounded task per repository or a coordinated documentation rollout.
+
+## Required before affected production slices
+
+### CG-05 - `thoth-app` CI is incomplete
+
+Current GitHub CI runs coverage tests but does not independently run:
+
+- lint;
+- production build;
+- GraphQL generation consistency.
+
+Vercel build success is useful evidence but is not a replacement for explicit repository CI gates.
+
+### CG-06 - `metrics-dashboard` lacks detected CI and tests
+
+Before client migration:
+
+- add CI;
+- add at least service/data transformation tests;
+- require lint and production build;
+- add comparison fixtures for old/new data paths.
+
+### CG-07 - `metrics-widget` lacks detected unit tests
+
+Current CI covers lint, build and consumer smoke only.
+
+Add tests for data fetching, coverage semantics, partial results and rendering before the canonical API migration.
+
+### CG-08 - `cc-license` CI uses old actions
+
+Modernize checkout/toolchain actions before or alongside LIC-01, without mixing functional licence changes into the CI-only PR.
+
+### CG-09 - Thoth schema generation is unclear
+
+`thoth-api/src/schema.rs` exists, but the root `diesel.toml` declares `src/schema.rs`.
+
+Confirm and document the canonical command and working directory before metrics or publisher-service migrations.
+
+### CG-10 - Thoth runtime operations are not mapped
+
+Document:
+
+- runtime platform;
+- deployment trigger;
+- database migration execution;
+- rollback;
+- backup/restore verification;
+- production approvers.
+
+## Verification gaps
+
+The connector did not verify:
+
+- branch-protection rules;
+- required GitHub checks;
+- environment reviewers;
+- current crate publication process;
+- all secret names or owners;
+- production database version/configuration;
+- Thoth API/export hosting.
+
+Missing evidence is missing work.

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -1,27 +1,27 @@
 # Repository Control Gaps
 
-Status: Active findings
+Status: ACTIVE FINDINGS
 Evidence date: 2026-07-24
 
 ## Foundation closeout
 
 ### CG-01 - Independent review of PR #764
 
-The engineering-control foundation is implemented but not independently approved. Required: final diff/CI review, finding resolution, CTO merge approval and merge into `develop`.
+The engineering-control foundation has implementation and remediation work but is not independently approved. Required: completed implementation report, final diff/CI review, finding resolution, CTO merge approval and merge into `develop`.
 
 ### CG-02 - External Metrics design spelling
 
-Repository documents use `thoth-sphinx` / `Sphinx`. The external Metrics design source still needs correction and Project-source replacement.
+The private Metrics design contains an obsolete repository/component spelling. The exact Google Doc and Drive revision are recorded in `docs/engineering/design-references.md`. Repository documents use `thoth-sphinx` / `Sphinx`. Correcting the private source remains a source-owner follow-up and does not imply a second component.
 
 ## Blocking before programme implementation
 
 ### CG-03 - `thoth-sphinx` is empty
 
-Bootstrap before WP6 or driver work.
+`main` and `develop` exist, but the repository has no workspace, CI, protections or runtime. Complete BR-SPHINX-01 and SPHINX-BOOT-01 before WP6 or driver work.
 
 ### CG-04 - Branch topology differs
 
-Use actual branches until normalization or explicit exceptions.
+Use verified actual branches until normalization or explicit exceptions complete. Publisher Services uses standard task branches. Metrics uses repository-local integration branches only after readiness.
 
 ### CG-05 - Related repositories lack complete instructions
 
@@ -29,21 +29,21 @@ App, Sphinx, dashboard, widget and cc-license remain outstanding. Dissemination 
 
 ### CG-06 - Shared ADRs remain proposed
 
-ADR-0001 and ADR-0002 require CTO approval and independent review.
+ADR-0001 and ADR-0002 require explicit CTO approval and independent review before dependent implementation.
 
 ### CG-07 - Publisher Services platform ADR open
 
-Issue #765 exists. ADR-01 must finalize enum, mappings and ambiguous destinations.
+Issue #765 exists. ADR-01 must finalize enum values, mechanisms and ambiguous destinations.
 
 ### CG-08 - Metrics readiness open
 
-Issue #766 exists. Sphinx bootstrap, Diesel control, branch readiness and service-role decisions remain prerequisites.
+Issue #766 exists. Sphinx normalization/bootstrap, Diesel control, branch readiness and service-role decisions remain prerequisites.
 
 ## Production-slice controls
 
 ### CG-09 - Source fixtures/mappings incomplete
 
-Metrics fixtures, COUNTER mappings, finalization and OPERAS projections are missing.
+Metrics fixtures, COUNTER mappings, finalization settings and OPERAS projections are missing.
 
 ### CG-10 - OPERAS inbound completeness unavailable
 

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -55,9 +55,22 @@ Do not start implementation that depends on either decision until the CTO:
 - approves strict separation of distribution and metrics platform types;
 - records the approval in the ADRs.
 
+### CG-06 - Publisher Services control foundation is not complete
+
+The required repository documents exist under `docs/publisher-services/`.
+
+P0-01 remains incomplete until:
+
+- the master GitHub issue is created from `master-issue.md`;
+- its number is recorded in `task-status.md`;
+- PR #764 receives independent approval and merges;
+- ADR-0001 and ADR-0002 are approved or remain explicit implementation blockers.
+
+Publisher Services ADR-01 must still finalize the distribution enum. The current platform inventory is a verified baseline, not an approved enum.
+
 ## Required before affected production slices
 
-### CG-06 - `thoth-app` CI is incomplete
+### CG-07 - `thoth-app` CI is incomplete
 
 Current GitHub CI runs coverage tests but does not independently run:
 
@@ -67,7 +80,7 @@ Current GitHub CI runs coverage tests but does not independently run:
 
 Vercel build success is useful evidence but is not a replacement for explicit repository CI gates.
 
-### CG-07 - `metrics-dashboard` lacks detected CI and tests
+### CG-08 - `metrics-dashboard` lacks detected CI and tests
 
 Before client migration:
 
@@ -76,23 +89,23 @@ Before client migration:
 - require lint and production build;
 - add comparison fixtures for old/new data paths.
 
-### CG-08 - `metrics-widget` lacks detected unit tests
+### CG-09 - `metrics-widget` lacks detected unit tests
 
 Current CI covers lint, build and consumer smoke only.
 
 Add tests for data fetching, coverage semantics, partial results and rendering before the canonical API migration.
 
-### CG-09 - `cc-license` CI uses old actions
+### CG-10 - `cc-license` CI uses old actions
 
 Modernize checkout/toolchain actions before or alongside LIC-01, without mixing functional licence changes into the CI-only PR.
 
-### CG-10 - Thoth schema generation is unclear
+### CG-11 - Thoth schema generation is unclear
 
 `thoth-api/src/schema.rs` exists, but the root `diesel.toml` declares `src/schema.rs`.
 
 Confirm and document the canonical command and working directory before metrics or publisher-service migrations.
 
-### CG-11 - Thoth runtime operations are not mapped
+### CG-12 - Thoth runtime operations are not mapped
 
 Document:
 

--- a/docs/engineering/repository-map/environments.md
+++ b/docs/engineering/repository-map/environments.md
@@ -1,34 +1,34 @@
 # Environment and Deployment Map
 
-Status: Partially verified  
+Status: Partially verified
 Evidence date: 2026-07-24
 
 ## 1. Verified environments
 
 ### Thoth App
 
-Hosting: Vercel  
-Framework: Next.js  
-Node: 22.x  
-Production branch observed: `main`  
-Preview branch observed: `dev`  
+Hosting: Vercel
+Framework: Next.js
+Node: 22.x
+Production branch observed: `main`
+Preview branch observed: `dev`
 Production domain: `admin.thoth.pub`
 
 Production deployments are created from merges into `main`. Feature/development commits receive Vercel preview deployments.
 
 ### Metrics Dashboard
 
-Hosting: Vercel  
-Framework: Next.js  
-Node: 22.x  
-Production branch observed: `main`  
-Development branch: `develop`  
+Hosting: Vercel
+Framework: Next.js
+Node: 22.x
+Production branch observed: `main`
+Development branch: `develop`
 Production domain: `metrics.thoth.pub`
 
 ### Metrics Widget
 
-Delivery: npm package  
-Release trigger: published GitHub release  
+Delivery: npm package
+Release trigger: published GitHub release
 Validation before publish:
 
 - release tag equals `v<package.json version>`;
@@ -39,23 +39,23 @@ Validation before publish:
 
 ### Thoth
 
-Release artefact: container image in GHCR  
-Trigger: published GitHub release  
+Release artefact: container image in GHCR
+Trigger: published GitHub release
 Image: `ghcr.io/thoth-pub/thoth`
 
 The production compute platform, database migration execution path, deployment approval and rollback procedure were not verified in CTRL-02 and require a follow-up operations inventory.
 
 ### Thoth Dissemination
 
-Release artefact: Docker Hub image  
-Trigger: published GitHub release  
+Release artefact: Docker Hub image
+Trigger: published GitHub release
 Image: `openbookpublishers/thoth-dissemination`
 
 Operational execution also occurs through GitHub Actions. Some workflows can write to Thoth and external platforms and use protected credentials/environments.
 
 ### Thoth Sphinx
 
-Current environment: none verified  
+Current environment: none verified
 Planned architecture:
 
 - scheduled ECS/Fargate tasks;
@@ -69,8 +69,8 @@ Planned architecture must not be documented as deployed state.
 
 ### cc-license
 
-Delivery: Rust crate  
-Registry: crates.io is documented in the repository README.  
+Delivery: Rust crate
+Registry: crates.io is documented in the repository README.
 The exact publication procedure and release owner were not verified.
 
 ## 2. API endpoints referenced by repositories

--- a/docs/engineering/repository-map/environments.md
+++ b/docs/engineering/repository-map/environments.md
@@ -22,8 +22,14 @@ Hosting: Vercel
 Framework: Next.js
 Node: 22.x
 Production branch observed: `main`
-Development branch: `develop`
+Active development branch observed: `dev`
 Production domain: `metrics.thoth.pub`
+
+Production deployments are associated with `main`. Active development is
+observed on `dev`. The existing `develop` branch is stale and must not be used
+as an implementation base before BR-DASH-01 reconciles it. Vercel production
+and preview branch behaviour must be reverified during BR-DASH-01 rather than
+inferred from Git branch names.
 
 ### Metrics Widget
 

--- a/docs/engineering/repository-map/environments.md
+++ b/docs/engineering/repository-map/environments.md
@@ -43,7 +43,7 @@ Release artefact: container image in GHCR
 Trigger: published GitHub release
 Image: `ghcr.io/thoth-pub/thoth`
 
-The production compute platform, database migration execution path, deployment approval and rollback procedure were not verified in CTRL-02 and require a follow-up operations inventory.
+The production compute platform, database migration execution path, deployment approval and rollback procedure remain unverified under control gap [CG-13](./control-gaps.md#cg-13---thoth-runtime-operations-unmapped) and require a separately specified operations inventory.
 
 ### Thoth Dissemination
 

--- a/docs/engineering/repository-map/environments.md
+++ b/docs/engineering/repository-map/environments.md
@@ -1,0 +1,97 @@
+# Environment and Deployment Map
+
+Status: Partially verified  
+Evidence date: 2026-07-24
+
+## 1. Verified environments
+
+### Thoth App
+
+Hosting: Vercel  
+Framework: Next.js  
+Node: 22.x  
+Production branch observed: `main`  
+Preview branch observed: `dev`  
+Production domain: `admin.thoth.pub`
+
+Production deployments are created from merges into `main`. Feature/development commits receive Vercel preview deployments.
+
+### Metrics Dashboard
+
+Hosting: Vercel  
+Framework: Next.js  
+Node: 22.x  
+Production branch observed: `main`  
+Development branch: `develop`  
+Production domain: `metrics.thoth.pub`
+
+### Metrics Widget
+
+Delivery: npm package  
+Release trigger: published GitHub release  
+Validation before publish:
+
+- release tag equals `v<package.json version>`;
+- lint;
+- build;
+- package dry run;
+- consumer smoke test.
+
+### Thoth
+
+Release artefact: container image in GHCR  
+Trigger: published GitHub release  
+Image: `ghcr.io/thoth-pub/thoth`
+
+The production compute platform, database migration execution path, deployment approval and rollback procedure were not verified in CTRL-02 and require a follow-up operations inventory.
+
+### Thoth Dissemination
+
+Release artefact: Docker Hub image  
+Trigger: published GitHub release  
+Image: `openbookpublishers/thoth-dissemination`
+
+Operational execution also occurs through GitHub Actions. Some workflows can write to Thoth and external platforms and use protected credentials/environments.
+
+### Thoth Sphinx
+
+Current environment: none verified  
+Planned architecture:
+
+- scheduled ECS/Fargate tasks;
+- EventBridge;
+- private S3;
+- AWS Secrets Manager or SSM;
+- CloudWatch;
+- manual GitHub Actions with AWS OIDC.
+
+Planned architecture must not be documented as deployed state.
+
+### cc-license
+
+Delivery: Rust crate  
+Registry: crates.io is documented in the repository README.  
+The exact publication procedure and release owner were not verified.
+
+## 2. API endpoints referenced by repositories
+
+- GraphQL production: `https://api.thoth.pub/graphql`
+- Export production: `https://export.thoth.pub`
+- GraphQL test/codegen: `https://api.test.thoth.pub/graphql`
+- Current OPERAS metrics API: `https://metrics-api.operas-eu.org`
+
+Do not hardcode these into new domain logic when environment configuration is appropriate.
+
+## 3. Environment controls still required
+
+- branch-to-environment map after branch normalization;
+- production deployment owners;
+- Thoth API/export runtime platform;
+- database migration execution and approval;
+- rollback and restore commands;
+- feature-flag ownership;
+- service-role and secret-rotation ownership;
+- staging equivalents for Sphinx and metrics ingestion;
+- observability dashboard locations.
+
+No production task may infer these missing controls.

--- a/docs/engineering/repository-map/repositories/cc-license.md
+++ b/docs/engineering/repository-map/repositories/cc-license.md
@@ -1,0 +1,52 @@
+# Repository: thoth-pub/cc-license
+
+## Responsibility
+
+Canonical Rust parser and metadata authority for Creative Commons licence URLs retained by Thoth.
+
+## Branches
+
+GitHub default/release: `main`  
+Development: `develop`  
+Target: `develop -> master`
+
+BR-LIC-01 must normalize the release branch before publication.
+
+## Stack
+
+- Rust 2021
+- crate name `cc_license`
+- regex-based parsing
+- crates.io distribution documented
+
+## Commands
+
+```bash
+cargo test --workspace --verbose
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+## CI
+
+Current CI runs tests, clippy and formatting on `main` and `develop`.
+
+The workflow uses older checkout/actions-rs actions. Modernization should be a separate CI task from licence behaviour.
+
+## Publisher Services requirements
+
+LIC-01 will add or confirm:
+
+- canonical URL output;
+- enumeration of retained licences;
+- descriptions and display metadata;
+- legacy/jurisdiction metadata;
+- public-domain tools retained by Thoth;
+- rejection of invalid/spoofed URLs;
+- normalization tests.
+
+Thoth must consume a released crate version rather than copying parsing rules.
+
+## Release gap
+
+The exact crate publication command, credentials, approval and rollback/yank procedure are not verified. Record them before LIC-01 is marked production ready.

--- a/docs/engineering/repository-map/repositories/cc-license.md
+++ b/docs/engineering/repository-map/repositories/cc-license.md
@@ -6,8 +6,8 @@ Canonical Rust parser and metadata authority for Creative Commons licence URLs r
 
 ## Branches
 
-GitHub default/release: `main`  
-Development: `develop`  
+GitHub default/release: `main`
+Development: `develop`
 Target: `develop -> master`
 
 BR-LIC-01 must normalize the release branch before publication.

--- a/docs/engineering/repository-map/repositories/metrics-dashboard.md
+++ b/docs/engineering/repository-map/repositories/metrics-dashboard.md
@@ -1,5 +1,7 @@
 # Repository: thoth-pub/metrics-dashboard
 
+Evidence date: 2026-07-24
+
 ## Responsibility
 
 Publisher-facing analytics dashboard.
@@ -9,11 +11,24 @@ Current implementation combines Thoth metadata with the OPERAS metrics API. The 
 ## Branches
 
 GitHub default/release: `main`
-Development: `develop`
-Observed release: `develop -> main`
-Target: `develop -> master`
+Active development: `dev`
+Legacy stale branch: `develop`
+Observed release: `dev -> main`
+Target after BR-DASH-01: `develop -> master`
 
-BR-DASH-01 must normalize the release branch and Vercel production branch.
+Verified branch evidence:
+
+- `main`: `92d90380e948b3f11f88821054fbad9a5a07f387`;
+- `dev`: `1f81745e6d9e812baab62a19e41a0c0f3b9ff0c9`;
+- stale `develop`: `1619899076d16de81abf5c2c6abdd40d985512e6`;
+- `dev` is 10 commits ahead of `develop`, with no commits behind.
+
+Until BR-DASH-01 reconciles the branches, implementation work must branch from
+the verified `dev` branch. Another base requires an explicit CTO exception.
+
+BR-DASH-01 must reconcile the active development history before normalizing the
+development branch, release branch and Vercel configuration. PR #764 does not
+perform that normalization.
 
 ## Stack
 

--- a/docs/engineering/repository-map/repositories/metrics-dashboard.md
+++ b/docs/engineering/repository-map/repositories/metrics-dashboard.md
@@ -1,0 +1,75 @@
+# Repository: thoth-pub/metrics-dashboard
+
+## Responsibility
+
+Publisher-facing analytics dashboard.
+
+Current implementation combines Thoth metadata with the OPERAS metrics API. The metrics programme will replace this with one authenticated Thoth-owned server-side query path.
+
+## Branches
+
+GitHub default/release: `main`  
+Development: `develop`  
+Observed release: `develop -> main`  
+Target: `develop -> master`
+
+BR-DASH-01 must normalize the release branch and Vercel production branch.
+
+## Stack
+
+- Next.js 16
+- React 19
+- TypeScript
+- MUI
+- TanStack Query
+- GraphQL Request
+
+## Mandatory orientation
+
+Before editing:
+
+- `README.md`
+- `package.json`
+- data services and query hooks
+- chart/aggregation utilities
+- export utilities
+- environment configuration
+- applicable metrics API specification
+
+## Commands
+
+```bash
+npm ci
+npm run lint
+npm run build
+```
+
+No automated test script was detected.
+
+## CI
+
+No GitHub Actions workflow was detected.
+
+CG-06 must be resolved before the final client migration:
+
+- add CI;
+- add tests for data transformations and failure semantics;
+- add old/new comparison fixtures;
+- require lint and production build.
+
+## Deployment
+
+Vercel team: Thoth  
+Node: 22.x  
+Production domain: `metrics.thoth.pub`  
+Production branch observed: `main`
+
+## Metrics migration invariants
+
+- Browser code must not hold Thoth service credentials.
+- Use a server-side route/BFF.
+- Replace per-DOI OPERAS batching with bounded Thoth queries.
+- Do not combine incompatible measures.
+- Surface coverage, `dataThrough`, warnings and partial state.
+- Dependency failure must not display as zero.
+- Preserve a controlled fallback during the observation window.

--- a/docs/engineering/repository-map/repositories/metrics-dashboard.md
+++ b/docs/engineering/repository-map/repositories/metrics-dashboard.md
@@ -8,9 +8,9 @@ Current implementation combines Thoth metadata with the OPERAS metrics API. The 
 
 ## Branches
 
-GitHub default/release: `main`  
-Development: `develop`  
-Observed release: `develop -> main`  
+GitHub default/release: `main`
+Development: `develop`
+Observed release: `develop -> main`
 Target: `develop -> master`
 
 BR-DASH-01 must normalize the release branch and Vercel production branch.
@@ -59,9 +59,9 @@ CG-06 must be resolved before the final client migration:
 
 ## Deployment
 
-Vercel team: Thoth  
-Node: 22.x  
-Production domain: `metrics.thoth.pub`  
+Vercel team: Thoth
+Node: 22.x
+Production domain: `metrics.thoth.pub`
 Production branch observed: `main`
 
 ## Metrics migration invariants

--- a/docs/engineering/repository-map/repositories/metrics-dashboard.md
+++ b/docs/engineering/repository-map/repositories/metrics-dashboard.md
@@ -50,7 +50,7 @@ No automated test script was detected.
 
 No GitHub Actions workflow was detected.
 
-CG-06 must be resolved before the final client migration:
+[CG-11](../control-gaps.md#cg-11---ci-gaps) must be resolved before the final client migration:
 
 - add CI;
 - add tests for data transformations and failure semantics;

--- a/docs/engineering/repository-map/repositories/metrics-widget.md
+++ b/docs/engineering/repository-map/repositories/metrics-widget.md
@@ -1,0 +1,64 @@
+# Repository: thoth-pub/metrics-widget
+
+## Responsibility
+
+Embeddable React/JavaScript metrics package published to npm.
+
+## Branches
+
+GitHub default/release: `main`  
+Development: `dev`  
+CI branch filters: `main`, `dev`  
+Target: `develop -> master`
+
+BR-WIDGET-01 must normalize branch names and preserve release automation.
+
+## Stack
+
+- React 19 peer dependency
+- TypeScript 5.9
+- Vite 7
+- Biome
+- API Extractor
+- generated declaration/package output in `dist/`
+
+## Commands
+
+```bash
+npm ci
+npm run lint
+npm run build
+npm run test:consumer
+npm pack --dry-run
+```
+
+## CI
+
+Current CI runs:
+
+- lint;
+- build;
+- consumer smoke test.
+
+No unit-test suite was detected.
+
+## Release
+
+A published GitHub release:
+
+1. checks out the release;
+2. verifies the tag is `v<package.json version>`;
+3. lints;
+4. builds;
+5. checks package contents;
+6. runs consumer smoke;
+7. publishes to npm.
+
+## Metrics migration invariants
+
+- Preserve React and vanilla-JavaScript consumers.
+- Preserve public package exports and CSS isolation.
+- Do not embed machine credentials.
+- The future authenticated path must be compatible with third-party embedding.
+- Add tests for data failure, coverage and partial response semantics before cutover.
+- A release is high risk because it publishes a public package.

--- a/docs/engineering/repository-map/repositories/metrics-widget.md
+++ b/docs/engineering/repository-map/repositories/metrics-widget.md
@@ -6,9 +6,9 @@ Embeddable React/JavaScript metrics package published to npm.
 
 ## Branches
 
-GitHub default/release: `main`  
-Development: `dev`  
-CI branch filters: `main`, `dev`  
+GitHub default/release: `main`
+Development: `dev`
+CI branch filters: `main`, `dev`
 Target: `develop -> master`
 
 BR-WIDGET-01 must normalize branch names and preserve release automation.

--- a/docs/engineering/repository-map/repositories/thoth-app.md
+++ b/docs/engineering/repository-map/repositories/thoth-app.md
@@ -1,0 +1,108 @@
+# Repository: thoth-pub/thoth-app
+
+## Responsibility
+
+Authenticated publisher and staff management UI for Thoth metadata and administrative workflows.
+
+## Branches
+
+GitHub default/release: `main`  
+Development: `dev`  
+Observed release: `dev -> main`  
+Target: `develop -> master`
+
+BR-APP-01 must normalize the branch topology before a long-lived programme integration branch is created, unless the CTO records a temporary exception.
+
+## Stack
+
+- Next.js 16 App Router
+- React 19
+- TypeScript 5.9
+- MUI 7
+- Tailwind CSS 4
+- TanStack Query
+- XState
+- GraphQL Request and GraphQL Code Generator
+- NextAuth and ZITADEL
+- Vitest and Testing Library
+
+Architecture follows Feature-Sliced Design.
+
+## Mandatory orientation
+
+Before editing:
+
+- `DOCUMENTATION.md`
+- `package.json`
+- `codegen.ts`
+- relevant `app/`, `src/entities/`, `src/features/`, `src/widgets/`, `src/shared/`
+- auth and proxy configuration
+- relevant tests
+- `.github/workflows/test.yml`
+- applicable API schema and task specification
+
+## Commands
+
+```bash
+npm ci
+npm run generate
+npm run lint
+npm test -- --run --coverage
+npm run build
+```
+
+Run `npm run generate` when GraphQL documents or consumed schema fields change.
+
+## Generated artefacts
+
+GraphQL codegen:
+
+- schema source: `https://api.test.thoth.pub/graphql`
+- documents: `app/**/*.{ts,tsx}`, `src/**/*.{ts,tsx}`
+- output: `gql/`
+
+A cross-repository API slice must ensure the test API or pinned preview exposes the exact schema before regenerating.
+
+## CI
+
+Current GitHub CI:
+
+```bash
+npm ci
+npm test -- --run --coverage
+```
+
+Lint, production build and codegen consistency are not current GitHub gates and must be run manually until CG-05 is resolved.
+
+## Deployment
+
+Vercel team: Thoth  
+Node: 22.x  
+Production domain: `admin.thoth.pub`  
+Production branch observed: `main`  
+Preview branch observed: `dev`
+
+Changing branch topology requires coordinated Vercel configuration and rollback evidence.
+
+## Programme effects
+
+Publisher Services:
+
+- read-only publisher package/platform view;
+- superuser configuration UI;
+- staff subscription report;
+- API-backed licence options.
+
+Metrics:
+
+- publisher uploads;
+- import status/errors;
+- publisher-platform approvals;
+- no browser service credentials.
+
+## Prohibited assumptions
+
+- Do not encode linked platform rules independently from backend descriptors.
+- Do not ship machine credentials to browser code.
+- Do not treat Vercel build success as complete test evidence.
+- Do not regenerate types from an API contract different from the branch being implemented.

--- a/docs/engineering/repository-map/repositories/thoth-app.md
+++ b/docs/engineering/repository-map/repositories/thoth-app.md
@@ -6,9 +6,9 @@ Authenticated publisher and staff management UI for Thoth metadata and administr
 
 ## Branches
 
-GitHub default/release: `main`  
-Development: `dev`  
-Observed release: `dev -> main`  
+GitHub default/release: `main`
+Development: `dev`
+Observed release: `dev -> main`
 Target: `develop -> master`
 
 BR-APP-01 must normalize the branch topology before a long-lived programme integration branch is created, unless the CTO records a temporary exception.
@@ -76,10 +76,10 @@ Lint, production build and codegen consistency are not current GitHub gates and 
 
 ## Deployment
 
-Vercel team: Thoth  
-Node: 22.x  
-Production domain: `admin.thoth.pub`  
-Production branch observed: `main`  
+Vercel team: Thoth
+Node: 22.x
+Production domain: `admin.thoth.pub`
+Production branch observed: `main`
 Preview branch observed: `dev`
 
 Changing branch topology requires coordinated Vercel configuration and rollback evidence.

--- a/docs/engineering/repository-map/repositories/thoth-app.md
+++ b/docs/engineering/repository-map/repositories/thoth-app.md
@@ -72,7 +72,7 @@ npm ci
 npm test -- --run --coverage
 ```
 
-Lint, production build and codegen consistency are not current GitHub gates and must be run manually until CG-05 is resolved.
+Lint, production build and codegen consistency are not current GitHub gates and must be run manually until [CG-11](../control-gaps.md#cg-11---ci-gaps) is resolved.
 
 ## Deployment
 

--- a/docs/engineering/repository-map/repositories/thoth-dissemination.md
+++ b/docs/engineering/repository-map/repositories/thoth-dissemination.md
@@ -6,9 +6,9 @@ Existing execution engine for delivering metadata and files to external distribu
 
 ## Branches
 
-GitHub default/release: `main`  
-Development: `develop`  
-Normal feature PRs currently target `develop`  
+GitHub default/release: `main`
+Development: `develop`
+Normal feature PRs currently target `develop`
 Target release branch: `master`
 
 BR-DIS-01 must normalize the release branch before final programme release.

--- a/docs/engineering/repository-map/repositories/thoth-dissemination.md
+++ b/docs/engineering/repository-map/repositories/thoth-dissemination.md
@@ -1,0 +1,97 @@
+# Repository: thoth-pub/thoth-dissemination
+
+## Responsibility
+
+Existing execution engine for delivering metadata and files to external distribution and preservation platforms.
+
+## Branches
+
+GitHub default/release: `main`  
+Development: `develop`  
+Normal feature PRs currently target `develop`  
+Target release branch: `master`
+
+BR-DIS-01 must normalize the release branch before final programme release.
+
+## Stack
+
+- Python 3.11
+- platform-specific uploader modules
+- Docker
+- GitHub Actions
+- external APIs, SFTP/SWORD and object storage
+- Thoth API/location write-back
+
+## Mandatory orientation
+
+Before editing:
+
+- `AGENTS.md`
+- `README.md`
+- `disseminator.py`
+- `obtain_new_ids.py`
+- relevant `*uploader.py`
+- location write-back scripts
+- relevant `requirements*.txt`
+- relevant workflow YAML
+- tests for the affected path
+- applicable task specification
+
+## Commands
+
+```bash
+python -m pip install -r requirements.txt
+python -m unittest discover -v
+python -m compileall -q .
+```
+
+When workflows change, validate YAML/action syntax with the repository's established actionlint procedure.
+
+## CI
+
+GitHub CI runs:
+
+- Python 3.11;
+- full unittest discovery;
+- source compilation.
+
+## Release and operations
+
+Published GitHub releases build and publish:
+
+```text
+openbookpublishers/thoth-dissemination
+```
+
+GitHub Actions also perform scheduled/manual operational work. Some paths can:
+
+- upload to external platforms;
+- modify external metadata;
+- write locations to Thoth;
+- process publisher catalogues.
+
+Dry run and read-only discovery must remain credential-free where designed.
+
+## Programme effects
+
+Publisher Services:
+
+- API-owned publisher discovery;
+- env/compare/api modes;
+- durable back-catalogue job worker;
+- linked OAPEN/DOAB adapter deduplication.
+
+Metrics:
+
+- no canonical metrics responsibility after Sphinx exists.
+
+## Prohibited operations
+
+Implementing agents must not:
+
+- dispatch production workflows;
+- use production credentials;
+- submit real works;
+- run apply modes;
+- remove configured publisher lists before comparison/cutover approval;
+- treat an empty API assignment as permission to process all works.

--- a/docs/engineering/repository-map/repositories/thoth-sphinx.md
+++ b/docs/engineering/repository-map/repositories/thoth-sphinx.md
@@ -1,0 +1,90 @@
+# Repository: thoth-pub/thoth-sphinx
+
+## Responsibility
+
+Planned metrics collection, normalization, orchestration, rollup application, OPERAS synchronization and reconciliation.
+
+## Current state
+
+Visibility: private  
+GitHub default branch: `main`  
+Repository content: empty as of 2026-07-24  
+CI: none  
+Deployment: none verified
+
+The repository is not implementation-ready.
+
+## Canonical naming
+
+Use:
+
+```text
+thoth-sphinx
+Sphinx
+```
+
+Use only `thoth-sphinx` and `Sphinx` in new material.
+
+## Required branch bootstrap
+
+BR-SPHINX-01 must establish:
+
+```text
+develop -> master
+```
+
+Task branches then follow:
+
+```text
+feature/metrics/<slice> -> feature/metrics -> develop -> master
+```
+
+## Planned stack and boundaries
+
+The approved metrics design expects a Rust workspace with boundaries equivalent to:
+
+- core normalized types and driver traits;
+- Thoth GraphQL client;
+- storage/manifests;
+- OPERAS adapter;
+- runner/orchestration;
+- platform drivers.
+
+Sphinx:
+
+- does not own canonical metrics;
+- does not write directly to PostgreSQL;
+- does not keep durable state only in local files, SQLite, S3 or GitHub Actions;
+- does not construct browser-facing credentials;
+- does not submit source-driver payloads directly to OPERAS.
+
+## Required bootstrap task
+
+The bootstrap must add:
+
+- Cargo workspace;
+- stable Rust toolchain policy;
+- crate/module boundaries;
+- README;
+- AGENTS.md;
+- license;
+- formatting, clippy and tests;
+- GitHub CI;
+- secret-scanning baseline;
+- configuration conventions;
+- a no-op executable/driver test;
+- branch/release documentation;
+- no AWS resources and no production behaviour.
+
+## Planned runtime
+
+Not yet provisioned:
+
+- ECS/Fargate;
+- EventBridge;
+- private S3;
+- AWS OIDC for manual Actions;
+- Secrets Manager/SSM;
+- CloudWatch.
+
+A bootstrap PR must not provision or deploy these automatically.

--- a/docs/engineering/repository-map/repositories/thoth-sphinx.md
+++ b/docs/engineering/repository-map/repositories/thoth-sphinx.md
@@ -8,11 +8,12 @@ Planned metrics collection, normalization, orchestration, rollup application, OP
 
 Visibility: private
 GitHub default branch: `main`
+Active development branch: `develop`
 Repository content: empty as of 2026-07-24
 CI: none
 Deployment: none verified
 
-The repository is not implementation-ready.
+Both branches exist, but the repository remains non-implementation-ready because it has no workspace, code, CI, protection evidence or runtime.
 
 ## Canonical naming
 
@@ -23,25 +24,28 @@ thoth-sphinx
 Sphinx
 ```
 
-Use only `thoth-sphinx` and `Sphinx` in new material.
+The private Metrics design contains an obsolete spelling. Its exact Drive revision is recorded in `docs/engineering/design-references.md`.
 
-## Required branch bootstrap
+## Required branch normalization
 
-BR-SPHINX-01 must establish:
+BR-SPHINX-01 must:
+
+- create `master` from current `main`;
+- retain and verify the existing `develop` branch;
+- align `develop` with the approved bootstrap base;
+- make `master` the release/default branch;
+- protect `master` and `develop`;
+- retain `main` until references are confirmed absent.
+
+The resulting flow is:
 
 ```text
-develop -> master
-```
-
-Task branches then follow:
-
-```text
-feature/metrics/<slice> -> feature/metrics -> develop -> master
+develop -> feature/metrics -> feature/metrics/<slice> -> feature/metrics -> develop -> master
 ```
 
 ## Planned stack and boundaries
 
-The approved metrics design expects a Rust workspace with boundaries equivalent to:
+The private Metrics design expects a Rust workspace with boundaries equivalent to:
 
 - core normalized types and driver traits;
 - Thoth GraphQL client;
@@ -60,25 +64,23 @@ Sphinx:
 
 ## Required bootstrap task
 
-The bootstrap must add:
+SPHINX-BOOT-01 must add:
 
 - Cargo workspace;
 - stable Rust toolchain policy;
 - crate/module boundaries;
-- README;
-- AGENTS.md;
+- README and root `AGENTS.md`;
 - license;
 - formatting, clippy and tests;
-- GitHub CI;
-- secret-scanning baseline;
+- GitHub CI and secret-scanning baseline;
 - configuration conventions;
-- a no-op executable/driver test;
+- no-op executable/driver test;
 - branch/release documentation;
 - no AWS resources and no production behaviour.
 
 ## Planned runtime
 
-Not yet provisioned:
+Not provisioned:
 
 - ECS/Fargate;
 - EventBridge;

--- a/docs/engineering/repository-map/repositories/thoth-sphinx.md
+++ b/docs/engineering/repository-map/repositories/thoth-sphinx.md
@@ -6,10 +6,10 @@ Planned metrics collection, normalization, orchestration, rollup application, OP
 
 ## Current state
 
-Visibility: private  
-GitHub default branch: `main`  
-Repository content: empty as of 2026-07-24  
-CI: none  
+Visibility: private
+GitHub default branch: `main`
+Repository content: empty as of 2026-07-24
+CI: none
 Deployment: none verified
 
 The repository is not implementation-ready.

--- a/docs/engineering/repository-map/repositories/thoth-sphinx.md
+++ b/docs/engineering/repository-map/repositories/thoth-sphinx.md
@@ -9,11 +9,11 @@ Planned metrics collection, normalization, orchestration, rollup application, OP
 Visibility: private
 GitHub default branch: `main`
 Active development branch: `develop`
-Repository content: empty as of 2026-07-24
+Repository content: placeholder-only `README.md` on `main` and `develop` as of 2026-07-24
 CI: none
 Deployment: none verified
 
-Both branches exist, but the repository remains non-implementation-ready because it has no workspace, code, CI, protection evidence or runtime.
+Both branches exist and contain only the placeholder `README.md`. The repository remains non-implementation-ready because it has no workspace, implementation, CI, protection evidence or runtime.
 
 ## Canonical naming
 
@@ -69,7 +69,7 @@ SPHINX-BOOT-01 must add:
 - Cargo workspace;
 - stable Rust toolchain policy;
 - crate/module boundaries;
-- README and root `AGENTS.md`;
+- replace or expand the placeholder README and add a root `AGENTS.md`;
 - license;
 - formatting, clippy and tests;
 - GitHub CI and secret-scanning baseline;

--- a/docs/engineering/repository-map/repositories/thoth.md
+++ b/docs/engineering/repository-map/repositories/thoth.md
@@ -6,9 +6,9 @@ Canonical bibliographic and metrics domain, PostgreSQL model, GraphQL API, autho
 
 ## Branches
 
-GitHub default/release: `master`  
-Development: `develop`  
-Normal task: `feature/... -> develop`  
+GitHub default/release: `master`
+Development: `develop`
+Normal task: `feature/... -> develop`
 Release: `develop -> master`
 
 This repository conforms to the approved target topology.

--- a/docs/engineering/repository-map/repositories/thoth.md
+++ b/docs/engineering/repository-map/repositories/thoth.md
@@ -101,7 +101,7 @@ Every schema task must verify:
 
 `thoth-api/src/schema.rs` is a generated/derived Diesel schema file.
 
-The exact regeneration procedure is a control gap because root `diesel.toml` declares `src/schema.rs`. Do not regenerate or relocate the schema without first resolving CG-09.
+The exact regeneration procedure is a control gap because root `diesel.toml` declares `src/schema.rs`. Do not regenerate or relocate the schema without first resolving [CG-12](../control-gaps.md#cg-12---thoth-schema-generation-unclear).
 
 ## CI and release
 

--- a/docs/engineering/repository-map/repositories/thoth.md
+++ b/docs/engineering/repository-map/repositories/thoth.md
@@ -1,0 +1,152 @@
+# Repository: thoth-pub/thoth
+
+## Responsibility
+
+Canonical bibliographic and metrics domain, PostgreSQL model, GraphQL API, authorization, import validation, rollups, export API and database migrations.
+
+## Branches
+
+GitHub default/release: `master`  
+Development: `develop`  
+Normal task: `feature/... -> develop`  
+Release: `develop -> master`
+
+This repository conforms to the approved target topology.
+
+## Stack
+
+- Rust 2021
+- Cargo workspace
+- PostgreSQL
+- Diesel
+- Redis
+- GraphQL API
+- REST/export server
+- ZITADEL integration
+
+Workspace members observed:
+
+- `thoth-api`
+- `thoth-api-server`
+- `thoth-client`
+- `thoth-errors`
+- `thoth-export-server`
+
+## Mandatory orientation
+
+Before editing:
+
+- `README.md`
+- `Cargo.toml`
+- `Makefile`
+- relevant crate `Cargo.toml`
+- `thoth-api/migrations/`
+- `thoth-api/src/schema.rs`
+- relevant authorization/policy modules
+- `.github/workflows/build_test_and_check.yml`
+- `.github/workflows/run_migrations.yml`
+- `CHANGELOG.md`
+- applicable ADR/task specification
+
+## Commands
+
+```bash
+make build
+make test
+make check
+make clippy
+make check-format
+make check-all
+```
+
+Underlying required checks:
+
+```bash
+cargo test --workspace
+cargo check --workspace
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+CI uses PostgreSQL 17 and Redis.
+
+## Migration controls
+
+Migration creation target:
+
+```bash
+make migration
+```
+
+Observed convention:
+
+```text
+thoth-api/migrations/YYYYMMDD_v<next-minor>/
+  up.sql
+  down.sql
+```
+
+Every schema task must verify:
+
+- empty database;
+- populated database;
+- constraints and indexes;
+- forward migration;
+- downgrade or forward-repair strategy;
+- generated Diesel schema;
+- migration ordering;
+- locking/downtime.
+
+## Generated artefacts
+
+`thoth-api/src/schema.rs` is a generated/derived Diesel schema file.
+
+The exact regeneration procedure is a control gap because root `diesel.toml` declares `src/schema.rs`. Do not regenerate or relocate the schema without first resolving CG-09.
+
+## CI and release
+
+PR checks include:
+
+- build;
+- workspace tests;
+- clippy;
+- formatting;
+- migrations;
+- changelog check.
+
+Every PR requires a `CHANGELOG.md` change under `## [Unreleased]`.
+
+Published GitHub releases build and publish:
+
+```text
+ghcr.io/thoth-pub/thoth
+```
+
+The production runtime and deployment/rollback process require separate verification.
+
+## Programme effects
+
+Publisher Services:
+
+- package and distribution configuration;
+- audit history;
+- durable jobs;
+- worker API;
+- OCLC feed index;
+- licence enforcement.
+
+Metrics:
+
+- canonical metric tables;
+- ingestion;
+- rollups;
+- entitlements;
+- protected metrics GraphQL;
+- OPERAS ledgers.
+
+## Prohibited assumptions
+
+- Do not write directly to production PostgreSQL.
+- Do not allow Sphinx to bypass the GraphQL write boundary.
+- Do not broaden authorization on API failure.
+- Do not merge database, API and unrelated refactors in one slice.

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -108,7 +108,7 @@ Blocking controls:
 1. Engineering-control foundation is unmerged.
 2. `ADR-0001` is `PROPOSED`.
 3. `ADR-0002` is `PROPOSED`.
-4. `thoth-sphinx` is empty.
+4. `thoth-sphinx` is placeholder-only and has not been bootstrapped.
 5. Thoth Diesel generation procedure is unresolved.
 6. Branch topology differs in Sphinx and client repositories.
 7. Service-role codes require approval before WP5.

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,0 +1,131 @@
+# Thoth Metrics
+
+Status: CONTROL FOUNDATION IN PROGRESS  
+Programme owner: CTO
+
+Primary repositories:
+
+- `thoth-pub/thoth`
+- `thoth-pub/thoth-sphinx`
+- `thoth-pub/metrics-dashboard`
+- `thoth-pub/metrics-widget`
+
+Related repository:
+
+- `thoth-pub/thoth-app`
+
+## 1. Purpose
+
+This directory is the repository-backed control surface for making Thoth the canonical owner of usage and sales metrics.
+
+It turns the approved technical design into:
+
+- an explicit decision summary;
+- a bounded work-package tracker;
+- a source and driver inventory;
+- a cross-repository contract register;
+- a historical migration inventory;
+- acceptance evidence requirements;
+- rollout, comparison, rollback and observation gates.
+
+## 2. Target outcome
+
+Thoth owns canonical metrics in its existing PostgreSQL database and GraphQL API.
+
+Sphinx:
+
+- discovers source units;
+- retrieves or references source artifacts;
+- normalizes source data;
+- submits bounded idempotent batches to Thoth;
+- applies restartable orchestration;
+- delivers eligible OPERAS exports;
+- imports only allowed OPERAS-only mappings;
+- records reconciliation outcomes in Thoth.
+
+Dashboard and widget clients stop querying OPERAS directly and use authenticated Thoth-owned server routes.
+
+## 3. Canonical boundaries
+
+### Thoth
+
+Thoth alone decides whether an observation becomes canonical.
+
+It owns metrics tables and constraints, identifier resolution, registries, publisher approvals, import state, hashes, duplicates, revisions, conflicts, coverage, rollups, authorization, entitlements, OPERAS ledgers and reconciliation records.
+
+### Sphinx
+
+Sphinx is stateless orchestration and interoperability.
+
+It must not:
+
+- write directly to PostgreSQL;
+- keep canonical state in local SQLite or S3;
+- decide canonical conflict winners outside Thoth;
+- send driver output directly to OPERAS;
+- store browser-facing service credentials;
+- claim guaranteed OPERAS inbound completeness without a complete discovery mechanism.
+
+### Clients
+
+Dashboard and widget browser code must not hold Thoth machine credentials.
+
+Use:
+
+```text
+Browser -> Thoth-owned server route -> authenticated Thoth GraphQL operation
+```
+
+## 4. Core invariants
+
+1. Every accepted record resolves to a Thoth work by DOI.
+2. Optional publication resolution uses ISBN or an unambiguous publication type.
+3. Institutions resolve to existing ROR-backed Thoth institutions; ingestion never creates them.
+4. Periods are half-open dates.
+5. Usage values reject negatives.
+6. Sales measures may allow signed integer units.
+7. Canonical identity excludes source and value.
+8. Publisher imports are final and cannot supersede accepted rows.
+9. Managed sources may create audited revisions.
+10. Missing or incomplete coverage is never represented as zero.
+11. Directly collected platform/measure mappings are never imported back from OPERAS.
+12. Current publisher, imprint and series attribution follows current Thoth metadata.
+13. Durable leases, checkpoints, imports, exports and reconciliation live in Thoth.
+14. Metrics code consumes capabilities rather than hardcoded package names.
+
+## 5. Programme non-goals
+
+The initial programme does not store raw clickstream events in Thoth, create a separate canonical metrics database, calculate sales revenue, let publishers submit managed platform data, create institutions from imports, use GitHub Actions as durable state, make OPERAS canonical, combine unlike measures, or expose unbounded public analytics queries.
+
+## 6. Current programme decision
+
+```text
+BLOCKED FOR IMPLEMENTATION
+```
+
+Blocking controls:
+
+1. Engineering-control foundation is unmerged.
+2. `ADR-0001` is `PROPOSED`.
+3. `ADR-0002` is `PROPOSED`.
+4. `thoth-sphinx` is empty.
+5. Thoth Diesel generation procedure is unresolved.
+6. Branch topology differs in Sphinx and client repositories.
+7. Service-role codes require approval before WP5.
+8. Representative source fixtures and COUNTER mappings are missing for source-specific work.
+9. Guaranteed OPERAS inbound discovery is unavailable.
+
+Discovery, benchmarking, fixture collection and task specification may continue.
+
+## 7. Files
+
+- `decisions.md`
+- `task-status.md`
+- `source-inventory.md`
+- `contract-register.md`
+- `migration-inventory.md`
+- `acceptance-matrix.md`
+- `rollout-plan.md`
+- `master-issue.md`
+
+Missing evidence is missing work.

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -18,7 +18,7 @@ Related repository:
 
 This directory is the repository-backed control surface for making Thoth the canonical owner of usage and sales metrics.
 
-It turns the approved technical design into:
+It turns the [private approved Metrics design](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit), Drive revision `6`, into:
 
 - an explicit decision summary;
 - a bounded work-package tracker;

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,6 +1,6 @@
 # Thoth Metrics
 
-Status: CONTROL FOUNDATION IN PROGRESS  
+Status: CONTROL FOUNDATION IN PROGRESS
 Programme owner: CTO
 
 Primary repositories:

--- a/docs/metrics/acceptance-matrix.md
+++ b/docs/metrics/acceptance-matrix.md
@@ -1,6 +1,6 @@
 # Thoth Metrics Acceptance Matrix
 
-Status: ACTIVE CONTROL MATRIX  
+Status: ACTIVE CONTROL MATRIX
 Owner: CTO
 
 | Requirement | Work | Evidence | Gate |

--- a/docs/metrics/acceptance-matrix.md
+++ b/docs/metrics/acceptance-matrix.md
@@ -1,0 +1,33 @@
+# Thoth Metrics Acceptance Matrix
+
+Status: ACTIVE CONTROL MATRIX  
+Owner: CTO
+
+| Requirement | Work | Evidence | Gate |
+|---|---|---|---|
+| Thoth sole canonical store | WP1/WP2 | schema/API review; no direct Sphinx DB writes | ingestion |
+| Stable registries | WP1 | migration/seed tests | configuration |
+| Work/publication/ROR resolution | WP2 | valid/unknown/ambiguous tests | ingestion |
+| Value rules | WP1/WP2 | measure-specific tests | ingestion |
+| Deterministic duplicates/revisions/conflicts | WP2 | concurrency/transaction tests | ingestion |
+| No overlapping double count | WP1/WP2 | exclusion/lock race tests | ingestion |
+| Publisher finality | WP2/WP3 | changed-value conflict tests | imports |
+| Every row auditable | WP2 | provenance/error parity | ingestion |
+| Zero vs unknown coverage | WP1/WP4 | coverage fixtures | client cutover |
+| Rollups rebuildable | WP1/WP4 | delta/revision/rebuild tests | serving |
+| Dashboard p95 <1s | WP4 | 600-work benchmark | dashboard |
+| Useful view <2s | WP10 | browser/server timing | dashboard |
+| Least-privilege service auth | WP5 | role matrix | serving |
+| No browser secret | WP5/WP10 | bundle/source inspection | clients |
+| Entitlements enforced | WP5/WP9 | capability tests | serve/export |
+| CloudFront sessions correct | WP7 | golden adjacent-day fixtures | driver |
+| No IP/user-agent persisted | WP7/WP11 | artifact/schema/log inspection | driver |
+| Restartable/idempotent runs | WP6-WP9 | lease/retry/overlap tests | schedules |
+| OPERAS outbound idempotent | WP9 | retry/hash tests | export |
+| No inbound loops | WP9 | direct/exported tests | inbound |
+| Honest inbound completeness | WP9 | cursor/snapshot or unverified tests | inbound |
+| Old/new comparison | WP10/WP11 | publisher/period reports | cutover |
+| Migration reconciled | WP11 | source/canonical/rollup/OPERAS report | shutdown |
+| Operational support | WP11 | alerts/runbooks/restore/rebuild exercise | production |
+
+Programme completion additionally requires integrated acceptance, migration reconciliation, performance, monitoring, rollback, observation and separately approved cleanup.

--- a/docs/metrics/contract-register.md
+++ b/docs/metrics/contract-register.md
@@ -1,6 +1,6 @@
 # Thoth Metrics Contract Register
 
-Status: ACTIVE DESIGN REGISTER  
+Status: ACTIVE DESIGN REGISTER
 Owner: Thoth Metrics programme
 
 ## 1. Normalized observation

--- a/docs/metrics/contract-register.md
+++ b/docs/metrics/contract-register.md
@@ -1,0 +1,62 @@
+# Thoth Metrics Contract Register
+
+Status: ACTIVE DESIGN REGISTER  
+Owner: Thoth Metrics programme
+
+## 1. Normalized observation
+
+Version:
+
+```text
+thoth-normalized-metrics/1
+```
+
+Required: source account, platform, measure, work DOI, period start/end, grain, value and methodology version. Optional: publication ISBN/type, country, ROR, source record and row.
+
+Owner: `thoth`. Producer: `thoth-sphinx`.
+
+Sphinx constructs batches; Thoth resolves codes and identifiers. Contract changes require versioning or explicit compatibility review.
+
+## 2. Registry and administration
+
+Thoth owns platform, measure, platform-measure, source account, publisher approval and entitlement operations. Codes are stable, mutations are protected, credentials never enter configuration JSON, and generated clients must be refreshed.
+
+## 3. Internal ingestion
+
+Thoth owns bounded claim/checkpoint/import/batch/rollup/export/reconciliation operations consumed by Sphinx.
+
+Required: least privilege, leases, stale-token rejection, idempotency, bounded batches, sanitized errors, exact row classifications and fail-closed behavior.
+
+## 4. Dashboard/widget
+
+Thoth owns entity metrics, dashboard/widget operations and registry queries.
+
+Required response concerns: distinct measure totals, timeline, breakdowns, coverage, freshness, watermark, warnings, partial state, BigInt strings and deterministic pagination.
+
+Semantics: OR within lists, AND between dimensions, exclusive end date, bounded ranges and filtering before pagination.
+
+## 5. Publisher import
+
+Flow: initialize private upload, direct browser upload, complete/queue, Sphinx claim/normalize, Thoth validate/commit, Sphinx complete, app reads result.
+
+Publisher derives from authentication; object keys are server-selected; MIME/size/checksum/decompression are bounded; managed platforms are prohibited.
+
+## 6. OPERAS
+
+Thoth owns canonical export claims and ledgers. Sphinx projects/delivers. Configuration includes platform/measure mapping, event URI, measure URI, uploader URI, enabled state and finalization. Drivers never construct OPERAS payloads.
+
+## 7. Authentication
+
+Proposed:
+
+```text
+METRICS_READ_SERVICE
+METRICS_INGEST_SERVICE
+METRICS_SYNC_SERVICE
+```
+
+Status: CTO APPROVAL REQUIRED. Consumers must not substitute superuser.
+
+## 8. Cross-repository gate
+
+Record exact producer commit/preview, generated types, contract fixtures, compatibility, merge order, non-production credentials and independent rollback before final review.

--- a/docs/metrics/decisions.md
+++ b/docs/metrics/decisions.md
@@ -1,0 +1,97 @@
+# Thoth Metrics Decision Summary
+
+Status: ACTIVE SUMMARY  
+Last updated: 2026-07-24  
+Owner: CTO
+
+The approved technical design and approved ADRs remain authoritative.
+
+## 1. Fixed architectural decisions
+
+### Canonical store and API
+
+- Use the existing Thoth PostgreSQL instance and standard schema.
+- Use `metric_`-prefixed tables with direct foreign keys.
+- Use the existing Thoth GraphQL API.
+- Sphinx writes through protected GraphQL operations, not direct database access.
+
+### Canonical observation grain
+
+The canonical unit is a source-reported aggregate at its finest reliable grain: day, month or explicit reporting period. Do not fabricate event-level precision. Periods are half-open.
+
+### Identity
+
+Work identity requires DOI. Optional publication identity uses ISBN or an unambiguous publication type. Institution identity uses an existing Thoth institution resolved by ROR. Ingestion does not create institutions.
+
+### Values and records
+
+Usage measures require non-negative integers. Sales measures may allow signed integer units. Identity excludes source and value. Same identity/same content is a duplicate. Managed winning sources may revise. Other changed values are conflicts. Publisher submissions are final.
+
+### Coverage and attribution
+
+Coverage is `COMPLETE`, `PARTIAL` or `UNKNOWN`. A missing record is zero only inside complete coverage. Historical metrics follow current work ownership and current imprint/series relationships.
+
+### Rollups
+
+Rollups are rebuildable projections. Canonical writes create durable rollup deltas. Revisions apply `new - old`.
+
+### Publisher imports
+
+Publisher uploads belong to the authenticated publisher, may use only approved `PUBLISHER_CONTROLLED` platforms, cannot submit managed data, become final after acceptance and produce explicit row classifications.
+
+### CloudFront methodology
+
+The target is daily country-level `title_sessions` using GET 200/206 requests, DOI paths, versioned bot filtering, IP plus user-agent transient sessions, a rolling 30-minute window, first UTC day attribution and deduplication by session/platform/DOI/country. No IP or user agent enters normalized output.
+
+### OPERAS
+
+Outbound uses durable Thoth claims. Sphinx delivers idempotently. Direct mappings are excluded inbound. Local corrections after remote delivery create divergence issues. Inbound completeness is not guaranteed without cursor, replication or complete snapshots.
+
+## 2. Proposed shared decisions
+
+`ADR-0001` is required for entitlements, serving, imports, export and collection policy.
+
+`ADR-0002` is required for metric platform implementation. `MetricPlatform` remains separate from `DistributionPlatform`.
+
+## 3. Decisions still required
+
+### Service-role codes
+
+Proposed:
+
+```text
+METRICS_READ_SERVICE
+METRICS_INGEST_SERVICE
+METRICS_SYNC_SERVICE
+```
+
+Approve exact codes, scope, rotation, audit ownership and whether rollup/reconciliation needs separate roles. Do not use `SUPERUSER` as a machine-service shortcut.
+
+### Lease/job primitive reuse
+
+Recommendation: share conventions and utility patterns, but keep distribution jobs and metric checkpoints/import/export claims domain-specific. A new ADR is required before one universal persisted job framework.
+
+### CloudFront multi-country sessions
+
+The design counts one title session per country when one session contains qualifying requests from multiple countries. Confirm before WP7 fixtures are finalized.
+
+### OPERAS completeness
+
+Guaranteed import requires a created-at cursor, replication, complete snapshot or complete incremental endpoint. Rolling scans must remain explicitly unverified.
+
+### COUNTER subset
+
+Select report types and metric mappings only after representative reports are supplied. Unsupported metrics fail explicitly.
+
+## 4. Implementation invariants
+
+1. No resolver calls OPERAS.
+2. No driver writes canonical data outside Thoth.
+3. No browser contains service credentials.
+4. No dependency failure becomes zero.
+5. No source field silently expands canonical identity.
+6. New dimensions require explicit schema/API design.
+7. GitHub Actions does not own checkpoints or leases.
+8. Sphinx runs are restartable.
+9. Every row receives an explicit classification.
+10. Every source mapping is versioned and deterministic.

--- a/docs/metrics/decisions.md
+++ b/docs/metrics/decisions.md
@@ -1,7 +1,7 @@
 # Thoth Metrics Decision Summary
 
-Status: ACTIVE SUMMARY  
-Last updated: 2026-07-24  
+Status: ACTIVE SUMMARY
+Last updated: 2026-07-24
 Owner: CTO
 
 The approved technical design and approved ADRs remain authoritative.

--- a/docs/metrics/master-issue.md
+++ b/docs/metrics/master-issue.md
@@ -9,6 +9,8 @@ The GitHub issue is the live programme tracker.
 
 Repository authorities:
 
+- [Private approved design](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit)
+
 - [README](./README.md)
 - [Decisions](./decisions.md)
 - [Task status](./task-status.md)

--- a/docs/metrics/master-issue.md
+++ b/docs/metrics/master-issue.md
@@ -1,0 +1,69 @@
+# Master GitHub Issue - Thoth Metrics
+
+Suggested title:
+
+```text
+Thoth Metrics: canonical ingestion, Sphinx orchestration and client cutover
+```
+
+Suggested labels:
+
+```text
+programme
+metrics
+engineering-control
+```
+
+## Objective
+
+Make Thoth the canonical datastore and API for usage and sales metrics, with restartable Sphinx collection, publisher imports, coverage-aware rollups, protected dashboard/widget queries, OPERAS synchronization and reconciled historical migration.
+
+## Authoritative control
+
+- [README](./README.md)
+- [Decisions](./decisions.md)
+- [Task tracker](./task-status.md)
+- [Source inventory](./source-inventory.md)
+- [Contract register](./contract-register.md)
+- [Migration inventory](./migration-inventory.md)
+- [Acceptance](./acceptance-matrix.md)
+- [Rollout](./rollout-plan.md)
+
+## Current gate
+
+- [ ] MET-CTRL-01 merged
+- [ ] ADR-0001 approved
+- [ ] ADR-0002 approved
+- [ ] SPHINX-BOOT-01 complete
+- [ ] THOTH-DB-CTRL-01 complete
+- [ ] branch decisions recorded
+- [ ] service-role codes approved before WP5
+
+## Work
+
+- [ ] WP1 Domain/database
+- [ ] WP2 Ingestion
+- [ ] WP3 Imports/UI
+- [ ] WP4 Rollups/GraphQL
+- [ ] WP5 Auth/entitlements
+- [ ] WP6 Sphinx core
+- [ ] WP7 CloudFront
+- [ ] WP8 Other drivers/COUNTER
+- [ ] WP9 OPERAS/reconciliation
+- [ ] WP10 Clients
+- [ ] WP11 Deployment/migration
+- [ ] MET-E2E-01
+
+## Dependencies
+
+- [ ] representative source files
+- [ ] regenerated reports
+- [ ] COUNTER examples/selection
+- [ ] CloudFront resources/decision
+- [ ] OPERAS cursor/snapshot/replication
+- [ ] URI mappings
+- [ ] source retention/finalization
+
+For every task record repository, risk, specification, base/integration/slice branches, PR, contracts, fixtures, implementation/reviewer, evidence, migration, rollout and rollback.
+
+Do not close on code or CI alone. Close after independent approval, merge, required rollout, reconciliation and tracker update.

--- a/docs/metrics/master-issue.md
+++ b/docs/metrics/master-issue.md
@@ -1,69 +1,21 @@
-# Master GitHub Issue - Thoth Metrics
+# Thoth Metrics Master Issue
 
-Suggested title:
+Status: OPEN  
+Issue: [#766 - Thoth Metrics: canonical ingestion, Sphinx orchestration and client cutover](https://github.com/thoth-pub/thoth/issues/766)  
+Created: 2026-07-24  
+Owner: CTO
 
-```text
-Thoth Metrics: canonical ingestion, Sphinx orchestration and client cutover
-```
+The GitHub issue is the live programme tracker.
 
-Suggested labels:
-
-```text
-programme
-metrics
-engineering-control
-```
-
-## Objective
-
-Make Thoth the canonical datastore and API for usage and sales metrics, with restartable Sphinx collection, publisher imports, coverage-aware rollups, protected dashboard/widget queries, OPERAS synchronization and reconciled historical migration.
-
-## Authoritative control
+Repository authorities:
 
 - [README](./README.md)
 - [Decisions](./decisions.md)
-- [Task tracker](./task-status.md)
+- [Task status](./task-status.md)
 - [Source inventory](./source-inventory.md)
 - [Contract register](./contract-register.md)
 - [Migration inventory](./migration-inventory.md)
-- [Acceptance](./acceptance-matrix.md)
-- [Rollout](./rollout-plan.md)
+- [Acceptance matrix](./acceptance-matrix.md)
+- [Rollout plan](./rollout-plan.md)
 
-## Current gate
-
-- [ ] MET-CTRL-01 merged
-- [ ] ADR-0001 approved
-- [ ] ADR-0002 approved
-- [ ] SPHINX-BOOT-01 complete
-- [ ] THOTH-DB-CTRL-01 complete
-- [ ] branch decisions recorded
-- [ ] service-role codes approved before WP5
-
-## Work
-
-- [ ] WP1 Domain/database
-- [ ] WP2 Ingestion
-- [ ] WP3 Imports/UI
-- [ ] WP4 Rollups/GraphQL
-- [ ] WP5 Auth/entitlements
-- [ ] WP6 Sphinx core
-- [ ] WP7 CloudFront
-- [ ] WP8 Other drivers/COUNTER
-- [ ] WP9 OPERAS/reconciliation
-- [ ] WP10 Clients
-- [ ] WP11 Deployment/migration
-- [ ] MET-E2E-01
-
-## Dependencies
-
-- [ ] representative source files
-- [ ] regenerated reports
-- [ ] COUNTER examples/selection
-- [ ] CloudFront resources/decision
-- [ ] OPERAS cursor/snapshot/replication
-- [ ] URI mappings
-- [ ] source retention/finalization
-
-For every task record repository, risk, specification, base/integration/slice branches, PR, contracts, fixtures, implementation/reviewer, evidence, migration, rollout and rollback.
-
-Do not close on code or CI alone. Close after independent approval, merge, required rollout, reconciliation and tracker update.
+Update the issue and repository tracker together. A checked issue item is not completion without required independent review, merge, rollout and reconciliation evidence.

--- a/docs/metrics/master-issue.md
+++ b/docs/metrics/master-issue.md
@@ -1,8 +1,8 @@
 # Thoth Metrics Master Issue
 
-Status: OPEN  
-Issue: [#766 - Thoth Metrics: canonical ingestion, Sphinx orchestration and client cutover](https://github.com/thoth-pub/thoth/issues/766)  
-Created: 2026-07-24  
+Status: OPEN
+Issue: [#766 - Thoth Metrics: canonical ingestion, Sphinx orchestration and client cutover](https://github.com/thoth-pub/thoth/issues/766)
+Created: 2026-07-24
 Owner: CTO
 
 The GitHub issue is the live programme tracker.

--- a/docs/metrics/migration-inventory.md
+++ b/docs/metrics/migration-inventory.md
@@ -1,0 +1,50 @@
+# Thoth Metrics Historical Migration Inventory
+
+Status: TEMPLATE; DISCOVERY REQUIRED  
+Owner: Thoth Metrics programme  
+Production migration risk: CRITICAL
+
+## 1. Source table
+
+| Source account | Platform | Measure | Earliest | Latest | Grain | Dimensions | Raw retained | Generated retained | Stable IDs | Revisions | OPERAS mapping | Direct | Issues | Status |
+|---|---|---|---|---|---|---|---|---|---|---|---|---:|---|---|
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | TBD | NOT INVENTORIED |
+
+## 2. CloudFront
+
+Inventory original protected logs, object metadata, DOI rule history, bot/GeoIP versions, legacy outputs and known inflation. Recompute deterministically with `cloudfront-title-session/2`. Do not import legacy generated CSV totals as canonical.
+
+## 3. Platform reports
+
+For each source retain raw input and checksum, report ID, source account, format/version, coverage, regenerated-report handling, row counts, errors and rerun idempotency.
+
+## 4. OPERAS
+
+Record complete snapshot/cursor if available, remote IDs, uploader/event/measure URIs, hashes, links to known Thoth exports, direct-collection exclusion, unresolved mappings and completeness status. Legacy submission ledgers are provenance, not proof of complete remote state.
+
+## 5. Sequence
+
+1. Approve registries/mappings.
+2. Deploy schema inactive.
+3. Import retained source reports.
+4. Recompute CloudFront.
+5. Import legacy ledgers as provenance.
+6. Import complete OPERAS snapshot only for non-direct mappings.
+7. Build rollups.
+8. Reconcile all layers.
+9. Compare old/new clients.
+10. Activate sources.
+11. Cut clients over.
+12. Stop legacy submissions after observation.
+
+## 6. Dry run
+
+Produce input checksums, versions, expected imports/rows, accepted/duplicate/revision/conflict/invalid/overlap/unresolved counts, coverage, rollup delta, export count, reconciliation issues, no-write proof and rerun comparison.
+
+## 7. Stop conditions
+
+Stop on incomplete inventory, ambiguous ownership/identity, unapproved mappings, unexplained overlap, secret/personal-data exposure, unexpected export, unreconciled counts, dry-run mismatch or missing backup/restore readiness.
+
+## 8. Rollback
+
+Disable accounts/claims/serving/export, use audited retractions/repair, rebuild rollups and return clients to legacy reads. Do not manually delete canonical history.

--- a/docs/metrics/migration-inventory.md
+++ b/docs/metrics/migration-inventory.md
@@ -1,7 +1,7 @@
 # Thoth Metrics Historical Migration Inventory
 
-Status: TEMPLATE; DISCOVERY REQUIRED  
-Owner: Thoth Metrics programme  
+Status: TEMPLATE; DISCOVERY REQUIRED
+Owner: Thoth Metrics programme
 Production migration risk: CRITICAL
 
 ## 1. Source table

--- a/docs/metrics/rollout-plan.md
+++ b/docs/metrics/rollout-plan.md
@@ -1,7 +1,7 @@
 # Thoth Metrics Rollout Plan
 
-Status: PROPOSED CONTROLLED SEQUENCE  
-Owner: CTO  
+Status: PROPOSED CONTROLLED SEQUENCE
+Owner: CTO
 Production activation: explicit CTO approval required
 
 ## 1. Principles

--- a/docs/metrics/rollout-plan.md
+++ b/docs/metrics/rollout-plan.md
@@ -1,0 +1,57 @@
+# Thoth Metrics Rollout Plan
+
+Status: PROPOSED CONTROLLED SEQUENCE  
+Owner: CTO  
+Production activation: explicit CTO approval required
+
+## 1. Principles
+
+Add schema before behavior, keep accounts/schedules/serving/export disabled initially, version mappings, compare before cutover, never dual-write canonical stores, reconcile all layers, retain rollback and never turn missing coverage into zero.
+
+## 2. Stage 0 - Control/readiness
+
+Require PR #764, approved ADRs, master issue, Sphinx bootstrap, branch decisions, Diesel procedure and role decision before WP5.
+
+## 3. Stage 1 - Canonical schema
+
+Deliver WP1 slices additively. Registries/accounts/routes/export stay disabled. Prove migrations, constraints, seeds, rollback and query baseline.
+
+## 4. Stage 2 - Ingestion
+
+Deliver WP2 against fixtures and disposable environments. Use bounded batches, central resolution, transactional identity/overlap handling, provenance and no production source credentials.
+
+## 5. Stage 3 - Rollups/protected queries
+
+Deliver WP4/WP5 behind inactive flags. Prove correctness, p95, coverage, authorization, capability checks and rebuild.
+
+## 6. Stage 4 - Sphinx core
+
+Deliver WP6 after bootstrap. No local durable DB, no production credentials, no-op driver first, overlapping/restart tests and pinned API contract.
+
+## 7. Stage 5 - CloudFront pilot
+
+Use one source account and bounded day with adjacent context. Dry-run, compare golden results, ingest non-production, verify coverage/rollup, recompute a small window, review legacy divergence, then enable collection without serving/export. Stop on personal-data leakage or unexplained differences.
+
+## 8. Stage 6 - Publisher import pilot
+
+Use one entitled publisher and approved platform. Verify private upload, ownership, approval, partial errors, duplicate retry, changed-value conflict and error download. Keep OPERAS export off.
+
+## 9. Stage 7 - Additional sources
+
+Enable one source account at a time only after its fixture/mapping gate. COUNTER support must not approximate unsupported metrics.
+
+## 10. Stage 8 - OPERAS
+
+Pilot one mapping/publisher/date scope. Inbound remains disabled without complete discovery or explicitly unverified. Historical export is never an upgrade side effect.
+
+## 11. Stage 9 - Client comparison/cutover
+
+Compare selected publishers/periods/measures/dimensions/coverage and known legacy divergence. A read fallback may exist temporarily; never write to two canonical stores.
+
+## 12. Stage 10 - Migration/operations
+
+Use the migration inventory, versioned normalizers, CloudFront recomputation, no accidental export, restore readiness, monitoring, runbooks and reconciliation. Production requires CTO approval.
+
+## 13. Observation/cleanup
+
+Observe freshness, errors, unresolved identifiers, rollup lag, export backlog, reconciliation, latency, coverage and late changes. Cleanup of legacy paths requires MET-E2E-01, stable observation, independent review and CTO approval.

--- a/docs/metrics/source-inventory.md
+++ b/docs/metrics/source-inventory.md
@@ -1,0 +1,79 @@
+# Metrics Source and Driver Inventory
+
+Status: INITIAL DESIGN INVENTORY; SOURCE MAPPINGS NOT APPROVED  
+Owner: Thoth Metrics programme  
+Evidence date: 2026-07-24
+
+## 1. Purpose
+
+Track where activity occurred (`MetricPlatform`), how it arrived (`MetricSource`), the concrete account (`MetricSourceAccount`), measure/grain/dimensions, fixture readiness and OPERAS behavior.
+
+Distribution assignments do not authorize metrics.
+
+## 2. Initial candidates
+
+| Source/route | Candidate platform | Candidate measure | Grain | Dimensions | Acquisition | Fixture state | Mapping state | Readiness |
+|---|---|---|---|---|---|---|---|---|
+| CloudFront logs | publisher website/CDN | `title_sessions` | DAY | work, country | DRIVER | protected samples required | methodology fixed; path/resources required | SAMPLE REQUIRED |
+| Thoth CSV v1 | approved publisher platform | approved usage or `net_units` | DAY/MONTH/PERIOD | publication/country/institution optional | PUBLISHER_UPLOAD | canonical examples to create | common contract fixed | BLOCKED ON WP1/WP2 |
+| COUNTER 5 | approved publisher platform | selected mappings | report-dependent | report-dependent | PUBLISHER_UPLOAD | representative reports required | unresolved | SAMPLE + MAPPING |
+| OAPEN | OAPEN metric platform | source-defined usage | likely day/month | source-dependent | DRIVER or OPERAS | examples required | unresolved | SAMPLE + MAPPING |
+| JSTOR | JSTOR metric platform | source-defined usage | likely month | source-dependent | TBD | examples required | unresolved | SAMPLE + MAPPING |
+| OpenEdition | OpenEdition metric platform | source-defined usage | TBD | TBD | DRIVER or OPERAS | examples required | unresolved | SAMPLE + MAPPING |
+| Other collectors | separate platforms | source-specific | TBD | TBD | DRIVER | inventory required | unresolved | DISCOVERY |
+| OPERAS mirror | mapped external platforms | configured | remote grain | supported projection | OPERAS | snapshot/scan fixtures | URI mappings required | EXTERNAL BLOCKER |
+| Admin historical import | approved mapping | preserved measure | source grain | source dimensions | ADMIN_IMPORT | retained inventory | versioned normalizer | MIGRATION ONLY |
+
+## 3. Required fixture set per source
+
+- valid ordinary/minimum/multi-work examples;
+- supported periods and dimensions;
+- malformed identifiers/dates/values;
+- duplicates and regenerated reports;
+- partial and empty successful reports;
+- coverage/finalization evidence;
+- stable report IDs or manifest fields;
+- checksum/ETag behavior;
+- credential-free sanitized data.
+
+No fixture may contain secrets, IP addresses or prohibited personal data.
+
+## 4. Driver scoping record
+
+```text
+Source code:
+Metric platform:
+Source account key:
+Ownership class:
+Measures:
+Grains:
+Country/institution/publication support:
+Discovery:
+Checkpoint:
+Lookback:
+Finalization:
+Upstream report ID:
+Retention:
+Manifest:
+Coverage:
+Revision behavior:
+Schedule:
+Credential owner/storage:
+Failure semantics:
+OPERAS direct_collection:
+Fixtures:
+Normalizer version:
+Methodology version:
+```
+
+## 5. CloudFront gate
+
+Require protected previous/target/following-day samples, DOI path rules, bot/GeoIP versions, unknown-country handling, multi-country decision, deterministic expected aggregates and confirmation that raw personal data stays in place.
+
+## 6. COUNTER gate
+
+Require report type/version examples, desired metric types, identifiers, periods, institution handling, suppression/zero semantics, regeneration behavior and approval ownership. Unsupported sections fail explicitly.
+
+## 7. OPERAS gate
+
+Require stable event/uploader/measure mappings, complete cursor/snapshot/replication or explicit unverified mode, loop prevention, exported-event identification, dimension projection, finalization, divergence semantics and reconciliation fixtures.

--- a/docs/metrics/source-inventory.md
+++ b/docs/metrics/source-inventory.md
@@ -1,7 +1,7 @@
 # Metrics Source and Driver Inventory
 
-Status: INITIAL DESIGN INVENTORY; SOURCE MAPPINGS NOT APPROVED  
-Owner: Thoth Metrics programme  
+Status: INITIAL DESIGN INVENTORY; SOURCE MAPPINGS NOT APPROVED
+Owner: Thoth Metrics programme
 Evidence date: 2026-07-24
 
 ## 1. Purpose

--- a/docs/metrics/task-status.md
+++ b/docs/metrics/task-status.md
@@ -19,7 +19,7 @@ A work package is not one implementation task. Each must be decomposed into boun
 | ADR-0002 Platform boundaries | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision | #766 |
 | SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `develop`; target `develop` after BR-SPHINX-01 verification | MET-CTRL-01; BR-SPHINX-01; approved bootstrap spec | #766 |
 | THOTH-DB-CTRL-01 Diesel generation procedure | `thoth` | MEDIUM | BLOCKED | `develop` -> `develop` | verified procedure | #766 |
-| BR-DASH-01 Dashboard branch readiness | dashboard | HIGH | BLOCKED | actual `develop`/`main` | Vercel rollback | #766 |
+| BR-DASH-01 Dashboard branch readiness | dashboard | HIGH | BLOCKED | observed `dev -> main`; reconcile stale `develop`, then normalize to `develop -> master` | Vercel rollback | #766 |
 | BR-WIDGET-01 Widget branch readiness | widget | HIGH | BLOCKED | actual `dev`/`main` | npm release protection | #766 |
 | BR-APP-01 App branch readiness | app | HIGH | BLOCKED | actual `dev`/`main` | Vercel branch plan | #766 |
 
@@ -47,6 +47,11 @@ develop -> feature/metrics -> feature/metrics/<slice> -> feature/metrics -> deve
 ```
 
 Do not create integration branches until a verified `develop` branch and release-protection decision exist.
+
+For `metrics-dashboard`, do not create `feature/metrics` from the stale
+`develop` branch. BR-DASH-01 must first reconcile active `dev` history into the
+target `develop` branch, or an explicit CTO exception must authorize another
+verified base.
 
 ## 5. Immediate next actions
 

--- a/docs/metrics/task-status.md
+++ b/docs/metrics/task-status.md
@@ -2,7 +2,7 @@
 
 Status: ACTIVE TRACKER  
 Programme owner: CTO  
-Master issue: NOT YET CREATED  
+Master issue: [#766](https://github.com/thoth-pub/thoth/issues/766)  
 Last updated: 2026-07-24
 
 ## 1. Control rule
@@ -11,60 +11,48 @@ A work package is not one implementation task. Each must be decomposed into boun
 
 ## 2. Foundation and readiness
 
-| Task | Repository | Risk | Status | Base / target | Dependencies |
-|---|---|---:|---|---|---|
-| MET-CTRL-01 Programme controls | `thoth` | LOW | IN PROGRESS | PR #764 -> `develop` | independent review; master issue |
-| ADR-0001 Package capability model | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision |
-| ADR-0002 Platform boundaries | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision |
-| SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `main`; approved bootstrap required | MET-CTRL-01; branch decision |
-| THOTH-DB-CTRL-01 Diesel generation procedure | `thoth` | MEDIUM | BLOCKED | `develop` -> `develop` | verified procedure |
-| BR-DASH-01 Dashboard branch readiness | dashboard | HIGH | BLOCKED | actual `develop`/`main` | Vercel rollback |
-| BR-WIDGET-01 Widget branch readiness | widget | HIGH | BLOCKED | actual `dev`/`main` | npm release protection |
-| BR-APP-01 App branch readiness | app | HIGH | BLOCKED | actual `dev`/`main` | Vercel branch plan |
+| Task | Repository | Risk | Status | Base / target | Dependencies | Issue |
+|---|---|---:|---|---|---|---|
+| MET-CTRL-01 Programme controls | `thoth` | LOW | IN PROGRESS | PR #764 -> `develop` | independent review; merge | [#766](https://github.com/thoth-pub/thoth/issues/766) |
+| ADR-0001 Package capability model | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision | #766 |
+| ADR-0002 Platform boundaries | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision | #766 |
+| SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `main`; approved bootstrap required | MET-CTRL-01; branch decision | #766 |
+| THOTH-DB-CTRL-01 Diesel generation procedure | `thoth` | MEDIUM | BLOCKED | `develop` -> `develop` | verified procedure | #766 |
+| BR-DASH-01 Dashboard branch readiness | dashboard | HIGH | BLOCKED | actual `develop`/`main` | Vercel rollback | #766 |
+| BR-WIDGET-01 Widget branch readiness | widget | HIGH | BLOCKED | actual `dev`/`main` | npm release protection | #766 |
+| BR-APP-01 App branch readiness | app | HIGH | BLOCKED | actual `dev`/`main` | Vercel branch plan | #766 |
 
 ## 3. Work packages
 
-| WP | Scope | Repositories | Risk | Status | Blocking dependencies |
-|---|---|---|---:|---|---|
-| WP1 | Domain and database foundation | `thoth` | HIGH | BLOCKED | MET-CTRL-01; ADRs; Diesel control |
-| WP2 | Canonical ingestion | `thoth` | CRITICAL | BLOCKED | WP1 |
-| WP3 | Upload API and publisher UI | `thoth`, app | HIGH | BLOCKED | WP1/WP2; ADR-0001; BR-APP-01 |
-| WP4 | Rollups and GraphQL | `thoth` | HIGH | BLOCKED | WP1/WP2; benchmark dataset |
-| WP5 | Service auth and entitlements | `thoth`, clients | CRITICAL | BLOCKED | ADR-0001; role decision; WP4 |
-| WP6 | Sphinx core | `thoth-sphinx` | HIGH | BLOCKED | bootstrap; pinned API contract |
-| WP7 | CloudFront driver | `thoth-sphinx` | HIGH | BLOCKED | WP6; fixtures; methodology confirmation |
-| WP8 | Additional drivers and COUNTER | Sphinx/app | HIGH | BLOCKED | WP6; source fixtures; COUNTER decision |
-| WP9 | OPERAS and reconciliation | Thoth/Sphinx | CRITICAL | BLOCKED | WP1/WP2/WP6; mappings; completeness route |
-| WP10 | Dashboard and widget clients | clients/Thoth | HIGH | BLOCKED | WP4/WP5; client CI/tests |
-| WP11 | Deployment, monitoring, migration | multiple | CRITICAL | BLOCKED | WP1-WP10 |
-| MET-E2E-01 | Integrated acceptance/cutover | multiple | CRITICAL | BLOCKED | all production slices |
+| WP | Scope | Repositories | Risk | Status | Blocking dependencies | Issue |
+|---|---|---|---:|---|---|---|
+| WP1 | Domain and database foundation | `thoth` | HIGH | BLOCKED | MET-CTRL-01; ADRs; Diesel control | #766 |
+| WP2 | Canonical ingestion | `thoth` | CRITICAL | BLOCKED | WP1 | #766 |
+| WP3 | Upload API and publisher UI | `thoth`, app | HIGH | BLOCKED | WP1/WP2; ADR-0001; BR-APP-01 | #766 |
+| WP4 | Rollups and GraphQL | `thoth` | HIGH | BLOCKED | WP1/WP2; benchmark dataset | #766 |
+| WP5 | Service auth and entitlements | `thoth`, clients | CRITICAL | BLOCKED | ADR-0001; role decision; WP4 | #766 |
+| WP6 | Sphinx core | `thoth-sphinx` | HIGH | BLOCKED | bootstrap; pinned API contract | #766 |
+| WP7 | CloudFront driver | `thoth-sphinx` | HIGH | BLOCKED | WP6; fixtures; methodology confirmation | #766 |
+| WP8 | Additional drivers and COUNTER | Sphinx/app | HIGH | BLOCKED | WP6; source fixtures; COUNTER decision | #766 |
+| WP9 | OPERAS and reconciliation | Thoth/Sphinx | CRITICAL | BLOCKED | WP1/WP2/WP6; mappings; completeness route | #766 |
+| WP10 | Dashboard and widget clients | clients/Thoth | HIGH | BLOCKED | WP4/WP5; client CI/tests | #766 |
+| WP11 | Deployment, monitoring, migration | multiple | CRITICAL | BLOCKED | WP1-WP10 | #766 |
+| MET-E2E-01 | Integrated acceptance/cutover | multiple | CRITICAL | BLOCKED | all production slices | #766 |
 
-## 4. Recommended decomposition
-
-WP1 should be split into registry/seed, source/checkpoint/approval, import/error, record/revision/provenance/coverage, rollup, OPERAS ledgers and admin GraphQL slices.
-
-WP2 should be split into normalized contract, identifier resolution, hashing, duplicate/conflict/revision transaction, overlap, publisher finality, bounded GraphQL ingestion and summaries/provenance.
-
-WP4 should be split into rollup application, rebuild/watermark, entity fields, dashboard, widget, coverage, limits and evidence-led performance tuning.
-
-WP6 should be split into workspace bootstrap completion, core, Thoth client, storage, runner, OPERAS boundary and no-op E2E.
-
-## 5. Branch strategy
-
-Target per repository:
+## 4. Branch strategy
 
 ```text
 develop -> feature/metrics -> feature/metrics/<slice> -> feature/metrics -> develop
 ```
 
-Do not create integration branches until verified `develop` and release protection exist.
+Do not create integration branches until a verified `develop` branch and release-protection decision exist.
 
-## 6. Immediate next actions
+## 5. Immediate next actions
 
-1. Create the master issue.
-2. Record its number.
-3. Complete/review PR #764.
-4. Approve or amend ADR-0001 and ADR-0002.
+1. Independently review PR #764.
+2. Resolve review findings.
+3. Approve or amend ADR-0001 and ADR-0002.
+4. Merge the engineering-control foundation.
 5. Scope SPHINX-BOOT-01.
 6. Resolve THOTH-DB-CTRL-01.
-7. Then prepare the first WP1 slice.
+7. Prepare the first bounded WP1 slice only after those gates.

--- a/docs/metrics/task-status.md
+++ b/docs/metrics/task-status.md
@@ -1,8 +1,8 @@
 # Thoth Metrics Task Status
 
-Status: ACTIVE TRACKER  
-Programme owner: CTO  
-Master issue: [#766](https://github.com/thoth-pub/thoth/issues/766)  
+Status: ACTIVE TRACKER
+Programme owner: CTO
+Master issue: [#766](https://github.com/thoth-pub/thoth/issues/766)
 Last updated: 2026-07-24
 
 ## 1. Control rule

--- a/docs/metrics/task-status.md
+++ b/docs/metrics/task-status.md
@@ -1,0 +1,70 @@
+# Thoth Metrics Task Status
+
+Status: ACTIVE TRACKER  
+Programme owner: CTO  
+Master issue: NOT YET CREATED  
+Last updated: 2026-07-24
+
+## 1. Control rule
+
+A work package is not one implementation task. Each must be decomposed into bounded repository-local tasks with an approved specification, one slice branch/PR, actual base/target, risk, dependencies, tests, migration/rollout/rollback and independent review.
+
+## 2. Foundation and readiness
+
+| Task | Repository | Risk | Status | Base / target | Dependencies |
+|---|---|---:|---|---|---|
+| MET-CTRL-01 Programme controls | `thoth` | LOW | IN PROGRESS | PR #764 -> `develop` | independent review; master issue |
+| ADR-0001 Package capability model | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision |
+| ADR-0002 Platform boundaries | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision |
+| SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `main`; approved bootstrap required | MET-CTRL-01; branch decision |
+| THOTH-DB-CTRL-01 Diesel generation procedure | `thoth` | MEDIUM | BLOCKED | `develop` -> `develop` | verified procedure |
+| BR-DASH-01 Dashboard branch readiness | dashboard | HIGH | BLOCKED | actual `develop`/`main` | Vercel rollback |
+| BR-WIDGET-01 Widget branch readiness | widget | HIGH | BLOCKED | actual `dev`/`main` | npm release protection |
+| BR-APP-01 App branch readiness | app | HIGH | BLOCKED | actual `dev`/`main` | Vercel branch plan |
+
+## 3. Work packages
+
+| WP | Scope | Repositories | Risk | Status | Blocking dependencies |
+|---|---|---|---:|---|---|
+| WP1 | Domain and database foundation | `thoth` | HIGH | BLOCKED | MET-CTRL-01; ADRs; Diesel control |
+| WP2 | Canonical ingestion | `thoth` | CRITICAL | BLOCKED | WP1 |
+| WP3 | Upload API and publisher UI | `thoth`, app | HIGH | BLOCKED | WP1/WP2; ADR-0001; BR-APP-01 |
+| WP4 | Rollups and GraphQL | `thoth` | HIGH | BLOCKED | WP1/WP2; benchmark dataset |
+| WP5 | Service auth and entitlements | `thoth`, clients | CRITICAL | BLOCKED | ADR-0001; role decision; WP4 |
+| WP6 | Sphinx core | `thoth-sphinx` | HIGH | BLOCKED | bootstrap; pinned API contract |
+| WP7 | CloudFront driver | `thoth-sphinx` | HIGH | BLOCKED | WP6; fixtures; methodology confirmation |
+| WP8 | Additional drivers and COUNTER | Sphinx/app | HIGH | BLOCKED | WP6; source fixtures; COUNTER decision |
+| WP9 | OPERAS and reconciliation | Thoth/Sphinx | CRITICAL | BLOCKED | WP1/WP2/WP6; mappings; completeness route |
+| WP10 | Dashboard and widget clients | clients/Thoth | HIGH | BLOCKED | WP4/WP5; client CI/tests |
+| WP11 | Deployment, monitoring, migration | multiple | CRITICAL | BLOCKED | WP1-WP10 |
+| MET-E2E-01 | Integrated acceptance/cutover | multiple | CRITICAL | BLOCKED | all production slices |
+
+## 4. Recommended decomposition
+
+WP1 should be split into registry/seed, source/checkpoint/approval, import/error, record/revision/provenance/coverage, rollup, OPERAS ledgers and admin GraphQL slices.
+
+WP2 should be split into normalized contract, identifier resolution, hashing, duplicate/conflict/revision transaction, overlap, publisher finality, bounded GraphQL ingestion and summaries/provenance.
+
+WP4 should be split into rollup application, rebuild/watermark, entity fields, dashboard, widget, coverage, limits and evidence-led performance tuning.
+
+WP6 should be split into workspace bootstrap completion, core, Thoth client, storage, runner, OPERAS boundary and no-op E2E.
+
+## 5. Branch strategy
+
+Target per repository:
+
+```text
+develop -> feature/metrics -> feature/metrics/<slice> -> feature/metrics -> develop
+```
+
+Do not create integration branches until verified `develop` and release protection exist.
+
+## 6. Immediate next actions
+
+1. Create the master issue.
+2. Record its number.
+3. Complete/review PR #764.
+4. Approve or amend ADR-0001 and ADR-0002.
+5. Scope SPHINX-BOOT-01.
+6. Resolve THOTH-DB-CTRL-01.
+7. Then prepare the first WP1 slice.

--- a/docs/metrics/task-status.md
+++ b/docs/metrics/task-status.md
@@ -3,6 +3,7 @@
 Status: ACTIVE TRACKER
 Programme owner: CTO
 Master issue: [#766](https://github.com/thoth-pub/thoth/issues/766)
+Approved design: [private Google Doc](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit), Drive revision `6`
 Last updated: 2026-07-24
 
 ## 1. Control rule
@@ -16,7 +17,7 @@ A work package is not one implementation task. Each must be decomposed into boun
 | MET-CTRL-01 Programme controls | `thoth` | LOW | IN PROGRESS | PR #764 -> `develop` | independent review; merge | [#766](https://github.com/thoth-pub/thoth/issues/766) |
 | ADR-0001 Package capability model | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision | #766 |
 | ADR-0002 Platform boundaries | `thoth` | MEDIUM | PROPOSED | PR #764 -> `develop` | CTO decision | #766 |
-| SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `main`; approved bootstrap required | MET-CTRL-01; branch decision | #766 |
+| SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `develop`; target `develop` after BR-SPHINX-01 verification | MET-CTRL-01; BR-SPHINX-01; approved bootstrap spec | #766 |
 | THOTH-DB-CTRL-01 Diesel generation procedure | `thoth` | MEDIUM | BLOCKED | `develop` -> `develop` | verified procedure | #766 |
 | BR-DASH-01 Dashboard branch readiness | dashboard | HIGH | BLOCKED | actual `develop`/`main` | Vercel rollback | #766 |
 | BR-WIDGET-01 Widget branch readiness | widget | HIGH | BLOCKED | actual `dev`/`main` | npm release protection | #766 |

--- a/docs/publisher-services/README.md
+++ b/docs/publisher-services/README.md
@@ -1,0 +1,119 @@
+# Publisher Services and Distribution Configuration
+
+Status: CONTROL FOUNDATION IN PROGRESS  
+Programme owner: CTO  
+Primary coordinating repository: `thoth-pub/thoth`  
+Related repositories:
+
+- `thoth-pub/thoth-app`
+- `thoth-pub/thoth-dissemination`
+- `thoth-pub/cc-license`
+
+Deferred implementation:
+
+- OAI-PMH work currently associated with `feature/oai-pmh-http` in `thoth`
+
+## 1. Purpose
+
+This directory is the repository-backed control surface for implementing publisher packages, explicit distribution-platform assignments, durable back-catalogue jobs, licence enforcement, staff interfaces, dissemination cutover, OCLC KB feed discovery and later OAI-PMH eligibility.
+
+The approved technical design remains the architectural source. These files turn that design into:
+
+- a decision register;
+- an executable task/dependency tracker;
+- a verified platform-inventory baseline;
+- acceptance evidence requirements;
+- rollout and rollback gates.
+
+## 2. Programme outcome
+
+Thoth becomes authoritative for desired publisher service configuration:
+
+- every publisher has exactly one non-null package;
+- every publisher has an explicit set of enabled distribution platforms;
+- package and platform configuration are independent;
+- publisher users may read their own configuration;
+- only superusers may change it;
+- durable jobs represent automatic back-catalogue work;
+- dissemination temporarily remains the push-delivery executor;
+- legacy publisher-ID environment lists are removed only after comparison and observation;
+- OAI-PMH later uses package capability plus canonical open-licence and lifecycle rules.
+
+## 3. Programme non-goals
+
+This programme does not initially:
+
+- implement work-level distribution choices;
+- port every uploader to Rust;
+- add complete per-work/per-platform observed delivery state;
+- add general metadata-change events or withdrawals;
+- make package choice imply platform assignments;
+- expose package values anonymously;
+- merge distribution and metrics platform domains;
+- activate deferred OAI-PMH before its dependencies and branch assessment pass.
+
+## 4. Authority and required reading
+
+Read in this order:
+
+1. approved Publisher Services technical design;
+2. approved cross-programme ADRs under `docs/engineering/decisions/`;
+3. this directory;
+4. task specifications;
+5. repository-local `AGENTS.md`;
+6. live code, migrations, PRs and CI.
+
+Where sources conflict, stop and escalate. Chat history is not authoritative.
+
+## 5. Current programme decision
+
+```text
+BLOCKED FOR IMPLEMENTATION
+```
+
+Reasons:
+
+1. `P0-01` is still part of the unmerged engineering-control foundation.
+2. `ADR-0001` package capability model is `PROPOSED`.
+3. `ADR-0002` platform domain boundaries is `PROPOSED`.
+4. Publisher Services `ADR-01` has not finalized the distribution-platform enum.
+5. Branch-readiness tasks are required before work in repositories whose current topology differs from policy.
+
+Discovery and documentation may continue. Production implementation must not start.
+
+## 6. Files
+
+- `decisions.md` - settled, proposed and unresolved decisions.
+- `task-status.md` - task dependencies, repository, branch, risk and evidence status.
+- `platform-inventory.md` - verified current dissemination baseline and ADR-01 questions.
+- `acceptance-matrix.md` - programme requirements mapped to evidence.
+- `rollout-plan.md` - additive rollout, comparison, pilot, observation and rollback.
+- `master-issue.md` - body for the programme's GitHub tracking issue.
+
+## 7. Status vocabulary
+
+- `PLANNED` - scoped in the approved design but not ready.
+- `BLOCKED` - cannot safely start because a prerequisite is missing.
+- `READY` - written specification and dependencies are approved.
+- `IN PROGRESS` - one approved branch/PR is active.
+- `CHANGES REQUIRED` - review found blocking work.
+- `APPROVED` - independently reviewed and merge-ready.
+- `MERGED` - repository merge complete.
+- `ROLLED OUT` - intended environment activation complete.
+- `CLOSED` - observation, reconciliation and tracker updates complete.
+
+A task is not complete merely because code exists or CI passes.
+
+## 8. Implementation rule
+
+Each implementation task receives:
+
+- an approved written specification;
+- one bounded slice branch and PR;
+- exact base and target branches;
+- risk classification;
+- required tests;
+- migration, rollout and rollback sections;
+- independent review.
+
+Implementers may not merge, deploy, access production secrets or approve their own work.

--- a/docs/publisher-services/README.md
+++ b/docs/publisher-services/README.md
@@ -1,8 +1,8 @@
 # Publisher Services and Distribution Configuration
 
-Status: CONTROL FOUNDATION IN PROGRESS  
-Programme owner: CTO  
-Primary coordinating repository: `thoth-pub/thoth`  
+Status: CONTROL FOUNDATION IN PROGRESS
+Programme owner: CTO
+Primary coordinating repository: `thoth-pub/thoth`
 Related repositories:
 
 - `thoth-pub/thoth-app`

--- a/docs/publisher-services/README.md
+++ b/docs/publisher-services/README.md
@@ -17,7 +17,7 @@ Deferred implementation:
 
 This directory is the repository-backed control surface for implementing publisher packages, explicit distribution-platform assignments, durable back-catalogue jobs, licence enforcement, staff interfaces, dissemination cutover, OCLC KB feed discovery and later OAI-PMH eligibility.
 
-The approved technical design remains the architectural source. These files turn that design into:
+The approved design is the [private Google Doc](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit), Drive revision `3`, indexed in [`docs/engineering/design-references.md`](../engineering/design-references.md). These files turn that design into:
 
 - a decision register;
 - an executable task/dependency tracker;
@@ -56,7 +56,7 @@ This programme does not initially:
 
 Read in this order:
 
-1. approved Publisher Services technical design;
+1. [private approved Publisher Services design](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit);
 2. approved cross-programme ADRs under `docs/engineering/decisions/`;
 3. this directory;
 4. task specifications;

--- a/docs/publisher-services/acceptance-matrix.md
+++ b/docs/publisher-services/acceptance-matrix.md
@@ -1,0 +1,104 @@
+# Publisher Services Acceptance Matrix
+
+Status: ACTIVE CONTROL MATRIX  
+Owner: CTO
+
+This matrix records the minimum evidence required for programme acceptance. Task specifications may add stricter criteria.
+
+## 1. Programme-level requirements
+
+| Requirement | Owning task(s) | Required evidence | Activation gate |
+|---|---|---|---|
+| Every publisher has one non-null package | BE-01, MIG-01 | migration tests on empty/populated DB; production dry-run counts; post-backfill query | schema/backfill approval |
+| OASIS is the default | BE-01 | existing/new publisher tests | backend merge |
+| Package does not imply platforms | BE-01, BE-03 | unit/integration tests showing unchanged assignments/jobs | backend merge |
+| Publisher reads own package/platforms only | BE-03, APP-01 | anonymous, wrong-org, correct-org, superuser tests | API/UI activation |
+| Only superusers change configuration | BE-03, APP-01 | backend authorization tests; UI control absence | API/UI activation |
+| Linked OAPEN/DOAB normalized server-side | ADR-01, BE-02, BE-03 | one-sided state impossible; one logical activation identity | backend merge |
+| One linked activation creates one logical job | BE-04 | transactional job/target tests | worker pilot |
+| Pull/manual destinations create no upload job | BE-02, BE-04 | exhaustive descriptor/job tests | backend merge |
+| Configuration changes are audited atomically | BE-03 | transaction tests including failure rollback | backend merge |
+| Claims are exclusive and leased | BE-04 | concurrency and stale-token tests | worker deployment |
+| Legacy assignments backfill without jobs | MIG-01 | reviewed dry run; repeat run no-op; job count unchanged | production backfill |
+| Dissemination API mode fails closed | DIS-01 | API failure and empty-list tests | comparison activation |
+| Comparison mode is clean before cutover | DIS-01 | publisher/platform diff report reviewed and signed off | API source cutover |
+| Back-catalogue worker is at-least-once safe | DIS-02 | retry/idempotency/concurrency tests; controlled pilot | general job creation |
+| OCLC index reflects enabled publishers | EXP-01 | JSON/text equivalence, deterministic order, cache tests | public endpoint |
+| Licence options come from `cc-license` | LIC-01, LIC-02, APP-03 | canonicalization/spoof tests; all write paths; generated client | strict enforcement |
+| OAI filtering occurs before pagination | OAI-01 | GetRecord/List*/count/token matrix | OAI activation |
+| OASIS/non-open works never leak to OAI | OAI-01 | complete package/licence/lifecycle matrix | OAI activation |
+| Monitoring and rollback are operational | OPS-01 | dashboards, alerts, runbooks, named owners, exercise evidence | production enablement |
+| Full flow works end to end | E2E-01 | configuration -> job -> adapter -> result/report evidence | cleanup |
+| Legacy configuration retained through observation | DIS-01, DIS-02, OPS-01 | observation record and explicit cleanup approval | cleanup |
+
+## 2. Cross-cutting technical evidence
+
+Every applicable task must provide:
+
+### Authorization
+
+- anonymous;
+- authenticated without permission;
+- another publisher's scope;
+- correct publisher scope;
+- superuser;
+- worker/service role;
+- stale or invalid credentials.
+
+### Migrations
+
+- forward migration;
+- revert or approved forward repair;
+- empty database;
+- representative populated database;
+- defaults and nullability;
+- constraints and indexes;
+- locking/downtime assessment;
+- generated Diesel schema;
+- deployment order.
+
+### Pagination and reports
+
+- deterministic ordering;
+- bounded page size;
+- filters applied before pagination;
+- counts match filtered results;
+- CSV respects the same filters;
+- no protected package leakage.
+
+### Jobs and workflows
+
+- duplicate activation;
+- retry;
+- stale lease;
+- overlapping workers;
+- partial adapter failure;
+- empty scope;
+- unknown platform;
+- pull/manual platform;
+- linked multi-target platform;
+- sanitized bounded error storage.
+
+### Compatibility
+
+- GraphQL schema;
+- internal Rust client;
+- `thoth-app` generated client;
+- dissemination mapping;
+- export formats;
+- OAI tokens and counts;
+- current publisher configuration.
+
+## 3. Definition of programme done
+
+Publisher Services is not done until:
+
+1. all required tasks are independently approved and merged;
+2. production backfill is reconciled;
+3. comparison mode is clean;
+4. one controlled automatic-push pilot succeeds;
+5. monitoring and rollback are verified;
+6. E2E-01 passes;
+7. the observation period closes without unresolved P0/P1 findings;
+8. cleanup receives explicit CTO approval;
+9. task tracker and repository status are updated.

--- a/docs/publisher-services/acceptance-matrix.md
+++ b/docs/publisher-services/acceptance-matrix.md
@@ -1,6 +1,6 @@
 # Publisher Services Acceptance Matrix
 
-Status: ACTIVE CONTROL MATRIX  
+Status: ACTIVE CONTROL MATRIX
 Owner: CTO
 
 This matrix records the minimum evidence required for programme acceptance. Task specifications may add stricter criteria.

--- a/docs/publisher-services/decisions.md
+++ b/docs/publisher-services/decisions.md
@@ -1,0 +1,148 @@
+# Publisher Services Decision Summary
+
+Status: ACTIVE SUMMARY  
+Last updated: 2026-07-24  
+Owner: CTO
+
+This file summarizes decisions. The approved technical design and approved ADRs remain authoritative.
+
+## 1. Settled product decisions
+
+### Packages
+
+The package enum is:
+
+```text
+OASIS
+OBELISK
+SPHINX
+PYRAMID
+```
+
+Every publisher has exactly one package.
+
+OASIS is the non-null default.
+
+Publisher users may read their own package. Only superusers may change it. Package values are not anonymous public data.
+
+Package choice does not itself enable or disable distribution platforms.
+
+### Distribution assignments
+
+Every independently meaningful destination has its own `DistributionPlatform` value.
+
+Assignments are explicit publisher configuration.
+
+Disabled rows are retained for history. Re-enabling creates a new activation identity.
+
+OAPEN and DOAB are separate destinations but initially form one linked selection. They map to one logical delivery adapter and must not upload twice.
+
+### Licence authority
+
+`thoth-pub/cc-license` is authoritative for supported Creative Commons licences and retained public-domain tools.
+
+Thoth must not independently parse or normalize Creative Commons URLs.
+
+A missing licence is `NULL` and means no declared open licence/All Rights Reserved.
+
+### OAI-PMH eligibility
+
+OAI-PMH is deferred.
+
+A work is eligible only when:
+
+1. the publisher has the approved OAI package capability;
+2. the work has a licence recognized as open by `cc-license`;
+3. existing lifecycle and metadata requirements pass.
+
+OASIS is excluded. Non-open works are excluded for every package.
+
+### Desired, job and observed state
+
+Keep separate:
+
+- desired publisher configuration;
+- durable execution jobs;
+- future observed per-work/per-platform delivery state.
+
+This programme initially implements desired state and durable publisher back-catalogue jobs only.
+
+## 2. Proposed shared decisions awaiting CTO approval
+
+### ADR-0001 - Package capability model
+
+Proposes:
+
+- code-owned exhaustive capability mappings;
+- metrics collection permitted independently of serving/export;
+- retained metrics visible after an entitled upgrade;
+- no automatic historical OPERAS bulk export after upgrade;
+- package changes never alter distribution assignments.
+
+Implementation dependency:
+
+- `BE-01`
+- metrics entitlement tasks
+- `OAI-01`
+
+### ADR-0002 - Platform domain boundaries
+
+Proposes:
+
+- `DistributionPlatform` and `MetricPlatform` remain separate types;
+- no name-based conversion;
+- no initial cross-domain mapping table;
+- OAPEN/DOAB linkage exists only in the distribution domain unless separately approved.
+
+Implementation dependency:
+
+- Publisher Services `ADR-01` and `BE-02`
+- metrics platform registry.
+
+## 3. Decisions delegated to Publisher Services ADR-01
+
+ADR-01 must finalize:
+
+1. complete user-visible distribution destination inventory;
+2. stable enum codes and display names;
+3. current uploader, feed or manual mechanism;
+4. linked groups;
+5. `AutomaticPush`, `PullFeed` or `Manual` behaviour;
+6. whether back-catalogue activation creates a job;
+7. update and withdrawal support;
+8. credential ownership model;
+9. current publisher-configuration source;
+10. whether the following are separate destinations:
+   - Google Books and Google Play;
+   - EBSCO KB and EBSCOHost;
+   - multiple ProQuest products/destinations.
+
+No `OTHER` enum value is permitted.
+
+## 4. Operational invariants
+
+1. API outages fail closed.
+2. An empty publisher/platform assignment is a successful no-op, never "all".
+3. Backfill of existing assignments creates no back-catalogue jobs.
+4. One linked activation creates one logical multi-target job.
+5. Pull-feed and manual destinations create no uploader job.
+6. Claims are leased and stale claim tokens cannot complete current work.
+7. Automatic job creation is initially inactive.
+8. Comparison mode must be clean before legacy configuration cutover.
+9. Production activation requires a pilot, monitoring, rollback and CTO approval.
+10. Legacy configuration remains available through the observation period.
+
+## 5. Future decisions explicitly deferred
+
+- work-level `ALL_PUBLISHER_PLATFORMS`, `SELECTED_PLATFORMS`, `NONE`;
+- exact work-level platform sets;
+- metadata-change outbox;
+- work upsert and withdrawal jobs;
+- complete observed delivery state;
+- delivery fingerprints and remote identifiers;
+- scheduled reconciliation;
+- Rust ports of uploaders;
+- publisher-managed service changes;
+- package-to-platform defaults.
+
+These must reuse the approved package, platform, adapter, audit and job foundations.

--- a/docs/publisher-services/decisions.md
+++ b/docs/publisher-services/decisions.md
@@ -1,7 +1,7 @@
 # Publisher Services Decision Summary
 
-Status: ACTIVE SUMMARY  
-Last updated: 2026-07-24  
+Status: ACTIVE SUMMARY
+Last updated: 2026-07-24
 Owner: CTO
 
 This file summarizes decisions. The approved technical design and approved ADRs remain authoritative.

--- a/docs/publisher-services/master-issue.md
+++ b/docs/publisher-services/master-issue.md
@@ -1,0 +1,122 @@
+# Master GitHub Issue - Publisher Services and Distribution Configuration
+
+Use this as the body of the programme's master issue in `thoth-pub/thoth`.
+
+Suggested title:
+
+```text
+Publisher Services: packages, distribution configuration and controlled rollout
+```
+
+Suggested labels:
+
+```text
+programme
+publisher-services
+engineering-control
+```
+
+---
+
+## Objective
+
+Implement the approved Publisher Services and Distribution Configuration design across Thoth, thoth-app, thoth-dissemination and cc-license with additive schema, explicit authorization, audited migration, comparison-mode cutover, bounded pilots, monitoring and rollback.
+
+## Authoritative control
+
+- [Technical design](./README.md)
+- [Decision summary](./decisions.md)
+- [Task tracker](./task-status.md)
+- [Platform inventory](./platform-inventory.md)
+- [Acceptance matrix](./acceptance-matrix.md)
+- [Rollout plan](./rollout-plan.md)
+- [Engineering operating model](../engineering/ai-delivery/operating-model.md)
+- [Decision register](../engineering/decisions/decision-register.md)
+
+## Current gate
+
+- [ ] P0-01 approved and merged
+- [ ] ADR-0001 approved
+- [ ] ADR-0002 approved
+- [ ] ADR-01 platform inventory approved
+- [ ] branch-readiness dependencies recorded
+- [ ] programme integration branches approved
+
+No production implementation begins before the applicable gate passes.
+
+## Tasks
+
+### Foundation
+
+- [ ] P0-01 - Project control documents and tracker
+- [ ] ADR-01 - Platform inventory and final architecture
+- [ ] LIC-01 - Expand cc-license
+- [ ] LIC-02 - Enforce supported licences in Thoth
+
+### Backend
+
+- [ ] BE-01 - Publisher package model
+- [ ] BE-02 - Distribution platform model
+- [ ] BE-03 - Protected service configuration
+- [ ] BE-04 - Durable distribution jobs
+
+### Migration and interfaces
+
+- [ ] MIG-01 - Audit and production backfill
+- [ ] APP-01 - Publisher service configuration UI
+- [ ] APP-02 - Staff subscription report
+- [ ] APP-03 - API-backed licence options
+
+### Cutover and downstream services
+
+- [ ] DIS-01 - API publisher discovery and comparison mode
+- [ ] DIS-02 - Back-catalogue job worker
+- [ ] EXP-01 - OCLC KBART feed index
+- [ ] OAI-01 - Package and licence gating
+
+### Stabilization
+
+- [ ] OPS-01 - Monitoring, runbooks and cleanup
+- [ ] E2E-01 - Full workflow verification
+
+## Issue maintenance
+
+For every task, add:
+
+```text
+Repository:
+Risk:
+Specification:
+Base:
+Branch:
+PR target:
+PR:
+Implementation model:
+Independent reviewer:
+Status:
+Acceptance evidence:
+Rollout/activation:
+```
+
+Do not close a checkbox at PR creation or CI success.
+
+Close it only after:
+
+- independent `APPROVED` decision;
+- merge;
+- required rollout/observation;
+- tracker update.
+
+## Production gates
+
+- [ ] package/platform schema deployed without behaviour change
+- [ ] licence audit complete before strict enforcement
+- [ ] backfill dry run approved
+- [ ] production backfill produced zero jobs
+- [ ] comparison mode clean
+- [ ] API cutover rollback exercised
+- [ ] one bounded worker pilot approved
+- [ ] monitoring and runbooks operational
+- [ ] E2E-01 passed
+- [ ] observation complete
+- [ ] CTO approved cleanup

--- a/docs/publisher-services/master-issue.md
+++ b/docs/publisher-services/master-issue.md
@@ -9,6 +9,8 @@ The GitHub issue is the live programme tracker.
 
 Repository authorities:
 
+- [Private approved design](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit)
+
 - [README](./README.md)
 - [Decisions](./decisions.md)
 - [Task status](./task-status.md)

--- a/docs/publisher-services/master-issue.md
+++ b/docs/publisher-services/master-issue.md
@@ -1,8 +1,8 @@
 # Publisher Services Master Issue
 
-Status: OPEN  
-Issue: [#765 - Publisher Services: packages, distribution configuration and controlled rollout](https://github.com/thoth-pub/thoth/issues/765)  
-Created: 2026-07-24  
+Status: OPEN
+Issue: [#765 - Publisher Services: packages, distribution configuration and controlled rollout](https://github.com/thoth-pub/thoth/issues/765)
+Created: 2026-07-24
 Owner: CTO
 
 The GitHub issue is the live programme tracker.

--- a/docs/publisher-services/master-issue.md
+++ b/docs/publisher-services/master-issue.md
@@ -1,122 +1,19 @@
-# Master GitHub Issue - Publisher Services and Distribution Configuration
+# Publisher Services Master Issue
 
-Use this as the body of the programme's master issue in `thoth-pub/thoth`.
+Status: OPEN  
+Issue: [#765 - Publisher Services: packages, distribution configuration and controlled rollout](https://github.com/thoth-pub/thoth/issues/765)  
+Created: 2026-07-24  
+Owner: CTO
 
-Suggested title:
+The GitHub issue is the live programme tracker.
 
-```text
-Publisher Services: packages, distribution configuration and controlled rollout
-```
+Repository authorities:
 
-Suggested labels:
-
-```text
-programme
-publisher-services
-engineering-control
-```
-
----
-
-## Objective
-
-Implement the approved Publisher Services and Distribution Configuration design across Thoth, thoth-app, thoth-dissemination and cc-license with additive schema, explicit authorization, audited migration, comparison-mode cutover, bounded pilots, monitoring and rollback.
-
-## Authoritative control
-
-- [Technical design](./README.md)
-- [Decision summary](./decisions.md)
-- [Task tracker](./task-status.md)
+- [README](./README.md)
+- [Decisions](./decisions.md)
+- [Task status](./task-status.md)
 - [Platform inventory](./platform-inventory.md)
 - [Acceptance matrix](./acceptance-matrix.md)
 - [Rollout plan](./rollout-plan.md)
-- [Engineering operating model](../engineering/ai-delivery/operating-model.md)
-- [Decision register](../engineering/decisions/decision-register.md)
 
-## Current gate
-
-- [ ] P0-01 approved and merged
-- [ ] ADR-0001 approved
-- [ ] ADR-0002 approved
-- [ ] ADR-01 platform inventory approved
-- [ ] branch-readiness dependencies recorded
-- [ ] programme integration branches approved
-
-No production implementation begins before the applicable gate passes.
-
-## Tasks
-
-### Foundation
-
-- [ ] P0-01 - Project control documents and tracker
-- [ ] ADR-01 - Platform inventory and final architecture
-- [ ] LIC-01 - Expand cc-license
-- [ ] LIC-02 - Enforce supported licences in Thoth
-
-### Backend
-
-- [ ] BE-01 - Publisher package model
-- [ ] BE-02 - Distribution platform model
-- [ ] BE-03 - Protected service configuration
-- [ ] BE-04 - Durable distribution jobs
-
-### Migration and interfaces
-
-- [ ] MIG-01 - Audit and production backfill
-- [ ] APP-01 - Publisher service configuration UI
-- [ ] APP-02 - Staff subscription report
-- [ ] APP-03 - API-backed licence options
-
-### Cutover and downstream services
-
-- [ ] DIS-01 - API publisher discovery and comparison mode
-- [ ] DIS-02 - Back-catalogue job worker
-- [ ] EXP-01 - OCLC KBART feed index
-- [ ] OAI-01 - Package and licence gating
-
-### Stabilization
-
-- [ ] OPS-01 - Monitoring, runbooks and cleanup
-- [ ] E2E-01 - Full workflow verification
-
-## Issue maintenance
-
-For every task, add:
-
-```text
-Repository:
-Risk:
-Specification:
-Base:
-Branch:
-PR target:
-PR:
-Implementation model:
-Independent reviewer:
-Status:
-Acceptance evidence:
-Rollout/activation:
-```
-
-Do not close a checkbox at PR creation or CI success.
-
-Close it only after:
-
-- independent `APPROVED` decision;
-- merge;
-- required rollout/observation;
-- tracker update.
-
-## Production gates
-
-- [ ] package/platform schema deployed without behaviour change
-- [ ] licence audit complete before strict enforcement
-- [ ] backfill dry run approved
-- [ ] production backfill produced zero jobs
-- [ ] comparison mode clean
-- [ ] API cutover rollback exercised
-- [ ] one bounded worker pilot approved
-- [ ] monitoring and runbooks operational
-- [ ] E2E-01 passed
-- [ ] observation complete
-- [ ] CTO approved cleanup
+Update the issue and repository tracker together. A checked issue item is not completion without required independent review, merge, rollout and observation evidence.

--- a/docs/publisher-services/platform-inventory.md
+++ b/docs/publisher-services/platform-inventory.md
@@ -1,8 +1,8 @@
 # Distribution Platform Inventory
 
-Status: VERIFIED BASELINE; FINAL ENUM NOT APPROVED  
-Inventory owner: Publisher Services ADR-01  
-Evidence date: 2026-07-24  
+Status: VERIFIED BASELINE; FINAL ENUM NOT APPROVED
+Inventory owner: Publisher Services ADR-01
+Evidence date: 2026-07-24
 Observed `thoth-dissemination` reference: commit `5e88ce1b58e5f962cc4f4ef6fb00c08f50b57add`
 
 ## 1. Purpose

--- a/docs/publisher-services/platform-inventory.md
+++ b/docs/publisher-services/platform-inventory.md
@@ -1,0 +1,136 @@
+# Distribution Platform Inventory
+
+Status: VERIFIED BASELINE; FINAL ENUM NOT APPROVED  
+Inventory owner: Publisher Services ADR-01  
+Evidence date: 2026-07-24  
+Observed `thoth-dissemination` reference: commit `5e88ce1b58e5f962cc4f4ef6fb00c08f50b57add`
+
+## 1. Purpose
+
+This file records the current operational baseline for ADR-01.
+
+It distinguishes:
+
+- verified uploader/workflow behaviour;
+- proposed user-visible `DistributionPlatform` values;
+- unresolved inventory decisions.
+
+It must not be used as the final enum until ADR-01 is independently reviewed and approved.
+
+## 2. Behaviour vocabulary
+
+- `AutomaticPush` - enabling a new publisher assignment may require a durable back-catalogue upload job.
+- `PullFeed` - the destination retrieves a Thoth feed; no uploader job is created.
+- `Manual` - staff action or destination-specific coordination is required; no automatic job is created.
+
+This classification describes desired Publisher Services behaviour, not merely the existence of a current schedule.
+
+## 3. Verified current uploader baseline
+
+Current `disseminator.py` exposes these uploader keys:
+
+```text
+InternetArchive
+OAPEN
+ScienceOpen
+CUL
+Crossref
+Figshare
+Zenodo
+ProjectMUSE
+JSTOR
+EBSCOHost
+ProQuest
+GooglePlay
+BKCI
+```
+
+`DSPACE` is not a separate current user-visible uploader key; generic DSpace/SWORD support is an implementation mechanism.
+
+## 4. Candidate destination inventory
+
+| Proposed enum | Display name | Current key/mechanism | Proposed behaviour | Linked group | Current schedule | Location handling | Update support | Withdrawal support | Current publisher source | Status |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `INTERNET_ARCHIVE` | Internet Archive | `InternetArchive` | AutomaticPush | - | daily | immediate Thoth writeback | verified idempotent update for owned items | unverified | `IA_ENV_PUBLISHERS` | VERIFIED CANDIDATE |
+| `OAPEN` | OAPEN | `OAPEN` SWORD/metadata delivery | AutomaticPush | `OAPEN_DOAB` | weekly | deferred catch-up | needs ADR verification | unverified | platform publisher list/environment | VERIFIED CANDIDATE |
+| `DOAB` | DOAB | linked logical target; no separate uploader | AutomaticPush | `OAPEN_DOAB` | follows OAPEN | deferred catch-up | linked semantics require verification | unverified | same linked configuration | VERIFIED LOGICAL CANDIDATE |
+| `SCIENCE_OPEN` | ScienceOpen | `ScienceOpen` | Manual | - | manual | no verified automatic writeback | unverified | unverified | manual eligibility/configuration | VERIFIED CANDIDATE |
+| `CAMBRIDGE_UNIVERSITY_LIBRARY` | Cambridge University Library | `CUL` SWORDv2 | AutomaticPush | - | monthly | immediate `OTHER` writeback | unverified | unverified | environment publisher list | VERIFIED CANDIDATE |
+| `CROSSREF` | Crossref | `Crossref` HTTPS metadata deposit | AutomaticPush | - | hourly | none | likely repeat deposit; exact semantics require verification | unverified | environment list plus per-publisher credentials | VERIFIED CANDIDATE |
+| `FIGSHARE` | Figshare | `Figshare` API | AutomaticPush | - | monthly | immediate per-publication writeback | current existing-record guard blocks simple repeat; clarify desired updates | unverified | environment publisher list | VERIFIED CANDIDATE |
+| `ZENODO` | Zenodo | `Zenodo` API | AutomaticPush | - | monthly | immediate per-publication writeback | current existing-record guard blocks simple repeat; clarify desired updates | unverified | environment publisher list | VERIFIED CANDIDATE |
+| `PROJECT_MUSE` | Project MUSE | `ProjectMUSE` FTP | AutomaticPush | - | intended weekly | none; notification flow | unverified | unverified | environment list plus per-publisher credentials | VERIFIED CANDIDATE; CURRENT SCHEDULE BUG |
+| `JSTOR` | JSTOR | `JSTOR` FTP | AutomaticPush | - | weekly | none; notification flow | unverified | unverified | environment list plus per-publisher folder | VERIFIED CANDIDATE |
+| `EBSCO_HOST` | EBSCOHost | `EBSCOHost` FTP | AutomaticPush | - | weekly | none; notification flow | unverified | unverified | environment publisher list | VERIFIED CANDIDATE |
+| `PROQUEST` | ProQuest | `ProQuest` FTP/ebrary format | AutomaticPush | - | weekly | none; notification flow | unverified | unverified | environment publisher list | VERIFIED CANDIDATE; PRODUCT SCOPE OPEN |
+| `GOOGLE_PLAY` | Google Play Books | `GooglePlay` bucket delivery | AutomaticPush | - | daily | none | unverified | unverified | environment list plus per-publisher collection code | VERIFIED CANDIDATE |
+| `BKCI` | Book Citation Index | `BKCI` FTP | AutomaticPush | - | monthly | none; notification flow | unverified | unverified | environment list plus per-publisher credentials | VERIFIED CANDIDATE |
+| `OCLC_KB` | OCLC Knowledge Base | Thoth KBART pull-feed/index | PullFeed | - | destination pull | feed membership, no location writeback | feed reflects current state | feed removal reflects current state | existing OCLC arrangements/records | DESIGN CANDIDATE; VERIFY OPERATIONS |
+
+## 5. Current operational caveats
+
+The current repository documents these defects:
+
+1. The Project MUSE scheduled workflow passes `MUSE`, while current dispatch expects `ProjectMUSE`.
+2. The ProQuest uploader's intended EPUB-only fallback can fail because it retrieves a PDF ISBN first.
+
+ADR-01 must record these as current-state defects. It must not normalize the inventory as though scheduled delivery is healthy.
+
+## 6. Unresolved enum questions
+
+### Google Books vs Google Play
+
+The current Google Play delivery sends ONIX using a Google Books export profile.
+
+ADR-01 must establish whether:
+
+- `GOOGLE_PLAY` represents the complete destination;
+- Google Books is independently selectable and needs `GOOGLE_BOOKS`;
+- both are one operational delivery with two user-visible outcomes.
+
+Do not create both values solely from export-format naming.
+
+### EBSCOHost vs EBSCO Knowledge Base
+
+Current code verifies EBSCOHost push delivery.
+
+Establish whether a separate EBSCO KB pull-feed/configuration exists. If independently meaningful, add `EBSCO_KB`; otherwise do not.
+
+### ProQuest products
+
+Current code exposes one `ProQuest` uploader using a ProQuest ebrary export.
+
+Establish whether staff sell/configure multiple independently selectable ProQuest destinations. If yes, use separate explicit enum values and adapters/descriptors.
+
+### Other manually managed destinations
+
+Interview operations staff and inspect private configuration before enum approval.
+
+No `OTHER` value may absorb an unidentified destination.
+
+## 7. ADR-01 evidence checklist
+
+Before approval, attach evidence for every destination:
+
+- [ ] current uploader, feed or manual process;
+- [ ] stable enum code;
+- [ ] display name;
+- [ ] current publisher list/configuration source;
+- [ ] linked-platform group;
+- [ ] back-catalogue behaviour;
+- [ ] accepted work types;
+- [ ] required file/metadata formats;
+- [ ] update support;
+- [ ] withdrawal support;
+- [ ] location writeback;
+- [ ] credential ownership model;
+- [ ] dry-run/read-only verification method;
+- [ ] operational owner;
+- [ ] known defects;
+- [ ] migration/backfill mapping.
+
+## 8. Safety rule
+
+The provisional inventory must not be converted directly into production rows or jobs.
+
+MIG-01 must use an approved mapping, dry run and no-job import mode.

--- a/docs/publisher-services/rollout-plan.md
+++ b/docs/publisher-services/rollout-plan.md
@@ -1,7 +1,7 @@
 # Publisher Services Rollout Plan
 
-Status: PROPOSED CONTROLLED SEQUENCE  
-Owner: CTO  
+Status: PROPOSED CONTROLLED SEQUENCE
+Owner: CTO
 Production activation: explicit CTO approval required
 
 ## 1. Safety principles

--- a/docs/publisher-services/rollout-plan.md
+++ b/docs/publisher-services/rollout-plan.md
@@ -1,0 +1,310 @@
+# Publisher Services Rollout Plan
+
+Status: PROPOSED CONTROLLED SEQUENCE  
+Owner: CTO  
+Production activation: explicit CTO approval required
+
+## 1. Safety principles
+
+- Add schema and APIs before changing live behaviour.
+- Keep automatic job creation inactive initially.
+- Audit and backfill before strict enforcement or cutover.
+- Run legacy and API configuration in comparison mode.
+- Fail closed.
+- Pilot one bounded publisher/platform activation.
+- Observe before cleanup.
+- Preserve rollback until reconciliation proves stability.
+
+## 2. Stage 0 - Control foundation
+
+Required:
+
+- P0-01 documents and master issue;
+- ADR-0001 approved;
+- ADR-0002 approved;
+- repository/branch readiness recorded;
+- task specifications and review assignments.
+
+Exit evidence:
+
+- PR #764 independently approved and merged;
+- master issue links every task;
+- no unresolved control contradiction.
+
+Rollback:
+
+- revert documentation PR; no runtime effect.
+
+## 3. Stage 1 - Licence and package foundations
+
+Deliver:
+
+- LIC-01;
+- BE-01;
+- LIC-02 only after production licence audit planning.
+
+Controls:
+
+- additive package column with OASIS default;
+- package capability mapping inactive outside read paths;
+- no platform assignment changes;
+- no strict licence enforcement before audit.
+
+Exit evidence:
+
+- migration and capability matrix tests;
+- supported licence inventory;
+- zero unexplained current licence values.
+
+Rollback:
+
+- disable consuming paths;
+- use forward repair for persisted package values if required;
+- do not delete audit evidence.
+
+## 4. Stage 2 - Platform and protected configuration
+
+Deliver:
+
+- ADR-01;
+- BE-02;
+- BE-03;
+- BE-04 storage/API with automatic job creation disabled.
+
+Controls:
+
+- linked normalization in backend;
+- optimistic concurrency;
+- audit transaction;
+- job creation feature flag/config default off;
+- worker role cannot alter publisher configuration.
+
+Exit evidence:
+
+- authorization matrix;
+- linked-state tests;
+- job concurrency/lease tests;
+- no live jobs created by deployment.
+
+Rollback:
+
+- disable configuration mutation;
+- preserve additive tables;
+- revert client exposure.
+
+## 5. Stage 3 - Audit and backfill
+
+Deliver:
+
+- MIG-01 dry-run tool;
+- approved package mapping;
+- approved platform mapping;
+- licence normalization plan.
+
+Required dry-run output:
+
+- publisher count by package;
+- publisher/platform assignments;
+- unmatched legacy identifiers;
+- linked-state anomalies;
+- unsupported licences;
+- expected inserts/updates;
+- expected job count, which must be zero;
+- rerun result.
+
+Production run controls:
+
+- explicit input checksum/version;
+- no-job import mode;
+- transaction/batching plan;
+- bounded logs;
+- reconciliation queries;
+- backup/restore readiness;
+- CTO approval immediately before execution.
+
+Stop conditions:
+
+- any unexpected job;
+- unexplained publisher omission;
+- ambiguous platform mapping;
+- unsupported licence without disposition;
+- counts differ from reviewed dry run.
+
+Rollback:
+
+- transaction rollback where possible;
+- otherwise approved reverse/forward repair using captured before-state;
+- automatic jobs remain disabled.
+
+## 6. Stage 4 - Interfaces
+
+Deliver:
+
+- APP-01;
+- APP-02;
+- APP-03.
+
+Controls:
+
+- package read-only for publisher users;
+- superuser-only mutations/reports;
+- server result replaces optimistic linked-platform state;
+- generated GraphQL types pinned to merged schema;
+- no frontend-owned capability or linked-platform matrix.
+
+Exit evidence:
+
+- authorization E2E tests;
+- concurrency failure UX;
+- CSV/report count parity;
+- API-backed licence option parity.
+
+Rollback:
+
+- hide/disable routes;
+- retain backend additive APIs;
+- no data rollback.
+
+## 7. Stage 5 - Dissemination comparison
+
+Deliver DIS-01 in modes:
+
+```text
+env
+compare
+api
+```
+
+Initial production mode:
+
+```text
+compare
+```
+
+Comparison report must show:
+
+- legacy publisher set;
+- API publisher set;
+- additions;
+- omissions;
+- linked-platform normalization;
+- unsupported platform descriptors;
+- duplicate adapter routes.
+
+Cutover gate:
+
+- differences resolved or explicitly approved;
+- API outages tested fail closed;
+- empty API assignment tested as no-op;
+- no fallback to all publishers/works;
+- rollback to `env` documented and exercised.
+
+Activation:
+
+- switch one pathway/platform at a time where practical;
+- CTO approval per high-risk cutover.
+
+## 8. Stage 6 - Back-catalogue worker pilot
+
+Deploy DIS-02 with:
+
+- schedule disabled or tightly bounded;
+- protected environment;
+- explicit worker identity;
+- low concurrency;
+- retry/backoff;
+- metrics and alerts;
+- no automatic job creation.
+
+Pilot:
+
+1. choose one publisher;
+2. choose one verified `AutomaticPush` platform;
+3. review eligible catalogue count;
+4. enable one activation/job;
+5. observe claim, attempts, adapter outcomes and completion;
+6. reconcile external state and Thoth locations;
+7. exercise retry or controlled failure;
+8. record decision.
+
+Do not pilot OAPEN/DOAB first unless linked multi-target behaviour is the explicit test objective.
+
+Rollback:
+
+- stop worker schedule;
+- revoke/disable worker role;
+- cancel pending pilot jobs;
+- restore legacy path;
+- reconcile partial external delivery.
+
+## 9. Stage 7 - General enablement
+
+Prerequisites:
+
+- successful pilot;
+- no unresolved P0/P1 findings;
+- acceptable comparison history;
+- alerting operational;
+- support/runbook ownership assigned.
+
+Enable:
+
+- automatic job creation for approved destinations;
+- scheduled worker;
+- controlled platform-by-platform adoption.
+
+Maintain:
+
+- legacy comparison or fallback;
+- reconciliation reports;
+- bounded concurrency;
+- activation audit.
+
+## 10. Stage 8 - Downstream services
+
+### OCLC KBART
+
+Enable EXP-01 after:
+
+- OCLC_KB enum approval;
+- publisher backfill reconciliation;
+- public output/privacy review.
+
+### OAI-PMH
+
+Begin OAI-01 only after:
+
+- BE-01 merged;
+- LIC-02 merged and enforced safely;
+- deferred branch divergence assessed;
+- fresh branch/port decision recorded;
+- complete package/licence/lifecycle test matrix.
+
+## 11. Stage 9 - Observation and cleanup
+
+Minimum observation record includes:
+
+- activation dates;
+- comparison differences;
+- failed/retried jobs;
+- stale leases;
+- unexpected external duplicates;
+- support incidents;
+- rollback events;
+- publisher configuration corrections.
+
+Cleanup requires:
+
+- E2E-01 approval;
+- stable observation period set by CTO;
+- no unresolved high-severity reconciliation issues;
+- explicit cleanup task and rollback assessment.
+
+Only then remove:
+
+- publisher-ID environment lists;
+- comparison mode;
+- duplicate licence lists;
+- superseded scripts/configuration.
+
+Cleanup is irreversible operational change and requires independent review plus CTO approval.

--- a/docs/publisher-services/task-status.md
+++ b/docs/publisher-services/task-status.md
@@ -2,93 +2,49 @@
 
 Status: ACTIVE TRACKER  
 Programme owner: CTO  
-Master issue: NOT YET CREATED  
+Master issue: [#765](https://github.com/thoth-pub/thoth/issues/765)  
 Last updated: 2026-07-24
 
 ## 1. Control rule
 
-No task moves to `READY` without:
+No task moves to `READY` without an approved written specification, approved architecture dependencies, verified repository/base, branch-readiness completion or explicit CTO exception, named implementation and independent-review models, and explicit test, migration, rollout and rollback requirements.
 
-- approved written specification;
-- approved architecture dependencies;
-- verified repository and base;
-- branch-readiness dependency complete or explicit CTO exception;
-- named implementation and independent-review models;
-- test, migration, rollout and rollback requirements.
-
-`TBD` is missing work, not an implicit approval.
+`TBD` is missing work, not implicit approval.
 
 ## 2. Task tracker
 
 | Task | Repository | Risk | Current status | Required base / PR target | Blocking dependencies | Issue | PR | Acceptance |
 |---|---|---:|---|---|---|---|---|---|
-| P0-01 Control documents and tracker | `thoth` | LOW | IN PROGRESS | `develop` / `develop` | Independent review; master issue; PR #764 merge | TBD | #764 | PENDING |
-| ADR-01 Platform inventory and final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0002 approval | TBD | TBD | NOT STARTED |
-| LIC-01 Expand `cc-license` | `cc-license` | MEDIUM | BLOCKED | actual `develop`; programme target after branch-readiness decision | P0-01; branch readiness `BR-LIC-01`; approved LIC-01 spec | TBD | TBD | NOT STARTED |
-| LIC-02 Enforce supported licences | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | LIC-01 release; production licence audit plan | TBD | TBD | NOT STARTED |
-| BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | P0-01; ADR-0001 approval | TBD | TBD | NOT STARTED |
-| BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | ADR-01; ADR-0002 approval | TBD | TBD | NOT STARTED |
-| BE-03 Protected service configuration | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-01; BE-02 | TBD | TBD | NOT STARTED |
-| BE-04 Durable distribution jobs | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-02; BE-03 | TBD | TBD | NOT STARTED |
-| MIG-01 Audit and production backfill | `thoth` plus operations | CRITICAL | BLOCKED | dedicated migration branch/PR and separately approved production run | BE-01; BE-02; BE-03; licence audit; dry-run tooling | TBD | TBD | NOT STARTED |
-| APP-01 Service configuration UI | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; programme target after `BR-APP-01` | BE-03; branch readiness; generated API contract | TBD | TBD | NOT STARTED |
-| APP-02 Staff subscription report | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; programme target after `BR-APP-01` | BE-03; BE-04; APP-01 foundation | TBD | TBD | NOT STARTED |
-| APP-03 API-backed licence options | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; programme target after `BR-APP-01` | LIC-02; branch readiness | TBD | TBD | NOT STARTED |
-| DIS-01 API discovery and comparison mode | `thoth-dissemination` | HIGH | BLOCKED | actual `develop`; programme target after `BR-DIS-01` | BE-02; MIG-01 approved backfill; branch readiness | TBD | TBD | NOT STARTED |
-| DIS-02 Back-catalogue job worker | `thoth-dissemination` | CRITICAL | BLOCKED | Publisher Services integration branch | BE-04; DIS-01 clean comparison; production controls | TBD | TBD | NOT STARTED |
-| EXP-01 OCLC KBART feed index | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | BE-02; ADR-01 OCLC decision | TBD | TBD | NOT STARTED |
-| OAI-01 Package and licence gating | `thoth` | HIGH | BLOCKED | fresh branch after divergence assessment | BE-01; LIC-02; ADR-0001; branch assessment | TBD | TBD | NOT STARTED |
-| OPS-01 Monitoring, runbooks and cleanup | multiple | HIGH | BLOCKED | repository-local tasks | Implemented components; production ownership map | TBD | TBD | NOT STARTED |
-| E2E-01 Full workflow verification | multiple | HIGH | BLOCKED | no implementation branch; controlled acceptance run | all activated components; pilot data; rollback | TBD | TBD | NOT STARTED |
+| P0-01 Control documents and tracker | `thoth` | LOW | IN PROGRESS | `develop` / `develop` | Independent review; PR #764 merge | [#765](https://github.com/thoth-pub/thoth/issues/765) | [#764](https://github.com/thoth-pub/thoth/pull/764) | PENDING REVIEW |
+| ADR-01 Platform inventory and final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
+| LIC-01 Expand `cc-license` | `cc-license` | MEDIUM | BLOCKED | actual `develop`; target after branch-readiness decision | P0-01; BR-LIC-01; approved specification | #765 | TBD | NOT STARTED |
+| LIC-02 Enforce supported licences | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | LIC-01 release; production licence audit plan | #765 | TBD | NOT STARTED |
+| BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | P0-01; ADR-0001 approval | #765 | TBD | NOT STARTED |
+| BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | ADR-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
+| BE-03 Protected service configuration | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-01; BE-02 | #765 | TBD | NOT STARTED |
+| BE-04 Durable distribution jobs | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-02; BE-03 | #765 | TBD | NOT STARTED |
+| MIG-01 Audit and production backfill | `thoth` plus operations | CRITICAL | BLOCKED | dedicated migration branch/PR and separate production approval | BE-01; BE-02; BE-03; licence audit; dry run | #765 | TBD | NOT STARTED |
+| APP-01 Service configuration UI | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; target after BR-APP-01 | BE-03; generated API contract | #765 | TBD | NOT STARTED |
+| APP-02 Staff subscription report | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; target after BR-APP-01 | BE-03; BE-04; APP-01 | #765 | TBD | NOT STARTED |
+| APP-03 API-backed licence options | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; target after BR-APP-01 | LIC-02 | #765 | TBD | NOT STARTED |
+| DIS-01 API discovery and comparison mode | `thoth-dissemination` | HIGH | BLOCKED | actual `develop`; target after BR-DIS-01 | BE-02; MIG-01; branch readiness | #765 | TBD | NOT STARTED |
+| DIS-02 Back-catalogue job worker | `thoth-dissemination` | CRITICAL | BLOCKED | Publisher Services integration branch | BE-04; DIS-01 clean comparison; production controls | #765 | TBD | NOT STARTED |
+| EXP-01 OCLC KBART feed index | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | BE-02; ADR-01 OCLC decision | #765 | TBD | NOT STARTED |
+| OAI-01 Package and licence gating | `thoth` | HIGH | BLOCKED | fresh branch after divergence assessment | BE-01; LIC-02; ADR-0001; branch assessment | #765 | TBD | NOT STARTED |
+| OPS-01 Monitoring, runbooks and cleanup | multiple | HIGH | BLOCKED | repository-local tasks | implemented components; runtime ownership map | #765 | TBD | NOT STARTED |
+| E2E-01 Full workflow verification | multiple | HIGH | BLOCKED | controlled acceptance run | all activated components; pilot data; rollback | #765 | TBD | NOT STARTED |
 
 ## 3. Branch preparation
 
-Before programme implementation:
+- `thoth`: current `develop -> master` topology conforms. Create `feature/publisher-services` only after P0-01 and required ADRs.
+- `thoth-app`: current `dev -> main`; complete BR-APP-01 or approve an exception.
+- `thoth-dissemination`: current `develop -> main`; complete BR-DIS-01 or approve the programme-branch strategy.
+- `cc-license`: current `develop -> main`; complete BR-LIC-01 or approve the programme-branch strategy.
 
-### `thoth`
+## 4. Next status actions
 
-Current topology conforms:
-
-```text
-develop -> feature/publisher-services -> develop -> master
-```
-
-Create the integration branch only after P0-01 and required ADRs are approved.
-
-### `thoth-app`
-
-Current topology is `dev -> main`.
-
-Complete `BR-APP-01` or obtain an explicit CTO exception before creating a long-lived Publisher Services integration branch.
-
-### `thoth-dissemination`
-
-Current topology is `develop -> main`.
-
-Complete `BR-DIS-01` or record the approved temporary programme-branch strategy.
-
-### `cc-license`
-
-Current topology is `develop -> main`.
-
-Complete `BR-LIC-01` or record the approved temporary programme-branch strategy.
-
-## 4. Recommended implementation models
-
-| Risk | Implementation | Independent review |
-|---|---|---|
-| LOW | Codex medium reasoning | separate Codex/Claude medium |
-| MEDIUM | Codex medium/high | separate Claude high |
-| HIGH | Codex high | separate Claude high plus control review |
-| CRITICAL | Codex high with tightly bounded permissions | separate Claude high, control review and explicit CTO activation approval |
-
-The implementing agent never approves its own work.
-
-## 5. Next status actions
-
-1. Create the master GitHub issue from `master-issue.md`.
-2. Record its number here.
-3. Complete PR #764.
-4. Approve or amend ADR-0001 and ADR-0002.
-5. Merge the engineering-control foundation.
-6. Scope and begin ADR-01 only.
+1. Independently review PR #764.
+2. Resolve review findings.
+3. Approve or amend ADR-0001 and ADR-0002 through the CTO decision gate.
+4. Merge the engineering-control foundation.
+5. Scope ADR-01 as the first bounded Publisher Services implementation-readiness task.

--- a/docs/publisher-services/task-status.md
+++ b/docs/publisher-services/task-status.md
@@ -1,8 +1,8 @@
 # Publisher Services Task Status
 
-Status: ACTIVE TRACKER  
-Programme owner: CTO  
-Master issue: [#765](https://github.com/thoth-pub/thoth/issues/765)  
+Status: ACTIVE TRACKER
+Programme owner: CTO
+Master issue: [#765](https://github.com/thoth-pub/thoth/issues/765)
 Last updated: 2026-07-24
 
 ## 1. Control rule

--- a/docs/publisher-services/task-status.md
+++ b/docs/publisher-services/task-status.md
@@ -1,0 +1,94 @@
+# Publisher Services Task Status
+
+Status: ACTIVE TRACKER  
+Programme owner: CTO  
+Master issue: NOT YET CREATED  
+Last updated: 2026-07-24
+
+## 1. Control rule
+
+No task moves to `READY` without:
+
+- approved written specification;
+- approved architecture dependencies;
+- verified repository and base;
+- branch-readiness dependency complete or explicit CTO exception;
+- named implementation and independent-review models;
+- test, migration, rollout and rollback requirements.
+
+`TBD` is missing work, not an implicit approval.
+
+## 2. Task tracker
+
+| Task | Repository | Risk | Current status | Required base / PR target | Blocking dependencies | Issue | PR | Acceptance |
+|---|---|---:|---|---|---|---|---|---|
+| P0-01 Control documents and tracker | `thoth` | LOW | IN PROGRESS | `develop` / `develop` | Independent review; master issue; PR #764 merge | TBD | #764 | PENDING |
+| ADR-01 Platform inventory and final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0002 approval | TBD | TBD | NOT STARTED |
+| LIC-01 Expand `cc-license` | `cc-license` | MEDIUM | BLOCKED | actual `develop`; programme target after branch-readiness decision | P0-01; branch readiness `BR-LIC-01`; approved LIC-01 spec | TBD | TBD | NOT STARTED |
+| LIC-02 Enforce supported licences | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | LIC-01 release; production licence audit plan | TBD | TBD | NOT STARTED |
+| BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | P0-01; ADR-0001 approval | TBD | TBD | NOT STARTED |
+| BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | ADR-01; ADR-0002 approval | TBD | TBD | NOT STARTED |
+| BE-03 Protected service configuration | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-01; BE-02 | TBD | TBD | NOT STARTED |
+| BE-04 Durable distribution jobs | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-02; BE-03 | TBD | TBD | NOT STARTED |
+| MIG-01 Audit and production backfill | `thoth` plus operations | CRITICAL | BLOCKED | dedicated migration branch/PR and separately approved production run | BE-01; BE-02; BE-03; licence audit; dry-run tooling | TBD | TBD | NOT STARTED |
+| APP-01 Service configuration UI | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; programme target after `BR-APP-01` | BE-03; branch readiness; generated API contract | TBD | TBD | NOT STARTED |
+| APP-02 Staff subscription report | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; programme target after `BR-APP-01` | BE-03; BE-04; APP-01 foundation | TBD | TBD | NOT STARTED |
+| APP-03 API-backed licence options | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; programme target after `BR-APP-01` | LIC-02; branch readiness | TBD | TBD | NOT STARTED |
+| DIS-01 API discovery and comparison mode | `thoth-dissemination` | HIGH | BLOCKED | actual `develop`; programme target after `BR-DIS-01` | BE-02; MIG-01 approved backfill; branch readiness | TBD | TBD | NOT STARTED |
+| DIS-02 Back-catalogue job worker | `thoth-dissemination` | CRITICAL | BLOCKED | Publisher Services integration branch | BE-04; DIS-01 clean comparison; production controls | TBD | TBD | NOT STARTED |
+| EXP-01 OCLC KBART feed index | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | BE-02; ADR-01 OCLC decision | TBD | TBD | NOT STARTED |
+| OAI-01 Package and licence gating | `thoth` | HIGH | BLOCKED | fresh branch after divergence assessment | BE-01; LIC-02; ADR-0001; branch assessment | TBD | TBD | NOT STARTED |
+| OPS-01 Monitoring, runbooks and cleanup | multiple | HIGH | BLOCKED | repository-local tasks | Implemented components; production ownership map | TBD | TBD | NOT STARTED |
+| E2E-01 Full workflow verification | multiple | HIGH | BLOCKED | no implementation branch; controlled acceptance run | all activated components; pilot data; rollback | TBD | TBD | NOT STARTED |
+
+## 3. Branch preparation
+
+Before programme implementation:
+
+### `thoth`
+
+Current topology conforms:
+
+```text
+develop -> feature/publisher-services -> develop -> master
+```
+
+Create the integration branch only after P0-01 and required ADRs are approved.
+
+### `thoth-app`
+
+Current topology is `dev -> main`.
+
+Complete `BR-APP-01` or obtain an explicit CTO exception before creating a long-lived Publisher Services integration branch.
+
+### `thoth-dissemination`
+
+Current topology is `develop -> main`.
+
+Complete `BR-DIS-01` or record the approved temporary programme-branch strategy.
+
+### `cc-license`
+
+Current topology is `develop -> main`.
+
+Complete `BR-LIC-01` or record the approved temporary programme-branch strategy.
+
+## 4. Recommended implementation models
+
+| Risk | Implementation | Independent review |
+|---|---|---|
+| LOW | Codex medium reasoning | separate Codex/Claude medium |
+| MEDIUM | Codex medium/high | separate Claude high |
+| HIGH | Codex high | separate Claude high plus control review |
+| CRITICAL | Codex high with tightly bounded permissions | separate Claude high, control review and explicit CTO activation approval |
+
+The implementing agent never approves its own work.
+
+## 5. Next status actions
+
+1. Create the master GitHub issue from `master-issue.md`.
+2. Record its number here.
+3. Complete PR #764.
+4. Approve or amend ADR-0001 and ADR-0002.
+5. Merge the engineering-control foundation.
+6. Scope and begin ADR-01 only.

--- a/docs/publisher-services/task-status.md
+++ b/docs/publisher-services/task-status.md
@@ -3,48 +3,55 @@
 Status: ACTIVE TRACKER
 Programme owner: CTO
 Master issue: [#765](https://github.com/thoth-pub/thoth/issues/765)
+Approved design: [private Google Doc](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit), Drive revision `3`
 Last updated: 2026-07-24
 
 ## 1. Control rule
 
-No task moves to `READY` without an approved written specification, approved architecture dependencies, verified repository/base, branch-readiness completion or explicit CTO exception, named implementation and independent-review models, and explicit test, migration, rollout and rollback requirements.
+Publisher Services follows the approved design's one-task/one-branch/one-PR workflow. It does not use a long-lived programme integration branch.
+
+No task moves to `READY` without an approved specification, architecture dependencies, verified repository/base/target, branch-readiness completion or CTO exception, named implementation/review models, tests, migration, rollout and rollback.
 
 `TBD` is missing work, not implicit approval.
 
 ## 2. Task tracker
 
-| Task | Repository | Risk | Current status | Required base / PR target | Blocking dependencies | Issue | PR | Acceptance |
+| Task | Repository | Risk | Status | Verified base / PR target | Blocking dependencies | Issue | PR | Acceptance |
 |---|---|---:|---|---|---|---|---|---|
-| P0-01 Control documents and tracker | `thoth` | LOW | IN PROGRESS | `develop` / `develop` | Independent review; PR #764 merge | [#765](https://github.com/thoth-pub/thoth/issues/765) | [#764](https://github.com/thoth-pub/thoth/pull/764) | PENDING REVIEW |
-| ADR-01 Platform inventory and final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
-| LIC-01 Expand `cc-license` | `cc-license` | MEDIUM | BLOCKED | actual `develop`; target after branch-readiness decision | P0-01; BR-LIC-01; approved specification | #765 | TBD | NOT STARTED |
-| LIC-02 Enforce supported licences | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | LIC-01 release; production licence audit plan | #765 | TBD | NOT STARTED |
-| BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | P0-01; ADR-0001 approval | #765 | TBD | NOT STARTED |
-| BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | ADR-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
-| BE-03 Protected service configuration | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-01; BE-02 | #765 | TBD | NOT STARTED |
-| BE-04 Durable distribution jobs | `thoth` | HIGH | BLOCKED | Publisher Services integration branch | BE-02; BE-03 | #765 | TBD | NOT STARTED |
-| MIG-01 Audit and production backfill | `thoth` plus operations | CRITICAL | BLOCKED | dedicated migration branch/PR and separate production approval | BE-01; BE-02; BE-03; licence audit; dry run | #765 | TBD | NOT STARTED |
-| APP-01 Service configuration UI | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; target after BR-APP-01 | BE-03; generated API contract | #765 | TBD | NOT STARTED |
-| APP-02 Staff subscription report | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; target after BR-APP-01 | BE-03; BE-04; APP-01 | #765 | TBD | NOT STARTED |
-| APP-03 API-backed licence options | `thoth-app` | MEDIUM | BLOCKED | actual `dev`; target after BR-APP-01 | LIC-02 | #765 | TBD | NOT STARTED |
-| DIS-01 API discovery and comparison mode | `thoth-dissemination` | HIGH | BLOCKED | actual `develop`; target after BR-DIS-01 | BE-02; MIG-01; branch readiness | #765 | TBD | NOT STARTED |
-| DIS-02 Back-catalogue job worker | `thoth-dissemination` | CRITICAL | BLOCKED | Publisher Services integration branch | BE-04; DIS-01 clean comparison; production controls | #765 | TBD | NOT STARTED |
-| EXP-01 OCLC KBART feed index | `thoth` | MEDIUM | BLOCKED | Publisher Services integration branch | BE-02; ADR-01 OCLC decision | #765 | TBD | NOT STARTED |
-| OAI-01 Package and licence gating | `thoth` | HIGH | BLOCKED | fresh branch after divergence assessment | BE-01; LIC-02; ADR-0001; branch assessment | #765 | TBD | NOT STARTED |
-| OPS-01 Monitoring, runbooks and cleanup | multiple | HIGH | BLOCKED | repository-local tasks | implemented components; runtime ownership map | #765 | TBD | NOT STARTED |
-| E2E-01 Full workflow verification | multiple | HIGH | BLOCKED | controlled acceptance run | all activated components; pilot data; rollback | #765 | TBD | NOT STARTED |
+| P0-01 Control documents and tracker | `thoth` | LOW | IN REVIEW | `develop` / `develop` | PR #764 independent approval and merge | [#765](https://github.com/thoth-pub/thoth/issues/765) | [#764](https://github.com/thoth-pub/thoth/pull/764) | PENDING REVIEW |
+| ADR-01 Platform inventory/final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
+| LIC-01 Expand `cc-license` | `cc-license` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; BR-LIC-01 or CTO exception; approved spec | #765 | TBD | NOT STARTED |
+| LIC-02 Enforce supported licences | `thoth` | HIGH | BLOCKED | `develop` / `develop` | LIC-01 release; production licence audit plan | #765 | TBD | NOT STARTED |
+| BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0001 approval | #765 | TBD | NOT STARTED |
+| BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | `develop` / `develop` | ADR-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
+| BE-03 Protected service configuration | `thoth` | HIGH | BLOCKED | `develop` / `develop` | BE-01; BE-02 | #765 | TBD | NOT STARTED |
+| BE-04 Durable distribution jobs | `thoth` | HIGH | BLOCKED | `develop` / `develop` | BE-02; BE-03 | #765 | TBD | NOT STARTED |
+| MIG-01 Audit/production backfill | `thoth` + operations | CRITICAL | BLOCKED | dedicated task branch -> `develop`; separately approved production run | BE-01/02/03; licence audit; dry run | #765 | TBD | NOT STARTED |
+| APP-01 Service configuration UI | `thoth-app` | MEDIUM | BLOCKED | current `dev` / `dev` pending BR-APP-01 or exception | BE-03; generated API contract | #765 | TBD | NOT STARTED |
+| APP-02 Staff subscription report | `thoth-app` | MEDIUM | BLOCKED | current `dev` / `dev` pending BR-APP-01 or exception | BE-03; BE-04; APP-01 | #765 | TBD | NOT STARTED |
+| APP-03 API-backed licence options | `thoth-app` | MEDIUM | BLOCKED | current `dev` / `dev` pending BR-APP-01 or exception | LIC-02 | #765 | TBD | NOT STARTED |
+| DIS-01 API discovery/comparison | `thoth-dissemination` | HIGH | BLOCKED | `develop` / `develop` | BE-02; MIG-01; BR-DIS-01 or exception | #765 | TBD | NOT STARTED |
+| DIS-02 Back-catalogue worker | `thoth-dissemination` | CRITICAL | BLOCKED | `develop` / `develop` | BE-04; DIS-01 clean comparison; production controls | #765 | TBD | NOT STARTED |
+| EXP-01 OCLC KBART index | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | BE-02; ADR-01 OCLC decision | #765 | TBD | NOT STARTED |
+| OAI-01 Package/licence gating | `thoth` | HIGH | BLOCKED | fresh task branch; target decided after divergence review | BE-01; LIC-02; ADR-0001; resolve design/target-policy branch conflict | #765 | TBD | NOT STARTED |
+| OPS-01 Monitoring/runbooks/cleanup | multiple | HIGH | BLOCKED | repository-local task branches | implemented components; runtime ownership | #765 | TBD | NOT STARTED |
+| E2E-01 Full workflow verification | multiple | HIGH | BLOCKED | controlled acceptance run | all activated components; pilot; rollback | #765 | TBD | NOT STARTED |
 
-## 3. Branch preparation
+## 3. Branch rule
 
-- `thoth`: current `develop -> master` topology conforms. Create `feature/publisher-services` only after P0-01 and required ADRs.
-- `thoth-app`: current `dev -> main`; complete BR-APP-01 or approve an exception.
-- `thoth-dissemination`: current `develop -> main`; complete BR-DIS-01 or approve the programme-branch strategy.
-- `cc-license`: current `develop -> main`; complete BR-LIC-01 or approve the programme-branch strategy.
+Recommended task names follow the design, for example:
 
-## 4. Next status actions
+```text
+feature/publisher-services/adr-01
+feature/publisher-services/be-01
+feature/publisher-services/dis-01
+```
 
-1. Independently review PR #764.
-2. Resolve review findings.
-3. Approve or amend ADR-0001 and ADR-0002 through the CTO decision gate.
-4. Merge the engineering-control foundation.
-5. Scope ADR-01 as the first bounded Publisher Services implementation-readiness task.
+Each branch starts from the repository's verified development branch and targets that branch directly. Merge and delete it after independent approval. There is no parent `feature/publisher-services` branch.
+
+## 4. Next actions
+
+1. approve and merge PR #764;
+2. approve/amend ADR-0001 and ADR-0002;
+3. scope ADR-01 as the first bounded Publisher Services task;
+4. record repository-specific branch normalization or exceptions before affected tasks.

--- a/thoth-api-server/AGENTS.md
+++ b/thoth-api-server/AGENTS.md
@@ -1,0 +1,72 @@
+# AGENTS.md - `thoth-api-server`
+
+This file extends the repository-root `AGENTS.md`.
+
+It applies to the Actix HTTP server that exposes Thoth's GraphQL API.
+
+## 1. Ownership boundary
+
+This crate owns transport concerns:
+
+- Actix server setup;
+- GraphQL endpoint serving;
+- request context construction;
+- authentication/introspection integration;
+- CORS and HTTP middleware;
+- logging and transport-level error handling.
+
+Canonical domain rules, validation and authorization policies belong in `thoth-api`.
+
+Do not duplicate a domain rule in the HTTP layer.
+
+## 2. Authentication
+
+Treat authentication and ZITADEL introspection failures as deny-by-default.
+
+Do not:
+
+- convert an authentication backend failure into anonymous elevated access;
+- trust browser-provided publisher IDs or roles;
+- use CORS or origin checks as authorization;
+- log bearer tokens or introspection payloads;
+- collapse distinct machine roles into a broad superuser path without an approved ADR.
+
+Preserve the public behaviour of unrelated GraphQL queries when adding protected service operations.
+
+## 3. Request context
+
+Any new context field must have:
+
+- a clear owner and lifetime;
+- bounded resource use;
+- safe construction failure;
+- tests for missing/invalid state;
+- no production secret exposure.
+
+Database pools, authenticated users and request metadata must be passed through existing context patterns.
+
+## 4. HTTP compatibility
+
+For endpoint or middleware changes, assess:
+
+- URL and method compatibility;
+- content types;
+- status/error mapping;
+- CORS;
+- proxy behaviour;
+- request size and timeout limits;
+- observability;
+- health checks.
+
+Do not make a transport change that silently changes GraphQL domain semantics.
+
+## 5. Required checks
+
+```bash
+cargo test -p thoth-api-server
+cargo check --workspace
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+For changes that affect shared context or API behaviour, also run the full workspace tests.

--- a/thoth-api/AGENTS.md
+++ b/thoth-api/AGENTS.md
@@ -1,0 +1,187 @@
+# AGENTS.md - `thoth-api`
+
+This file extends the repository-root `AGENTS.md`.
+
+It applies to the canonical domain, PostgreSQL model, GraphQL schema/resolvers, validation, authorization and migrations in `thoth-api`.
+
+## 1. Ownership boundary
+
+`thoth-api` owns:
+
+- domain models and identifiers;
+- database access and schema mapping;
+- migrations;
+- validation and canonicalization;
+- GraphQL types, inputs, queries and mutations;
+- authorization policies;
+- durable jobs, leases and audit records implemented in Thoth.
+
+Do not place HTTP transport configuration or UI-specific behaviour here.
+
+## 2. Required orientation
+
+Before editing, inspect:
+
+- the relevant model module under `src/model/`;
+- `src/graphql/`;
+- `src/policy.rs`;
+- `src/db.rs`;
+- related migrations under `migrations/`;
+- `src/schema.rs`;
+- existing tests for the same domain;
+- relevant error variants in `thoth-errors`;
+- the approved ADR and task specification.
+
+Follow existing model/module patterns before creating new abstractions.
+
+## 3. Database migrations
+
+Create migration directories through the repository convention:
+
+```bash
+make migration
+```
+
+Expected shape:
+
+```text
+thoth-api/migrations/YYYYMMDD_v<version>/
+├── up.sql
+└── down.sql
+```
+
+A migration task must document:
+
+- new or altered tables, enums, columns, constraints and indexes;
+- existing-data treatment;
+- default and nullability behaviour;
+- expected table locking and runtime;
+- forward migration;
+- down migration or explicit forward-repair decision;
+- retry/idempotency behaviour;
+- deployment ordering.
+
+Do not make a destructive or lossy migration without explicit CTO approval and a tested backup/restore or forward-repair plan.
+
+Backfill existing data before adding constraints that existing rows cannot satisfy.
+
+Avoid application-side uniqueness checks without a matching database constraint.
+
+## 4. Diesel schema control gap
+
+The repository contains `thoth-api/src/schema.rs`, while the root `diesel.toml` currently identifies a different output path.
+
+Do not guess the schema-generation command or manually relocate generated schema.
+
+Every schema-changing task must first:
+
+1. identify the working command and directory used by maintainers;
+2. record it in the task/implementation report;
+3. generate or verify `thoth-api/src/schema.rs`;
+4. ensure no unrelated schema reformatting is introduced.
+
+If this cannot be established, stop and return `BLOCKED`.
+
+## 5. Transactions, concurrency and idempotency
+
+Use database-enforced correctness for concurrent operations.
+
+As applicable, use:
+
+- unique constraints;
+- foreign keys;
+- check constraints;
+- exclusion constraints;
+- row locks;
+- advisory locks;
+- leases with expiry;
+- claim tokens;
+- `FOR UPDATE SKIP LOCKED`;
+- deterministic idempotency keys.
+
+Tests must cover concurrent first-arrival, stale claims and repeat execution where the feature can be invoked more than once.
+
+Do not rely on GitHub Actions or a single worker process as a lock manager.
+
+## 6. GraphQL design
+
+Prefer additive schema changes.
+
+For new lists and reports:
+
+- paginate deterministically;
+- bound date ranges and result sizes;
+- avoid N+1 access;
+- use set-based SQL or batched loaders;
+- define OR/AND filter semantics explicitly;
+- preserve stable enum/API codes;
+- distinguish zero, absent and unknown where the domain requires it.
+
+Do not call an external API from a resolver for data that Thoth owns canonically.
+
+## 7. Authorization
+
+Use the central policy machinery in `src/policy.rs` and model-specific policies.
+
+Do not authorize only in the resolver body or frontend.
+
+Every new protected query/mutation must have explicit tests for:
+
+- no authentication;
+- wrong role;
+- wrong publisher scope;
+- correct publisher scope;
+- superuser or approved machine role.
+
+Service roles must be least-privilege and distinct where read, ingest and synchronization have different powers.
+
+An authentication/introspection failure must not broaden access.
+
+## 8. Validation and write-path coverage
+
+Canonical validation must apply to every route that can write the field:
+
+- direct GraphQL create/update;
+- imports;
+- bulk mutations;
+- administrative ingestion;
+- background worker mutations;
+- migration/backfill tools where appropriate.
+
+Do not fix only one entry point.
+
+Use canonical libraries such as `cc-license` rather than copying domain parsing rules.
+
+## 9. Errors and auditability
+
+Use stable, machine-readable error variants where clients or imports need classification.
+
+Preserve enough context for diagnosis without storing secrets or unbounded raw input.
+
+For imports and reconciliation, no row or state transition may disappear silently. Record accepted, duplicate, conflict, revised and rejected outcomes explicitly where required by the design.
+
+## 10. Required checks
+
+At minimum:
+
+```bash
+cargo test -p thoth-api --features backend
+cargo check --workspace
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+For broad or shared-domain changes, run:
+
+```bash
+cargo test --workspace
+```
+
+Database changes also require:
+
+```bash
+cargo run migrate
+cargo run migrate --revert
+```
+
+against disposable local databases, plus the populated-database procedure specified by the task.

--- a/thoth-client/AGENTS.md
+++ b/thoth-client/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md - `thoth-client`
+
+This file extends the repository-root `AGENTS.md`.
+
+It applies to Thoth's internal Rust GraphQL client and its query contract.
+
+## 1. Contract boundary
+
+`thoth-client` consumes the GraphQL schema produced by the local `thoth-api` crate.
+
+`build.rs` creates:
+
+```text
+assets/schema.graphql
+```
+
+from `thoth_api::graphql::create_schema()` during the build.
+
+Do not hand-edit the generated schema file.
+
+The tracked query source is:
+
+```text
+assets/queries.graphql
+```
+
+## 2. GraphQL changes
+
+When an API change affects internal consumers:
+
+1. update the API schema in `thoth-api`;
+2. update `assets/queries.graphql` only when the client must request new/different fields;
+3. build the client so the local schema is regenerated;
+4. fix generated enum/scalar conversions exhaustively;
+5. run downstream export-server tests.
+
+Do not use a remote schema for this crate. It must build against the exact local API contract.
+
+## 3. Compatibility
+
+GraphQL enum additions may require updates to explicit Rust conversion matches.
+
+Do not hide a new enum variant behind a wildcard that converts it incorrectly.
+
+Where the generated client exposes `Other(_)`, decide explicitly whether the consumer may safely ignore it or must fail.
+
+Preserve request retry and serialization behaviour unless the task explicitly changes it.
+
+## 4. Required checks
+
+```bash
+cargo build -p thoth-client
+cargo test -p thoth-client
+cargo test -p thoth-export-server
+cargo check --workspace
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Inspect the resulting schema/query diff and ensure it contains only the approved contract change.

--- a/thoth-errors/AGENTS.md
+++ b/thoth-errors/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md - `thoth-errors`
+
+This file extends the repository-root `AGENTS.md`.
+
+It applies to shared error types and their GraphQL/HTTP representations.
+
+## 1. Error contract
+
+Treat externally observable errors as part of the API contract.
+
+New errors must have:
+
+- one clear semantic meaning;
+- stable classification when clients depend on it;
+- safe user-facing text;
+- no secrets, tokens, SQL statements or unbounded upstream bodies;
+- appropriate GraphQL/HTTP mapping;
+- tests for serialization/mapping where applicable.
+
+Do not replace a specific actionable error with a generic internal error unless disclosure would be unsafe.
+
+Do not expose internal implementation details merely to make debugging easier.
+
+## 2. Compatibility
+
+Assess all consumers before renaming, merging or removing an error variant.
+
+Import, reconciliation and background-job errors may need a stable machine-readable code separate from the human-readable message.
+
+Sanitize and bound errors before storing them in durable job/import tables.
+
+## 3. Required checks
+
+```bash
+cargo test -p thoth-errors
+cargo test --workspace
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```

--- a/thoth-export-server/AGENTS.md
+++ b/thoth-export-server/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md - `thoth-export-server`
+
+This file extends the repository-root `AGENTS.md`.
+
+It applies to metadata export endpoints, query selection, format projections and OpenAPI/HTTP behaviour.
+
+## 1. Ownership boundary
+
+The export server owns:
+
+- export routes;
+- format-specific projections;
+- export query selection;
+- output serialization;
+- content type and cache behaviour;
+- API documentation derived from route definitions.
+
+It does not own canonical metadata validation or authorization rules.
+
+## 2. Source contract
+
+The server consumes Thoth data through the internal client and domain types.
+
+When the GraphQL contract changes:
+
+- update `thoth-client` first or in the same approved slice;
+- test against the exact local schema;
+- do not guess fields from an unmerged downstream branch.
+
+`THOTH_EXPORT_API` and related values may be used at build time. Record environment assumptions and never bake secrets into build output.
+
+## 3. Format correctness
+
+For every changed export format:
+
+- use representative fixtures;
+- test optional/missing fields;
+- test escaping of XML/CSV/JSON reserved characters;
+- preserve namespaces, identifiers and ordering required by the target;
+- preserve existing output unless the specification explicitly changes it;
+- document any external standard/version relied upon;
+- assess whether caches need invalidation.
+
+Do not reuse semantically different roles, measures or identifiers merely because their serialized shape is similar.
+
+## 4. Pagination and eligibility
+
+Apply eligibility and authorization filtering before pagination and counts.
+
+Verify consistency across:
+
+- individual record endpoints;
+- list endpoints;
+- counts;
+- feed/index endpoints;
+- cache validators;
+- OpenAPI documentation.
+
+Do not expose protected package or internal configuration data through a public export.
+
+## 5. Licence handling
+
+`cc-license` is the canonical Creative Commons parser and metadata authority.
+
+Do not add a second hard-coded licence registry or parse licence URLs independently in export code.
+
+## 6. Required checks
+
+```bash
+cargo test -p thoth-export-server
+cargo build -p thoth-export-server
+cargo check --workspace
+cargo clippy --all --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+Add focused fixture/golden tests for every changed serialization path.


### PR DESCRIPTION
## Summary

Establish the repository-backed engineering-control foundation for AI-assisted delivery across Thoth.

## Task and evidence

- Task: [`CTRL-FOUNDATION-01`](https://github.com/thoth-pub/thoth/blob/b5b1622e54cb3c6fb372dcf02366c8dc4e38654e/docs/engineering/ai-delivery/tasks/CTRL-FOUNDATION-01.md)
- Implementation report: [`CTRL-FOUNDATION-01-implementation-report`](https://github.com/thoth-pub/thoth/blob/b5b1622e54cb3c6fb372dcf02366c8dc4e38654e/docs/engineering/ai-delivery/implementation-reports/CTRL-FOUNDATION-01-implementation-report.md)
- Independent review brief: [`CTRL-FOUNDATION-01-review-brief`](https://github.com/thoth-pub/thoth/blob/b5b1622e54cb3c6fb372dcf02366c8dc4e38654e/docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md)
- Design reference index: [`design-references.md`](https://github.com/thoth-pub/thoth/blob/b5b1622e54cb3c6fb372dcf02366c8dc4e38654e/docs/engineering/design-references.md)
- Publisher Services issue: #765
- Thoth Metrics issue: #766

## Immutable design inputs

- [Private Publisher Services design](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit) - Drive revision `3`
- [Private Thoth Metrics design](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit) - Drive revision `6`
- [Private design reference metadata](https://github.com/thoth-pub/thoth/blob/b5b1622e54cb3c6fb372dcf02366c8dc4e38654e/docs/engineering/design-references.md)

## Scope

Documentation and instruction files only. This PR does not change Rust behaviour, GraphQL/export APIs, database schema or migrations, workflow behaviour, branch settings, runtime configuration, secrets, deployment or release behaviour.

## Programme workflow distinction

- Publisher Services: one fresh task branch and one PR per task; no long-lived programme branch.
- Thoth Metrics: repository-local `feature/metrics` integration branches after branch readiness.

## Decision state

ADR-0001 and ADR-0002 remain `PROPOSED`. Committing them does not approve dependent implementation.

## Verification

At the exact review head, run the commands in the committed review brief and confirm all current-head CI is green.

The implementing conversation cannot approve or merge this PR. Final merge approval belongs to the CTO after a separate high-reasoning Codex or Claude review returns `APPROVED`.



