### PR TITLE
docs: record CTO approval of ADR-0002 platform domain boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [764](https://github.com/thoth-pub/thoth/pull/764) - Add the AI-led engineering operating model, task and review templates, risk classification, release gates, and GitHub Flow controls
 
 ### Changed
+  - [769](https://github.com/thoth-pub/thoth/pull/769) - Record CTO approval of ADR-0002, establishing separate distribution and metrics platform domains with no initial cross-domain mapping, and reconcile the Publisher Services and Metrics control records without enabling implementation
   - [767](https://github.com/thoth-pub/thoth/pull/767) - Reconcile the Publisher Services programme controls with the merged P0-01 foundation while preserving the remaining independent-review, ADR, inventory and branch-readiness gates
   - [768](https://github.com/thoth-pub/thoth/pull/768) - Finalize the Publisher Services P0-01 repository closeout: record the merged closeout PR #767's independent approval and final-head CI evidence, mark P0-01 closed as the authoritative repository record, and replace the issue-synchronization rollback with a guarded procedure (documentation and control records only)
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -53,9 +53,9 @@ Agents must use observed repository state until an approved normalization task c
 - [Decision process](./decisions/README.md)
 - [Decision register](./decisions/decision-register.md)
 - [ADR-0001: publisher package capabilities](./decisions/ADR-0001-publisher-package-capability-model.md) - `PROPOSED`
-- [ADR-0002: platform domain boundaries](./decisions/ADR-0002-platform-domain-boundaries.md) - `PROPOSED`
+- [ADR-0002: platform domain boundaries](./decisions/ADR-0002-platform-domain-boundaries.md) - `APPROVED` (CTO, 2026-07-27, PR [#769](https://github.com/thoth-pub/thoth/pull/769))
 
-A committed proposed ADR is not approved. Dependent implementation remains blocked until the CTO decision is recorded and independently reviewed.
+A committed proposed ADR is not approved. ADR-0002 is approved; dependent implementation remains blocked by its other prerequisites. ADR-0001 remains proposed, and dependent implementation stays blocked until the CTO decision is recorded and independently reviewed.
 
 ## 7. Active programmes
 
@@ -95,11 +95,17 @@ Achieved:
   independent `APPROVED` review;
 - [x] PR #767 merged into `develop` as
   `bac598e32abbd0d7e69ff467c82945ee00df02ba` on 2026-07-27, closing P0-01;
-- [x] the repository programme trackers record the completed closeout.
+- [x] the repository programme trackers record the completed closeout;
+- [x] issue #765 was synchronized on 2026-07-27 as an external mirror of the
+  completed repository closeout; issue #765 remains open.
 
 Outstanding:
 
-- [ ] apply the separately authorized issue #765 synchronization as an external
-  mirror of the completed repository closeout.
+- None for the foundation closeout gate. Dependent Publisher Services and Metrics
+  implementation remains blocked by the ADR-0001, Publisher Services ADR-01 and
+  final-inventory, branch-readiness and task-specification gates recorded in the
+  programme controls. ADR-0002 was approved on 2026-07-27 through PR
+  [#769](https://github.com/thoth-pub/thoth/pull/769); it removes one shared-ADR
+  dependency and does not make either programme implementation-ready.
 
 The implementing conversation cannot approve its own work.

--- a/docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md
@@ -9,9 +9,25 @@ Base commit: `f2e09bd9b138e8ba2ca47a791533f4aae4ffab28`
 PR target: `develop`
 Programme integration branch: None
 Task branch: `feature/engineering/adr-0002-approve`
-Head commit: recorded in the handoff; this evidence report is the third and final
-commit on the branch, so its own SHA becomes the exact final head and is captured
-after push (the two preceding commits are `ddf635fd` and `7a82680c`).
+
+Pre-review evidence head:
+`f4ef99c97c21f86d0dccd29081a450e3bdf4ce54`
+
+This was the exact head at which:
+
+- the three original commits (`ddf635fd`, `7a82680c`, `f4ef99c9`) were present;
+- the 14-file cumulative diff versus `origin/develop` was inspected;
+- all four workflow runs and all seven required jobs succeeded;
+- both issue baselines (#765 and #766) were reconfirmed.
+
+This pre-review evidence head is not the final PR head after this evidence
+correction commit is created.
+
+This correction commit cannot contain its own SHA without creating a
+self-referential evidence loop. Its exact SHA and the resulting final PR head
+are authoritative in GitHub and the post-push handoff. The independent reviewer
+must inspect that new exact head and its fresh CI.
+
 Pull request: [#769](https://github.com/thoth-pub/thoth/pull/769) (draft)
 Expected branch deletion after merge: YES
 Final programme PR required: NO
@@ -41,16 +57,28 @@ REQUIRED` report was triggered.
 
 ## 3. Commits
 
-- `ddf635fd` - docs: approve ADR-0002 recording task (task specification only,
+Existing commits:
+
+- `ddf635fd...` - docs: approve ADR-0002 recording task (task specification only,
   committed first)
-- `7a82680c` - docs: record ADR-0002 approval (approval metadata and control-record
-  reconciliation)
-- `<this report>` - docs: record ADR-0002 approval evidence (final head; SHA in
-  handoff)
+- `7a82680c...` - docs: record ADR-0002 approval (approval metadata and
+  control-record reconciliation)
+- `f4ef99c97c21f86d0dccd29081a450e3bdf4ce54` - docs: record ADR-0002 approval
+  evidence
+
+Correction commit (this change), recorded by purpose and message; it cannot embed
+its own SHA:
+
+- docs: correct ADR-0002 approval evidence (pre-review evidence correction to the
+  implementation report only)
+
+The post-push handoff provides this correction commit's exact SHA, which becomes
+the final PR head.
 
 ## 4. Files changed
 
-Cumulative changed-file set versus `origin/develop` (a subset of the allowlist):
+The cumulative PR changes exactly 14 files versus `origin/develop`. All 14 files
+remain within the approved file allowlist:
 
 - `docs/engineering/ai-delivery/tasks/ADR-0002-APPROVE.md`
   - reason: approved task specification, committed before any other change.
@@ -112,6 +140,10 @@ Cumulative changed-file set versus `origin/develop` (a subset of the allowlist):
 - `CHANGELOG.md`
   - reason: one bounded `Changed` entry referencing PR #769.
   - behavioural effect: none.
+- `docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md`
+  - reason: Records implementation, verification, issue-baseline and
+    independent-review evidence.
+  - behavioural effect: None; documentation only.
 
 ## 5. Implementation decisions
 
@@ -232,24 +264,35 @@ Evidence: recorded in this report and the PR #769 diff.
 
 ## 11. CI
 
-CI status: PENDING at report authoring - the required jobs run at the exact final
-head (this evidence commit).
-
-Required jobs at the final head (all must conclude `success` before review
-approval):
+CI evidence at the pre-review evidence head
+`f4ef99c97c21f86d0dccd29081a450e3bdf4ce54`:
 
 ```text
-build
-format_check
-lint
-test
-build_and_push_staging_docker_image
-check-changelog
-run_migrations
+30284414011 - build-test-and-check
+  build: success
+  format_check: success
+  lint: success
+  test: success
+
+30284414051 - run-migrations
+  run_migrations: success
+
+30284414066 - check-changelog
+  check-changelog: success
+
+30284414243 - publish-to-dockerhub
+  build_and_push_staging_docker_image: success
 ```
 
-The actual workflow run IDs and the seven job conclusions at the final head are
-recorded in the handoff and visible on PR #769. A documentation-only no-build
+All seven required jobs (`build`, `format_check`, `lint`, `test`,
+`build_and_push_staging_docker_image`, `check-changelog`, `run_migrations`)
+concluded `success` at that head.
+
+This evidence-correction commit creates a new head. That new correction head
+requires a fresh, complete CI run before independent approval. The four runs above
+were executed at `f4ef99c9...` and must not be reused as the final-head CI for the
+new correction commit. The reviewer must inspect the new exact head's own fresh CI
+and confirm all seven jobs conclude `success` there. A documentation-only no-build
 path is acceptable but is not a substitute for independent review.
 
 ## 12. Rollout and rollback
@@ -438,3 +481,35 @@ Suggested review focus:
 - confirm both proposed issue bodies are minimal and the issues were not written.
 
 The agent may identify risks but may not approve the task.
+
+## 20. Pre-review correction
+
+Pre-review control decision: `CHANGES REQUIRED`.
+
+Findings identified and corrected before independent review:
+
+- **P1 - Incomplete tracked final-head/commit/CI evidence.** The report's Section 1
+  head-commit field was a placeholder deferring the head to the handoff, Section 3
+  did not record the third commit's SHA, and Section 11 left CI `PENDING`. This
+  correction records the pre-review evidence head
+  `f4ef99c97c21f86d0dccd29081a450e3bdf4ce54`, the three existing commit SHAs, and
+  the concrete CI evidence (four workflow run IDs, all seven jobs `success`) at
+  that head.
+- **P2 - Changed-file count understated and self-omission.** The report stated 13
+  changed files and omitted the implementation report itself. This correction
+  states the cumulative PR changes exactly 14 files, all within the approved
+  allowlist, and adds the implementation report to the Section 4 file list.
+
+Both findings were corrected in this single bounded evidence-correction commit,
+before any independent review or approval.
+
+Scope of this correction: only
+`docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md`
+changed. No architectural, decision-register, programme-tracker, CHANGELOG, task
+specification, GitHub issue or runtime content changed. All historical evidence
+and both issue synchronization proposals are preserved.
+
+Because this correction commit creates a new head, a fresh complete CI run is
+required at that new exact head before independent approval; the four runs recorded
+in Section 11 belong to `f4ef99c9...` and are not the final-head CI for the new
+correction commit.

--- a/docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md
@@ -1,0 +1,440 @@
+# ADR-0002-APPROVE Implementation Report
+
+## 1. Repository state
+
+Repository: `thoth-pub/thoth`
+Workflow: STANDARD
+Base branch: `develop`
+Base commit: `f2e09bd9b138e8ba2ca47a791533f4aae4ffab28`
+PR target: `develop`
+Programme integration branch: None
+Task branch: `feature/engineering/adr-0002-approve`
+Head commit: recorded in the handoff; this evidence report is the third and final
+commit on the branch, so its own SHA becomes the exact final head and is captured
+after push (the two preceding commits are `ddf635fd` and `7a82680c`).
+Pull request: [#769](https://github.com/thoth-pub/thoth/pull/769) (draft)
+Expected branch deletion after merge: YES
+Final programme PR required: NO
+Implementing agent: Claude Code (Anthropic official CLI), acting as the
+implementing engineering context in this session.
+Implementing model: `claude-opus-4-8` (Opus 4.8).
+Reasoning level: High.
+
+The expected base `f2e09bd9b138e8ba2ca47a791533f4aae4ffab28` was verified against
+`origin/develop` at the start of the task and had not advanced; no intervening
+commits altered scope.
+
+## 2. Scope confirmation
+
+Approved specification:
+`docs/engineering/ai-delivery/tasks/ADR-0002-APPROVE.md`
+
+Implemented objective: recorded the CTO's approval of `ADR-0002 - Distribution
+and Metrics Platform Domain Boundaries` exactly as written and reconciled the
+engineering-control, Publisher Services and Metrics control records with that
+approval, without amending the architectural decision, without approving any
+other decision, and without enabling implementation or producing runtime effect.
+
+Out-of-scope changes made: NONE. Every changed file is within the approved
+allowlist. No file outside the allowlist changed, so no `SCOPE AMENDMENT
+REQUIRED` report was triggered.
+
+## 3. Commits
+
+- `ddf635fd` - docs: approve ADR-0002 recording task (task specification only,
+  committed first)
+- `7a82680c` - docs: record ADR-0002 approval (approval metadata and control-record
+  reconciliation)
+- `<this report>` - docs: record ADR-0002 approval evidence (final head; SHA in
+  handoff)
+
+## 4. Files changed
+
+Cumulative changed-file set versus `origin/develop` (a subset of the allowlist):
+
+- `docs/engineering/ai-delivery/tasks/ADR-0002-APPROVE.md`
+  - reason: approved task specification, committed before any other change.
+  - behavioural effect: none (documentation).
+- `docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md`
+  - reason: record approval metadata (`Status: APPROVED`; approver; date; note).
+  - behavioural effect: none; architectural decision body byte-for-byte unchanged.
+- `docs/engineering/decisions/decision-register.md`
+  - reason: `Last updated: 2026-07-27`; ADR-0002 `APPROVED`; blocker satisfied;
+    approval PR referenced; ADR-0001 remains `PROPOSED`; merge/implementation and
+    approval-sequence rules unchanged.
+  - behavioural effect: none.
+- `docs/engineering/README.md`
+  - reason: ADR-0002 shown `APPROVED`; ADR-0001 remains `PROPOSED`; issue #765
+    synchronization recorded completed on 2026-07-27 and still open; no claim of
+    implementation readiness.
+  - behavioural effect: none.
+- `docs/engineering/repository-map/control-gaps.md`
+  - reason: CG-06 narrowed to ADR-0001; ADR-0002 recorded approved on 2026-07-27;
+    all other gaps retained.
+  - behavioural effect: none.
+- `docs/publisher-services/README.md`
+  - reason: ADR-0002 removed from active blockers and recorded approved;
+    `BLOCKED FOR IMPLEMENTATION` and ADR-0001/ADR-01/branch-readiness blockers
+    retained.
+  - behavioural effect: none.
+- `docs/publisher-services/decisions.md`
+  - reason: ADR-0002 moved to an approved shared decision with its exact
+    architectural meaning; ADR-0001 remains proposed; ADR-01 delegated decisions
+    and deferrals retained.
+  - behavioural effect: none.
+- `docs/publisher-services/task-status.md`
+  - reason: `Last updated: 2026-07-27`; ADR-01 and BE-02 dependencies reconciled
+    (ADR-0002 dependency removed; ADR-01 blocker narrowed to its missing bounded
+    specification and final inventory); completed issue #765 synchronization
+    removed from next actions; ADR-0002 approval recorded; ADR-0001 immediate.
+  - behavioural effect: none; no task became `READY`.
+- `docs/publisher-services/rollout-plan.md`
+  - reason: Stage 0 achieved evidence records P0-01 closed, issue #765
+    synchronized and still open, and ADR-0002 approved; outstanding evidence drops
+    issue #765 sync and ADR-0002 approval and retains the remaining gates.
+  - behavioural effect: none; no later stage activated.
+- `docs/metrics/README.md`
+  - reason: ADR-0002 recorded approved and no longer blocking;
+    `BLOCKED FOR IMPLEMENTATION`, `MET-CTRL-01 CHANGES REQUIRED` and all other
+    Metrics blockers retained.
+  - behavioural effect: none.
+- `docs/metrics/decisions.md`
+  - reason: ADR-0002 moved from proposed to approved shared architecture;
+    `MetricPlatform` separate from `DistributionPlatform`; no initial mapping;
+    ADR-0001 remains proposed; no Metrics-specific unresolved decision changed.
+  - behavioural effect: none.
+- `docs/metrics/task-status.md`
+  - reason: `Last updated: 2026-07-27`; ADR-0002 row `APPROVED` with CTO date and
+    approval PR; ADR-0001 remains `PROPOSED`; WP1 blocker narrowed to `ADR-0001`;
+    next actions record ADR-0002 achieved.
+  - behavioural effect: none; every work package remains `BLOCKED`; no task became
+    `READY`.
+- `CHANGELOG.md`
+  - reason: one bounded `Changed` entry referencing PR #769.
+  - behavioural effect: none.
+
+## 5. Implementation decisions
+
+1. The ADR change is confined to two hunks: the header `Status` line and the
+   Section 10 approval record. Section 10's `Approval required from: CTO` line and
+   the original proposal `Date: 2026-07-24` were preserved.
+2. The decision register's approval blocker was changed to a satisfied statement
+   rather than deleted, keeping the audit trail visible.
+3. Control gaps: CG-06 was retitled and rewritten to retain ADR-0001 as the
+   unresolved shared-ADR gate; no other CG entry changed.
+4. Historical evidence (prior task specifications, implementation reports and the
+   CTRL-FOUNDATION-01 review brief) that states ADR-0002 was `PROPOSED` at the
+   time those tasks ran was intentionally left unchanged; those are historical
+   records, not active control-record statements.
+5. Issue #765 and #766 were not written. Exact proposed post-merge bodies are
+   recorded in Section 16 for later separate review and authorization.
+
+Deviations from the specification: NONE.
+
+## 6. Database and migration effects
+
+Migration added: NO. No schema, SQL, migration, Rust, GraphQL or generated code
+changed.
+
+## 7. API and compatibility effects
+
+GraphQL/API changes: none.
+Generated schema/client updates: none.
+Backwards compatibility: unaffected (documentation and control records only).
+Deprecations: none.
+Cross-repository dependencies: none introduced. No shared platform abstraction or
+cross-domain mapping was created; ADR-0002's separation of `DistributionPlatform`
+and `MetricPlatform` is unchanged.
+
+## 8. Authorization and security
+
+Authorization paths changed: none.
+Roles/scopes involved: none.
+Negative authorization tests: not applicable.
+Secret or personal-data handling: none.
+Security limitations: not applicable; no runtime surface changed.
+
+## 9. Tests and checks
+
+This is a documentation and control-record change with no runtime effect. The
+required verification is repository-state consistency, link integrity and CI.
+
+### Formatting / static checks
+
+Command:
+
+```text
+git diff --check origin/develop...HEAD
+```
+
+Result:
+
+```text
+clean - no whitespace or conflict-marker errors
+```
+
+### Changed-file boundary
+
+Command:
+
+```text
+git diff --name-only origin/develop...HEAD | grep -Ev '^(CHANGELOG\.md|docs/)'
+```
+
+Result:
+
+```text
+(no output) - every change is within CHANGELOG.md or docs/
+```
+
+### State assertions
+
+Command:
+
+```text
+grep -n '^Status: APPROVED$' docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
+grep -n '^Status: PROPOSED$' docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+grep -n 'FINAL ENUM NOT APPROVED' docs/publisher-services/platform-inventory.md
+grep -n 'MET-CTRL-01.*CHANGES REQUIRED' docs/metrics/task-status.md
+grep -n 'ADR-0002.*APPROVED' docs/engineering/decisions/decision-register.md docs/metrics/task-status.md
+grep -n 'ADR-01.*BLOCKED' docs/publisher-services/task-status.md
+```
+
+Result:
+
+```text
+ADR-0002 Status: APPROVED (line 3)
+ADR-0001 Status: PROPOSED (line 3)
+platform-inventory: VERIFIED BASELINE; FINAL ENUM NOT APPROVED (line 3)
+MET-CTRL-01: CHANGES REQUIRED (present)
+ADR-0002 APPROVED present in decision-register.md and metrics/task-status.md
+ADR-01: BLOCKED present in publisher-services/task-status.md
+```
+
+### Relative-link integrity
+
+Every relative Markdown link in the changed files resolves to an existing file
+(checked by resolving each link against its file's directory).
+
+### Lint/static analysis
+
+Not applicable - no source code changed.
+
+## 10. Manual verification
+
+Environment: local worktree at the task head.
+Steps: read every changed file; diffed the ADR against `origin/develop`; ran the
+verification greps; re-ran the repository-wide stale-state search.
+Observed result: only approval metadata changed in the ADR; all active control
+records reconciled; all remaining `ADR-0002 ... PROPOSED` matches are historical
+evidence or this task's own spec-time snapshot.
+Evidence: recorded in this report and the PR #769 diff.
+
+## 11. CI
+
+CI status: PENDING at report authoring - the required jobs run at the exact final
+head (this evidence commit).
+
+Required jobs at the final head (all must conclude `success` before review
+approval):
+
+```text
+build
+format_check
+lint
+test
+build_and_push_staging_docker_image
+check-changelog
+run_migrations
+```
+
+The actual workflow run IDs and the seven job conclusions at the final head are
+recorded in the handoff and visible on PR #769. A documentation-only no-build
+path is acceptable but is not a substitute for independent review.
+
+## 12. Rollout and rollback
+
+Initial state after merge: ADR-0002 becomes `APPROVED` in the repository, removing
+one dependency; the Publisher Services and Metrics programmes remain blocked for
+implementation; issue #765 and #766 synchronization become separately authorized
+external mirrors.
+Activation required: none.
+Feature flag/configuration: none.
+Migration sequence: none.
+Rollback/disable procedure: revert this documentation PR; no runtime effect. Any
+issue rollback is guarded (re-fetch, compare, stop on mismatch, minimal reviewed
+reversal under explicit CTO authorization; never blind full-body overwrite).
+Monitoring required: none.
+
+## 13. No-runtime-effect assessment
+
+No Rust, SQL, migration, GraphQL, generated code, workflow or repository-protection
+file changed. The change set is limited to `CHANGELOG.md` and `docs/`. There is no
+deployment, release or behaviour activation, and no cross-domain mapping was
+created. Approving ADR-0002 removes one dependency and does not, by itself, make
+ADR-01, BE-02, Metrics WP1 or any other task `READY`.
+
+## 14. Proof the ADR decision body was not changed
+
+The cumulative diff of the ADR versus `origin/develop` is exactly two hunks:
+
+```diff
+@@ -1,6 +1,6 @@
+ # ADR-0002 - Distribution and Metrics Platform Domain Boundaries
+ 
+-Status: PROPOSED
++Status: APPROVED
+ Date: 2026-07-24
+ Decision owner: CTO
+ Programmes affected: Publisher Services, Thoth Metrics
+@@ -293,6 +293,7 @@ Rollback:
+ ## 10. Approval
+ 
+ Approval required from: CTO
+-Approved by:
+-Approval date:
+-Notes:
++Approved by: Javi, CTO
++Approval date: 2026-07-27
++Notes: Approved as written. DistributionPlatform and MetricPlatform remain
++separate domain types, with no initial cross-domain mapping.
+```
+
+Sections 1-9 (Context, Decision drivers, Options considered, Decision,
+Consequences, Invariants, Implementation impact, Validation, Rollout and rollback)
+are byte-for-byte unchanged. The original proposal `Date: 2026-07-24` is preserved.
+
+## 15. CTO approval evidence
+
+Exact CTO decision:
+
+> I approve ADR-0002 - Distribution and Metrics Platform Domain Boundaries as
+> written.
+> Do not amend the architectural decision.
+
+Approved by: Javi, CTO. Approval date: 2026-07-27.
+
+## 16. Live issue baselines and proposed synchronization (recorded, not applied)
+
+This task did not write to issue #765 or #766. Baselines were fetched read-only.
+
+### Issue #765
+
+```text
+state: OPEN
+baseline updatedAt: 2026-07-27T15:50:33Z
+complete-body sha256: 96c31089a3046eadf51a0fc39b12d0275ce26f4d752c64282f5dcb933f78ca15
+```
+
+Proposed minimal post-merge change (sha256 of proposed body
+`da12243b2a1898fd3fd574aada1dede3296ff13f38943e4fbb78a3dcb5ae1a35`):
+
+1. Update the existing `## Synchronization guard` baseline from
+   `updatedAt: 2026-07-24T17:17:09Z` to `updatedAt: 2026-07-27T15:50:33Z` (and the
+   reviewed baseline body to the current live body).
+2. Change only `- [ ] ADR-0002 approved` to `- [x] ADR-0002 approved`.
+3. Preserve every other line and checkbox. Keep the issue open.
+
+Proposed diff:
+
+```diff
+ ## Synchronization guard
+ 
+-Before applying this replacement: re-fetch the complete live issue body; re-fetch its current `updatedAt`; compare both exactly against the reviewed baseline `updatedAt: 2026-07-24T17:17:09Z` and body. ...
++Before applying this replacement: re-fetch the complete live issue body; re-fetch its current `updatedAt`; compare both exactly against the reviewed baseline `updatedAt: 2026-07-27T15:50:33Z` and body. ...
+ 
+ ## Current gate
+ 
+ - [x] P0-01 independently approved, repository-finalized and merged
+ - [ ] ADR-0001 approved
+-- [ ] ADR-0002 approved
++- [x] ADR-0002 approved
+ - [ ] ADR-01 platform inventory approved
+ - [ ] repository branch-readiness decisions recorded
+```
+
+### Issue #766
+
+```text
+state: OPEN
+baseline updatedAt: 2026-07-24T17:17:11Z
+complete-body sha256: 6b1bb092f3f0b436c01faaabbf4fb5df331268f4d687463b3c715fb4ea9d6dbc
+```
+
+Proposed minimal post-merge change (sha256 of proposed body
+`f4e8aa7e855b2b3c44b4cf38c60475861079698cc7f5cd95a6ac319b892cb772`):
+
+1. Add an equivalent forward-and-rollback `## Synchronization guard` section based
+   on the complete current body and `updatedAt: 2026-07-24T17:17:11Z`, inserted
+   immediately before `## Current gate`.
+2. Change only `- [ ] ADR-0002 approved` to `- [x] ADR-0002 approved` apart from
+   the guard section.
+3. Preserve every other line and checkbox. Keep the issue open.
+
+Proposed diff:
+
+```diff
+ The Metrics design uses repository-local `feature/metrics` integration branches only after each repository's branch-readiness gate.
+ 
++## Synchronization guard
++
++Before applying this replacement: re-fetch the complete live issue body; re-fetch its current `updatedAt`; compare both exactly against the reviewed baseline `updatedAt: 2026-07-24T17:17:11Z` and body. If either the live body or `updatedAt` differs, do not write. Regenerate the minimal diff from the new live body, obtain fresh independent review, and obtain separate explicit CTO authorization before writing. Any later rollback must likewise re-fetch and compare the live body and `updatedAt`, preserve unrelated edits, and apply only a reviewed minimal reversal under explicit CTO authorization; it must never restore an old complete snapshot blindly.
++
+ ## Current gate
+ 
+ - [ ] MET-CTRL-01 independently approved and merged
+ - [ ] ADR-0001 approved
+-- [ ] ADR-0002 approved
++- [x] ADR-0002 approved
+ - [ ] BR-SPHINX-01 complete
+ - [ ] SPHINX-BOOT-01 complete
+ - [ ] THOTH-DB-CTRL-01 complete
+```
+
+### Deferred write conditions (both issues)
+
+Each write requires, in order: this repository PR independently approved and
+merged; immediate pre-write re-fetch of the complete live body and `updatedAt`;
+exact baseline comparison; stop on any mismatch; fresh independent review of any
+regenerated diff; and separate explicit CTO authorization. The issues remain open.
+
+## 17. Residual blockers
+
+```text
+ADR-0001: PROPOSED
+Publisher Services ADR-01: unapproved
+Platform inventory: VERIFIED BASELINE; FINAL ENUM NOT APPROVED
+MET-CTRL-01: CHANGES REQUIRED
+All Publisher Services implementation tasks: BLOCKED
+All Metrics work packages: BLOCKED
+Branch-readiness decisions: outstanding
+```
+
+ADR-0002 approval removes exactly one shared dependency. No implementation task
+becomes `READY`.
+
+## 18. Independent-review requirement
+
+The implementing context is ineligible to approve this work. A fresh
+non-implementing reviewer with high reasoning must inspect the exact final head,
+all commits in order, the complete cumulative diff, ADR-0002 before and after,
+proof that only approval metadata changed in the ADR, all Publisher Services and
+Metrics tracker changes, all remaining blockers, exact-head CI, the complete issue
+#765 and #766 baselines, both proposed issue bodies, and the absence of runtime
+changes. The reviewer must return exactly one verdict: `APPROVED`, `CHANGES
+REQUIRED` or `BLOCKED`, permitted to approve only with no unresolved P0/P1
+finding. The reviewer must not mark the PR ready, merge it or edit either issue.
+
+## 19. Agent self-assessment
+
+Suggested review focus:
+
+- confirm the ADR diff is limited to approval metadata and the proposal date is
+  preserved;
+- confirm no implementation task or work package became `READY`;
+- confirm ADR-0001, the platform inventory and `MET-CTRL-01` are unchanged;
+- confirm the changed-file set is a subset of the allowlist and no runtime file
+  changed;
+- confirm both proposed issue bodies are minimal and the issues were not written.
+
+The agent may identify risks but may not approve the task.

--- a/docs/engineering/ai-delivery/tasks/ADR-0002-APPROVE.md
+++ b/docs/engineering/ai-delivery/tasks/ADR-0002-APPROVE.md
@@ -1,0 +1,392 @@
+# ADR-0002-APPROVE - Record approval of Distribution and Metrics Platform Domain Boundaries
+
+Status: APPROVED
+Programme: Cross-programme Engineering Control
+Affected programmes:
+
+- Publisher Services and Distribution Configuration
+- Thoth Metrics
+
+Repository: thoth-pub/thoth
+Workflow: STANDARD
+Base branch: develop
+Verified base commit: `f2e09bd9b138e8ba2ca47a791533f4aae4ffab28`
+PR target: develop
+Programme integration branch: None
+Risk: MEDIUM
+Owner: CTO
+Approved by: Javi, CTO
+Approval date: 2026-07-27
+Implementation reasoning: High
+Independent review reasoning: High
+Target branch name: `feature/engineering/adr-0002-approve`
+
+Dependencies:
+
+- ADR-0002 proposal present in `develop`, introduced by merged PR
+  [#764](https://github.com/thoth-pub/thoth/pull/764) as
+  `5b406e4ef9b5c192cc38eb8a97a41bbd0fc3bc06`;
+- GitHub issue [#765](https://github.com/thoth-pub/thoth/issues/765) OPEN at
+  baseline `updatedAt: 2026-07-27T15:50:33Z`;
+- GitHub issue [#766](https://github.com/thoth-pub/thoth/issues/766) OPEN at
+  baseline `updatedAt: 2026-07-24T17:17:11Z`;
+- an independent reviewer who did not implement this task.
+
+## 0. Implementing-agent provenance
+
+This specification is implemented by the actual agent that executed the task, not
+a guessed or preselected identity:
+
+- Implementing agent: Claude Code (Anthropic official CLI), acting as the
+  implementing engineering context in this session.
+- Model: `claude-opus-4-8` (Opus 4.8).
+- Implementation reasoning: High.
+
+The independent reviewer must be a fresh non-implementing context with high
+reasoning and is preferably a different model family.
+
+## 1. Objective
+
+Record the CTO's approval of `ADR-0002 - Distribution and Metrics Platform Domain
+Boundaries` exactly as written, and reconcile every active engineering-control,
+Publisher Services and Metrics record with that approval, without amending the
+architectural decision, without approving any other decision, and without
+enabling any implementation work or producing any runtime effect.
+
+## 2. CTO approval
+
+The exact CTO decision is:
+
+> I approve ADR-0002 - Distribution and Metrics Platform Domain Boundaries as
+> written.
+> Do not amend the architectural decision.
+
+Approved by: Javi, CTO. Approval date: 2026-07-27.
+
+The approval covers only the recording of approval metadata and the reconciliation
+of dependent control records. It does not amend the ADR body, approve any other
+ADR, approve the platform inventory, record branch readiness, or make any
+implementation task ready.
+
+## 3. Background and authority
+
+Authoritative sources, in precedence order:
+
+1. `thoth-pub/thoth` branch `develop` at
+   `f2e09bd9b138e8ba2ca47a791533f4aae4ffab28`;
+2. the existing `ADR-0002` body (the authoritative architectural decision);
+3. `docs/engineering/decisions/` and the decision register;
+4. `docs/publisher-services/` and `docs/metrics/` control records;
+5. GitHub issues #765 and #766;
+6. repository agent instructions and delivery controls.
+
+Current verified state at specification time:
+
+- `origin/develop` points at `f2e09bd9b138e8ba2ca47a791533f4aae4ffab28`; the
+  expected base is unchanged and no intervening commits alter this scope.
+- `ADR-0002` is `PROPOSED` (line 3 of the ADR body).
+- `ADR-0001` is `PROPOSED`.
+- The platform inventory is `VERIFIED BASELINE; FINAL ENUM NOT APPROVED`.
+- `MET-CTRL-01` is `CHANGES REQUIRED`.
+- Issue #765 is OPEN at `updatedAt: 2026-07-27T15:50:33Z`.
+- Issue #766 is OPEN at `updatedAt: 2026-07-24T17:17:11Z`.
+
+## 4. Explicit scope
+
+The task must:
+
+1. Commit this approved task specification first.
+2. Update only the approval state and approval record of
+   `docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md` to
+   `APPROVED`, recording the approver, approval date and an approval note,
+   preserving the original proposal date and every other section unchanged.
+3. Reconcile the active stale statements about ADR-0002 in:
+   - `docs/engineering/decisions/decision-register.md`;
+   - `docs/engineering/README.md`;
+   - `docs/engineering/repository-map/control-gaps.md`;
+   - `docs/publisher-services/README.md`;
+   - `docs/publisher-services/decisions.md`;
+   - `docs/publisher-services/task-status.md`;
+   - `docs/publisher-services/rollout-plan.md`;
+   - `docs/metrics/README.md`;
+   - `docs/metrics/decisions.md`;
+   - `docs/metrics/task-status.md`.
+4. Add one bounded `Changed` CHANGELOG entry referencing this approval PR.
+5. Create the implementation report
+   `docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md`.
+6. Record the live issue #765 and #766 baselines, complete-body hashes, and the
+   exact proposed post-merge synchronization bodies inside the report, without
+   writing either issue.
+
+## 5. Non-goals
+
+This task must not:
+
+- change the ADR-0002 architecture (options, recommended option, decision,
+  invariants, implementation impact, validation, rollout or rollback);
+- approve ADR-0001;
+- approve Publisher Services ADR-01;
+- approve the distribution-platform inventory;
+- record branch readiness;
+- modify issue #765 or #766;
+- make any implementation task `READY`;
+- change Rust, SQL, migrations, GraphQL or generated code;
+- change workflows or repository protection;
+- deploy, release or activate behaviour;
+- create a cross-domain mapping;
+- start Publisher Services or Metrics implementation;
+- merge its own PR.
+
+## 6. Invariants
+
+The final branch must preserve:
+
+```text
+ADR-0001: PROPOSED
+ADR-0002: APPROVED only after this PR merges
+Publisher Services ADR-01: unapproved
+Platform inventory: FINAL ENUM NOT APPROVED
+MET-CTRL-01: CHANGES REQUIRED
+All Publisher Services implementation tasks: BLOCKED
+All Metrics work packages: BLOCKED
+No shared platform abstraction or mapping
+No runtime effect
+```
+
+Approving ADR-0002 removes one dependency. It does not by itself make ADR-01,
+BE-02, Metrics WP1 or any other task ready.
+
+## 7. Approved file allowlist
+
+```text
+CHANGELOG.md
+docs/engineering/README.md
+docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
+docs/engineering/decisions/decision-register.md
+docs/engineering/repository-map/control-gaps.md
+docs/engineering/ai-delivery/tasks/ADR-0002-APPROVE.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0002-APPROVE-implementation-report.md
+docs/publisher-services/README.md
+docs/publisher-services/decisions.md
+docs/publisher-services/task-status.md
+docs/publisher-services/rollout-plan.md
+docs/metrics/README.md
+docs/metrics/decisions.md
+docs/metrics/task-status.md
+```
+
+The actual changed-file set may be a subset of this allowlist. A file is edited
+only when it contains an active stale statement or is required evidence. If
+another active file must change to make repository state consistent, stop and
+report `SCOPE AMENDMENT REQUIRED` with the exact additional file, active stale
+statement and proposed correction. Historical evidence (prior task
+specifications, implementation reports and review briefs) records the state at
+the time it was written and must not be rewritten.
+
+## 8. Acceptance criteria
+
+- [ ] The task specification was committed before any other change.
+- [ ] The changed-file set is a subset of the approved allowlist.
+- [ ] `docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md` shows
+  `Status: APPROVED`, `Approved by: Javi, CTO`, `Approval date: 2026-07-27` and
+  the required approval note; the original proposal date is preserved.
+- [ ] Only approval metadata changed in the ADR; options, recommended option,
+  decision, invariants, implementation impact, validation, rollout and rollback
+  are byte-for-byte unchanged.
+- [ ] The decision register shows `Last updated: 2026-07-27`, ADR-0002
+  `APPROVED` with its blocker recorded as satisfied and the approval PR
+  referenced, ADR-0001 remains `PROPOSED`, and the merge/implementation rules are
+  unchanged.
+- [ ] `docs/engineering/README.md` shows ADR-0002 `APPROVED`, ADR-0001
+  `PROPOSED`, records the issue #765 synchronization completed on 2026-07-27 and
+  still open, and does not claim either programme is implementation-ready.
+- [ ] `docs/engineering/repository-map/control-gaps.md` CG-06 no longer says both
+  shared ADRs remain proposed; it records ADR-0002 approved on 2026-07-27 and
+  retains ADR-0001 as the unresolved shared-ADR gate; all other gaps retained.
+- [ ] `docs/publisher-services/README.md` removes ADR-0002 from active blockers,
+  records ADR-0002 approved, retains `BLOCKED FOR IMPLEMENTATION` and the
+  ADR-0001, ADR-01/inventory and branch-readiness blockers.
+- [ ] `docs/publisher-services/decisions.md` records ADR-0002 as an approved
+  shared decision with its exact architectural meaning; ADR-0001 remains proposed.
+- [ ] `docs/publisher-services/task-status.md` shows `Last updated: 2026-07-27`,
+  ADR-01 `BLOCKED` with the P0-01/ADR-0002 dependencies removed and its blocker
+  narrowed to the missing approved bounded specification and final inventory,
+  BE-02 `BLOCKED` by ADR-01 without separately listing ADR-0002, the completed
+  issue #765 synchronization removed from next actions, ADR-0002 approval
+  recorded, ADR-0001 an immediate decision, and no task `READY`.
+- [ ] `docs/publisher-services/rollout-plan.md` Stage 0 achieved evidence records
+  P0-01 closed, issue #765 synchronized and still open, and ADR-0002 approved on
+  2026-07-27; outstanding evidence drops issue #765 sync and ADR-0002 approval,
+  retains ADR-0001, ADR-01/inventory, branch readiness and task specs; no later
+  stage activated.
+- [ ] `docs/metrics/README.md` records ADR-0002 approved and no longer blocking,
+  retains `BLOCKED FOR IMPLEMENTATION`, `MET-CTRL-01 CHANGES REQUIRED` and all
+  other Metrics blockers.
+- [ ] `docs/metrics/decisions.md` moves ADR-0002 from proposed to approved shared
+  architecture, records `MetricPlatform` separate from `DistributionPlatform`
+  with no initial mapping, ADR-0001 remains proposed, no Metrics-specific
+  unresolved decision changed.
+- [ ] `docs/metrics/task-status.md` shows `Last updated: 2026-07-27`, ADR-0002
+  row `APPROVED` with CTO approval date and approval PR, ADR-0001 `PROPOSED`,
+  WP1's generic `ADRs` blocker narrowed to `ADR-0001`, every work package
+  `BLOCKED`, `MET-CTRL-01 CHANGES REQUIRED`, no task `READY`, immediate next
+  actions recording ADR-0002 achieved.
+- [ ] A bounded `Changed` CHANGELOG entry references this PR.
+- [ ] The implementation report records base, branch, draft PR, agent, model,
+  commits, changed files, the CTO quotation, proof the ADR body was unchanged,
+  tracker changes, no-runtime-effect assessment, CI evidence, residual blockers,
+  the issue #765/#766 baselines and hashes, and both proposed issue bodies.
+- [ ] ADR-0001 remains `PROPOSED`; the platform inventory remains `FINAL ENUM NOT
+  APPROVED`; `MET-CTRL-01` remains `CHANGES REQUIRED`.
+- [ ] `git diff --check` passes and no runtime file changed.
+- [ ] Required final-head CI is green across all seven jobs.
+- [ ] Issue #765 remains OPEN at `updatedAt: 2026-07-27T15:50:33Z` and issue #766
+  remains OPEN at `updatedAt: 2026-07-24T17:17:11Z` (no write by this task).
+- [ ] An independent reviewer returns `APPROVED` before merge.
+
+## 9. Issue synchronization guards
+
+This task does not write to issue #765 or #766. It only records exact proposed
+post-merge synchronization bodies in the implementation report.
+
+Both issue writes are deferred and require, in order:
+
+1. this repository PR independently approved and merged;
+2. an immediate pre-write re-fetch of the complete live body and `updatedAt`;
+3. an exact baseline comparison;
+4. a stop on any mismatch;
+5. fresh independent review of any regenerated diff;
+6. separate explicit CTO authorization.
+
+Proposed minimal issue changes:
+
+- Issue #765: update its synchronization guard baseline to the current reviewed
+  body and `updatedAt: 2026-07-27T15:50:33Z`, and change only
+  `- [ ] ADR-0002 approved` to `- [x] ADR-0002 approved`; preserve every other
+  line and checkbox; keep the issue open.
+- Issue #766: add an equivalent forward and rollback synchronization guard based
+  on the complete current body and `updatedAt: 2026-07-24T17:17:11Z`, and change
+  only `- [ ] ADR-0002 approved` to `- [x] ADR-0002 approved` apart from the
+  guard section; preserve every other line and checkbox; keep the issue open.
+
+## 10. Verification
+
+```bash
+git diff --check origin/develop...HEAD
+git diff --name-only origin/develop...HEAD
+
+git diff --name-only origin/develop...HEAD \
+  | grep -Ev '^(CHANGELOG\.md|docs/)' \
+  && exit 1 || true
+
+grep -n '^Status: APPROVED$' \
+  docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
+
+grep -n '^Status: PROPOSED$' \
+  docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+
+grep -n 'FINAL ENUM NOT APPROVED' \
+  docs/publisher-services/platform-inventory.md
+
+grep -n 'MET-CTRL-01.*CHANGES REQUIRED' \
+  docs/metrics/task-status.md
+
+grep -n 'ADR-0002.*APPROVED' \
+  docs/engineering/decisions/decision-register.md \
+  docs/metrics/task-status.md
+
+grep -n 'ADR-01.*BLOCKED' \
+  docs/publisher-services/task-status.md
+```
+
+Required CI jobs at the final head:
+
+```text
+build
+format_check
+lint
+test
+build_and_push_staging_docker_image
+check-changelog
+run_migrations
+```
+
+All seven jobs must conclude `success` at the exact final head. A
+documentation-only no-build path is acceptable but is not a substitute for
+independent review.
+
+## 11. Rollout
+
+Initial state after merge:
+
+- ADR-0002 becomes `APPROVED` in the repository, removing one dependency;
+- the Publisher Services and Metrics programmes remain blocked for
+  implementation;
+- issue #765 and #766 synchronization become separately authorized external
+  mirrors.
+
+Feature flag or configuration: none. Staging or preview: none. Pilot: none.
+
+Activation approval:
+
+- CTO approval is required to merge this approval PR;
+- separate CTO authorization is required for each post-merge issue
+  synchronization.
+
+## 12. Rollback
+
+Code rollback: revert this documentation PR; no runtime effect.
+
+Issue rollback (guarded; no unconditional full-body overwrite): re-fetch the
+complete live body and `updatedAt`, compare against the expected state, stop on
+any mismatch, generate a minimal reversal preserving unrelated edits, obtain
+fresh independent review and explicit CTO authorization, and apply only the
+reviewed minimal reversal. Never restore an old complete snapshot blindly.
+
+## 13. Prohibition on implementation work
+
+This is a documentation and control-record task only. The implementing agent must
+not write Rust, SQL, migrations, GraphQL or generated code, must not change
+workflows or repository protection, must not deploy, release or activate
+behaviour, must not create any cross-domain mapping, and must not start Publisher
+Services or Metrics implementation. If reconciling repository state would require
+any such change, stop and report `BLOCKED`.
+
+## 14. Independent-review requirement
+
+The implementing context is ineligible to approve this work. A fresh
+non-implementing reviewer with high reasoning must inspect the exact final head,
+all commits in order, the complete cumulative diff, ADR-0002 before and after,
+proof that only approval metadata changed in the ADR, all Publisher Services and
+Metrics tracker changes, all remaining blockers, exact-head CI, the complete
+issue #765 and #766 baselines, both proposed issue bodies, and the absence of
+runtime changes. The reviewer must return exactly one verdict: `APPROVED`,
+`CHANGES REQUIRED` or `BLOCKED`. Approval is permitted only when there is no
+unresolved P0 or P1 finding. The reviewer must not mark the PR ready, merge it or
+edit either issue.
+
+## 15. Expected implementation report
+
+The agent must use:
+
+`docs/engineering/ai-delivery/implementation-report-template.md`
+
+and record the concrete evidence required by Section 4 and Section 6 of this
+specification.
+
+## 16. Approval
+
+Approved for implementation by: Javi, CTO. Date: 2026-07-27.
+
+Notes:
+
+- Documentation and control-record changes only.
+- This approval records the CTO's approval of ADR-0002 as written and does not
+  amend the architectural decision.
+- This approval does not approve ADR-0001, the platform inventory, branch
+  readiness, any implementation task, migration, workflow, deployment, release or
+  production activation.
+- This approval does not authorize any write to issue #765 or #766; each is a
+  separately reviewed and separately authorized step after this PR merges.
+- The implementing agent may create the task branch, commit, push and open a
+  draft PR, but may not approve or merge it.

--- a/docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
+++ b/docs/engineering/decisions/ADR-0002-platform-domain-boundaries.md
@@ -1,6 +1,6 @@
 # ADR-0002 - Distribution and Metrics Platform Domain Boundaries
 
-Status: PROPOSED
+Status: APPROVED
 Date: 2026-07-24
 Decision owner: CTO
 Programmes affected: Publisher Services, Thoth Metrics
@@ -293,6 +293,7 @@ Rollback:
 ## 10. Approval
 
 Approval required from: CTO
-Approved by:
-Approval date:
-Notes:
+Approved by: Javi, CTO
+Approval date: 2026-07-27
+Notes: Approved as written. DistributionPlatform and MetricPlatform remain
+separate domain types, with no initial cross-domain mapping.

--- a/docs/engineering/decisions/decision-register.md
+++ b/docs/engineering/decisions/decision-register.md
@@ -2,12 +2,12 @@
 
 Status: ACTIVE
 Owner: CTO
-Last updated: 2026-07-24
+Last updated: 2026-07-27
 
 | ADR | Decision | Status | Programmes | Approval blocker |
 |---|---|---|---|---|
 | `ADR-0001` | Publisher package capability model | PROPOSED | Publisher Services, Thoth Metrics, OAI-PMH | CTO approval of ownership, matrix and upgrade/export semantics |
-| `ADR-0002` | Distribution and metrics platform domain boundaries | PROPOSED | Publisher Services, Thoth Metrics | CTO approval of strict type separation and no initial cross-domain mapping |
+| `ADR-0002` | Distribution and metrics platform domain boundaries | APPROVED | Publisher Services, Thoth Metrics | Satisfied - CTO approved strict type separation and no initial cross-domain mapping on 2026-07-27 through PR [#769](https://github.com/thoth-pub/thoth/pull/769) |
 
 ## Merge and implementation rules
 

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -35,9 +35,14 @@ Use verified actual branches until normalization or explicit exceptions complete
 
 App, Sphinx, dashboard, widget and cc-license remain outstanding. Dissemination has incomplete controls.
 
-### CG-06 - Shared ADRs remain proposed
+### CG-06 - Shared ADR-0001 remains proposed
 
-ADR-0001 and ADR-0002 require explicit CTO approval and independent review before dependent implementation.
+ADR-0002 was approved by the CTO on 2026-07-27 and recorded as `APPROVED` through
+approval PR [#769](https://github.com/thoth-pub/thoth/pull/769); its independent
+review and merge close this part of the gate. ADR-0001 remains the unresolved
+shared-ADR gate and requires explicit CTO approval and independent review before
+its dependent implementation. Approving ADR-0002 removes one dependency and does
+not make any implementation task ready.
 
 ### CG-07 - Publisher Services platform ADR open
 

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -103,6 +103,14 @@ The initial programme does not store raw clickstream events in Thoth, create a s
 BLOCKED FOR IMPLEMENTATION
 ```
 
+Achieved:
+
+- `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
+  PR [#769](https://github.com/thoth-pub/thoth/pull/769)) and is no longer a
+  blocking control. `MetricPlatform` remains separate from `DistributionPlatform`
+  with no initial cross-domain mapping. Approval removes one shared-ADR
+  dependency and does not make any work package ready.
+
 Blocking controls:
 
 1. The shared engineering-control foundation is closed: PR #764 merged, and its
@@ -111,13 +119,12 @@ Blocking controls:
    programme control task `MET-CTRL-01` nevertheless remains `CHANGES REQUIRED`
    and is not yet closed.
 2. `ADR-0001` is `PROPOSED`.
-3. `ADR-0002` is `PROPOSED`.
-4. `thoth-sphinx` is placeholder-only and has not been bootstrapped.
-5. Thoth Diesel generation procedure is unresolved.
-6. Branch topology differs in Sphinx and client repositories.
-7. Service-role codes require approval before WP5.
-8. Representative source fixtures and COUNTER mappings are missing for source-specific work.
-9. Guaranteed OPERAS inbound discovery is unavailable.
+3. `thoth-sphinx` is placeholder-only and has not been bootstrapped.
+4. Thoth Diesel generation procedure is unresolved.
+5. Branch topology differs in Sphinx and client repositories.
+6. Service-role codes require approval before WP5.
+7. Representative source fixtures and COUNTER mappings are missing for source-specific work.
+8. Guaranteed OPERAS inbound discovery is unavailable.
 
 Discovery, benchmarking, fixture collection and task specification may continue.
 

--- a/docs/metrics/decisions.md
+++ b/docs/metrics/decisions.md
@@ -47,11 +47,11 @@ The target is daily country-level `title_sessions` using GET 200/206 requests, D
 
 Outbound uses durable Thoth claims. Sphinx delivers idempotently. Direct mappings are excluded inbound. Local corrections after remote delivery create divergence issues. Inbound completeness is not guaranteed without cursor, replication or complete snapshots.
 
-## 2. Proposed shared decisions
+## 2. Shared decisions
 
-`ADR-0001` is required for entitlements, serving, imports, export and collection policy.
+`ADR-0001` remains `PROPOSED`. It is required for entitlements, serving, imports, export and collection policy.
 
-`ADR-0002` is required for metric platform implementation. `MetricPlatform` remains separate from `DistributionPlatform`.
+`ADR-0002` is `APPROVED` (CTO, 2026-07-27, approval PR [#769](https://github.com/thoth-pub/thoth/pull/769)) as written, and is required for metric platform implementation. `MetricPlatform` remains a separate domain type from `DistributionPlatform`, with no name-based conversion and no initial cross-domain mapping.
 
 ## 3. Decisions still required
 

--- a/docs/metrics/task-status.md
+++ b/docs/metrics/task-status.md
@@ -4,7 +4,7 @@ Status: ACTIVE TRACKER
 Programme owner: CTO
 Master issue: [#766](https://github.com/thoth-pub/thoth/issues/766)
 Approved design: [private Google Doc](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit), Drive revision `6`
-Last updated: 2026-07-24
+Last updated: 2026-07-27
 
 ## 1. Control rule
 
@@ -16,7 +16,7 @@ A work package is not one implementation task. Each must be decomposed into boun
 |---|---|---:|---|---|---|---|
 | MET-CTRL-01 Programme controls | `thoth` | LOW | CHANGES REQUIRED | PR #764 merged into `develop` as `5b406e4ef9b5c192cc38eb8a97a41bbd0fc3bc06` | Shared foundation closed (P0-01 closeout PR #767 independently `APPROVED` and merged as `bac598e32abbd0d7e69ff467c82945ee00df02ba`); MET-CTRL-01's own `CHANGES REQUIRED` remediation outstanding | [#766](https://github.com/thoth-pub/thoth/issues/766) |
 | ADR-0001 Package capability model | `thoth` | MEDIUM | PROPOSED | `develop` - proposal introduced by merged PR #764 | CTO decision | #766 |
-| ADR-0002 Platform boundaries | `thoth` | MEDIUM | PROPOSED | `develop` - proposal introduced by merged PR #764 | CTO decision | #766 |
+| ADR-0002 Platform boundaries | `thoth` | MEDIUM | APPROVED | `develop` - proposal introduced by merged PR #764 | CTO approved 2026-07-27; approval PR [#769](https://github.com/thoth-pub/thoth/pull/769) | #766 |
 | SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `develop`; target `develop` after BR-SPHINX-01 verification | MET-CTRL-01; BR-SPHINX-01; approved bootstrap spec | #766 |
 | THOTH-DB-CTRL-01 Diesel generation procedure | `thoth` | MEDIUM | BLOCKED | `develop` -> `develop` | verified procedure | #766 |
 | BR-DASH-01 Dashboard branch readiness | dashboard | HIGH | BLOCKED | observed `dev -> main`; reconcile stale `develop`, then normalize to `develop -> master` | Vercel rollback | #766 |
@@ -27,7 +27,7 @@ A work package is not one implementation task. Each must be decomposed into boun
 
 | WP | Scope | Repositories | Risk | Status | Blocking dependencies | Issue |
 |---|---|---|---:|---|---|---|
-| WP1 | Domain and database foundation | `thoth` | HIGH | BLOCKED | MET-CTRL-01; ADRs; Diesel control | #766 |
+| WP1 | Domain and database foundation | `thoth` | HIGH | BLOCKED | MET-CTRL-01; ADR-0001; Diesel control | #766 |
 | WP2 | Canonical ingestion | `thoth` | CRITICAL | BLOCKED | WP1 | #766 |
 | WP3 | Upload API and publisher UI | `thoth`, app | HIGH | BLOCKED | WP1/WP2; ADR-0001; BR-APP-01 | #766 |
 | WP4 | Rollups and GraphQL | `thoth` | HIGH | BLOCKED | WP1/WP2; benchmark dataset | #766 |
@@ -59,7 +59,10 @@ verified base.
    `APPROVED` and merged as `bac598e32abbd0d7e69ff467c82945ee00df02ba`, closing
    P0-01, and the repository closeout record is reconciled. `MET-CTRL-01`
    remains `CHANGES REQUIRED` pending its own remediation.
-2. Approve or amend ADR-0001 and ADR-0002.
-3. Scope SPHINX-BOOT-01.
-4. Resolve THOTH-DB-CTRL-01.
-5. Prepare the first bounded WP1 slice only after those gates.
+2. `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
+   PR [#769](https://github.com/thoth-pub/thoth/pull/769)); this removes one
+   shared-ADR dependency and does not make any work package ready.
+3. Approve or amend `ADR-0001`.
+4. Scope SPHINX-BOOT-01.
+5. Resolve THOTH-DB-CTRL-01.
+6. Prepare the first bounded WP1 slice only after those gates.

--- a/docs/publisher-services/README.md
+++ b/docs/publisher-services/README.md
@@ -71,7 +71,14 @@ Where sources conflict, stop and escalate. Chat history is not authoritative.
 BLOCKED FOR IMPLEMENTATION
 ```
 
-Reasons:
+Achieved:
+
+- `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
+  PR [#769](https://github.com/thoth-pub/thoth/pull/769)). This removes one
+  shared-ADR dependency and does not, by itself, make ADR-01, BE-02 or any other
+  task ready.
+
+Reasons still blocking:
 
 1. The P0-01 control foundation is `CLOSED`. It merged through
    [PR #764](https://github.com/thoth-pub/thoth/pull/764) at
@@ -83,15 +90,14 @@ Reasons:
    final inventory, satisfy branch readiness, or make any implementation task
    ready. The remaining reasons below keep the programme blocked.
 2. `ADR-0001` package capability model is `PROPOSED`.
-3. `ADR-0002` platform domain boundaries is `PROPOSED`.
-4. Publisher Services `ADR-01` has not finalized or approved the
+3. Publisher Services `ADR-01` has not finalized or approved the
    distribution-platform enum.
-5. Branch-readiness tasks are required before work in repositories whose
+4. Branch-readiness tasks are required before work in repositories whose
    current topology differs from policy.
 
-Discovery, review and documentation may continue. P0-01 closure does not
-authorize production implementation, which must not start until its applicable
-architecture, specification and branch-readiness gates pass.
+Discovery, review and documentation may continue. P0-01 closure and ADR-0002
+approval do not authorize production implementation, which must not start until
+its applicable architecture, specification and branch-readiness gates pass.
 
 ## 6. Files
 

--- a/docs/publisher-services/decisions.md
+++ b/docs/publisher-services/decisions.md
@@ -67,9 +67,12 @@ Keep separate:
 
 This programme initially implements desired state and durable publisher back-catalogue jobs only.
 
-## 2. Proposed shared decisions awaiting CTO approval
+## 2. Shared decisions
 
 ### ADR-0001 - Package capability model
+
+Status: `PROPOSED` - awaiting its separate CTO decision on ownership, the
+capability matrix and upgrade/export semantics.
 
 Proposes:
 
@@ -87,12 +90,18 @@ Implementation dependency:
 
 ### ADR-0002 - Platform domain boundaries
 
-Proposes:
+Status: `APPROVED` (CTO, 2026-07-27, approval PR
+[#769](https://github.com/thoth-pub/thoth/pull/769)). Approved as written.
+
+Approved architecture:
 
 - `DistributionPlatform` and `MetricPlatform` remain separate types;
 - no name-based conversion;
 - no initial cross-domain mapping table;
 - OAPEN/DOAB linkage exists only in the distribution domain unless separately approved.
+
+Approval removes one dependency; it does not make `ADR-01`, `BE-02` or the
+metrics platform registry ready.
 
 Implementation dependency:
 

--- a/docs/publisher-services/rollout-plan.md
+++ b/docs/publisher-services/rollout-plan.md
@@ -35,14 +35,16 @@ Achieved evidence:
   [#767](https://github.com/thoth-pub/thoth/pull/767) (reviewed content head
   `d72137893ddea512c0d05c81d310eb59d045cd2b`) was independently `APPROVED` and
   merged into `develop` as `bac598e32abbd0d7e69ff467c82945ee00df02ba` on
-  2026-07-27, making the repository the authoritative P0-01 closure record.
+  2026-07-27, making the repository the authoritative P0-01 closure record;
+- issue #765 synchronized on 2026-07-27 as an external mirror of the completed
+  repository closeout; issue #765 remains open;
+- `ADR-0002` platform domain boundaries approved by the CTO on 2026-07-27
+  (approval PR [#769](https://github.com/thoth-pub/thoth/pull/769)); this removes
+  one shared-ADR dependency and does not unlock implementation.
 
 Outstanding evidence:
 
-- separately authorized issue #765 synchronization as an external mirror of the
-  completed repository closeout (it does not approve architecture or unlock
-  implementation);
-- ADR-0001 and ADR-0002 approval;
+- ADR-0001 approval;
 - Publisher Services ADR-01 specification and final platform-inventory
   approval;
 - applicable repository/branch-readiness decisions;

--- a/docs/publisher-services/task-status.md
+++ b/docs/publisher-services/task-status.md
@@ -4,7 +4,7 @@ Status: ACTIVE TRACKER
 Programme owner: CTO
 Master issue: [#765](https://github.com/thoth-pub/thoth/issues/765)
 Approved design: [private Google Doc](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit), Drive revision `3`
-Last updated: 2026-07-24
+Last updated: 2026-07-27
 
 ## 1. Control rule
 
@@ -19,11 +19,11 @@ No task moves to `READY` without an approved specification, architecture depende
 | Task | Repository | Risk | Status | Verified base / PR target | Blocking dependencies | Issue | PR | Acceptance |
 |---|---|---:|---|---|---|---|---|---|
 | P0-01 Control documents and tracker | `thoth` | LOW | CLOSED | `develop` at `5b406e4ef9b5c192cc38eb8a97a41bbd0fc3bc06` / `develop` | None; issue #765 synchronization is a separately authorized external mirror of the completed repository closeout | [#765](https://github.com/thoth-pub/thoth/issues/765) | Foundation [#764](https://github.com/thoth-pub/thoth/pull/764); closeout [#767](https://github.com/thoth-pub/thoth/pull/767) merged as `bac598e3`; finalization [#768](https://github.com/thoth-pub/thoth/pull/768) | CLOSED - PR #767 independently `APPROVED` and merged as `bac598e32abbd0d7e69ff467c82945ee00df02ba` on 2026-07-27; reviewed content head `d72137893ddea512c0d05c81d310eb59d045cd2b`; repository-finalized |
-| ADR-01 Platform inventory/final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
+| ADR-01 Platform inventory/final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | missing approved bounded ADR-01 specification; final distribution-platform inventory decision | #765 | TBD | NOT STARTED |
 | LIC-01 Expand `cc-license` | `cc-license` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; BR-LIC-01 or CTO exception; approved spec | #765 | TBD | NOT STARTED |
 | LIC-02 Enforce supported licences | `thoth` | HIGH | BLOCKED | `develop` / `develop` | LIC-01 release; production licence audit plan | #765 | TBD | NOT STARTED |
 | BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0001 approval | #765 | TBD | NOT STARTED |
-| BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | `develop` / `develop` | ADR-01; ADR-0002 approval | #765 | TBD | NOT STARTED |
+| BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | `develop` / `develop` | ADR-01 | #765 | TBD | NOT STARTED |
 | BE-03 Protected service configuration | `thoth` | HIGH | BLOCKED | `develop` / `develop` | BE-01; BE-02 | #765 | TBD | NOT STARTED |
 | BE-04 Durable distribution jobs | `thoth` | HIGH | BLOCKED | `develop` / `develop` | BE-02; BE-03 | #765 | TBD | NOT STARTED |
 | MIG-01 Audit/production backfill | `thoth` + operations | CRITICAL | BLOCKED | dedicated task branch -> `develop`; separately approved production run | BE-01/02/03; licence audit; dry run | #765 | TBD | NOT STARTED |
@@ -51,10 +51,11 @@ Each branch starts from the repository's verified development branch and targets
 
 ## 4. Next actions
 
-1. apply the separately authorized issue #765 synchronization as an external
-   mirror of the completed repository closeout; it does not approve architecture
-   or unlock implementation;
-2. approve or amend ADR-0001 and ADR-0002;
+1. `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
+   PR [#769](https://github.com/thoth-pub/thoth/pull/769)); this removes one
+   shared-ADR dependency and does not approve architecture or unlock
+   implementation;
+2. approve or amend `ADR-0001` (immediate decision);
 3. prepare and approve the bounded ADR-01 specification before architecture
    implementation starts;
 4. finalize and approve the distribution-platform inventory through ADR-01;


### PR DESCRIPTION
## Summary

Records the CTO's approval of **ADR-0002 - Distribution and Metrics Platform Domain Boundaries** exactly as written, and reconciles the engineering-control, Publisher Services and Metrics control records with that approval. Documentation and control-record changes only — no runtime effect.

CTO decision:

> I approve ADR-0002 - Distribution and Metrics Platform Domain Boundaries as written.
> Do not amend the architectural decision.

Task specification: `docs/engineering/ai-delivery/tasks/ADR-0002-APPROVE.md`

## Scope

- ADR-0002 status → `APPROVED` (approval metadata only; architectural decision body unchanged)
- Reconcile the engineering decision register, engineering README and CG-06 control gap
- Reconcile Publisher Services README, decisions, task-status and rollout-plan
- Reconcile Metrics README, decisions and task-status
- Bounded `Changed` CHANGELOG entry
- Implementation report with issue #765/#766 baselines, hashes and proposed post-merge issue bodies (issues are **not** written by this task)

## Invariants preserved

```
ADR-0001: PROPOSED
ADR-0002: APPROVED only after this PR merges
Publisher Services ADR-01: unapproved
Platform inventory: FINAL ENUM NOT APPROVED
MET-CTRL-01: CHANGES REQUIRED
All Publisher Services implementation tasks: BLOCKED
All Metrics work packages: BLOCKED
No shared platform abstraction or mapping
No runtime effect
```

Approving ADR-0002 removes one dependency. It does not by itself make ADR-01, BE-02, Metrics WP1 or any other task ready.

## Review

Draft until an independent, non-implementing reviewer with high reasoning returns `APPROVED`. The implementing context may not approve or merge this PR, and may not edit issue #765 or #766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
