### PR TITLE
docs: approve ADR-0001 publisher package capability model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [764](https://github.com/thoth-pub/thoth/pull/764) - Add the AI-led engineering operating model, task and review templates, risk classification, release gates, and GitHub Flow controls
 
 ### Changed
+  - [772](https://github.com/thoth-pub/thoth/pull/772) - Approve the shared publisher-package capability model, excluding managed OASIS metrics collection while permitting configured, private and non-blocking OBELISK collection
   - [771](https://github.com/thoth-pub/thoth/pull/771) - Skip heavy Rust, migration, and Docker jobs for documentation-only changes while preserving protected check contexts through complete-range, fail-closed CI classification
   - [770](https://github.com/thoth-pub/thoth/pull/770) - Correct ADR-0002 approval evidence and engineering rollout controls following post-merge review, preserving programme gates and issue baselines without enabling implementation
   - [769](https://github.com/thoth-pub/thoth/pull/769) - Record CTO approval of ADR-0002, establishing separate distribution and metrics platform domains with no initial cross-domain mapping, and reconcile the Publisher Services and Metrics control records without enabling implementation

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -52,10 +52,16 @@ Agents must use observed repository state until an approved normalization task c
 
 - [Decision process](./decisions/README.md)
 - [Decision register](./decisions/decision-register.md)
-- [ADR-0001: publisher package capabilities](./decisions/ADR-0001-publisher-package-capability-model.md) - `PROPOSED`
+- [ADR-0001: publisher package capabilities](./decisions/ADR-0001-publisher-package-capability-model.md) - `APPROVED` (Javi, CTO, 2026-07-28, approval PR [#772](https://github.com/thoth-pub/thoth/pull/772); approval record pending merge)
 - [ADR-0002: platform domain boundaries](./decisions/ADR-0002-platform-domain-boundaries.md) - `APPROVED` (CTO, 2026-07-27, PR [#769](https://github.com/thoth-pub/thoth/pull/769))
 
-A committed proposed ADR is not approved. ADR-0002 is approved; dependent implementation remains blocked by its other prerequisites. ADR-0001 remains proposed, and dependent implementation stays blocked until the CTO decision is recorded and independently reviewed.
+ADR-0001 and ADR-0002 are approved. ADR-0001 is approved by the CTO
+through PR [#772](https://github.com/thoth-pub/thoth/pull/772), pending merge
+of that independently reviewed approval record, and becomes
+repository-authoritative only after that PR merges. ADR approval removes the
+shared decision blocker but does not make any implementation task ready.
+Publisher Services and Metrics implementation remain blocked by their genuine
+programme, task-specification and repository-readiness prerequisites.
 
 ## 7. Active programmes
 
@@ -102,10 +108,11 @@ Achieved:
 Outstanding:
 
 - None for the foundation closeout gate. Dependent Publisher Services and Metrics
-  implementation remains blocked by the ADR-0001, Publisher Services ADR-01 and
-  final-inventory, branch-readiness and task-specification gates recorded in the
-  programme controls. ADR-0002 was approved on 2026-07-27 through PR
-  [#769](https://github.com/thoth-pub/thoth/pull/769); it removes one shared-ADR
-  dependency and does not make either programme implementation-ready.
+  implementation remains blocked by Publisher Services ADR-01 and its final
+  distribution-platform inventory, task-specific approved specifications,
+  applicable branch-readiness controls, and the Metrics programme-control,
+  Diesel-generation and repository-readiness gates recorded in the programme
+  controls. ADR-0001 and ADR-0002 approval remove shared decision dependencies
+  without making either programme implementation-ready.
 
 The implementing conversation cannot approve its own work.

--- a/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
@@ -11,6 +11,10 @@ Programme integration branch: None
 Task branch: `feature/engineering/adr-0001-approval`
 Approval content commit: `55fc33fe4ea5251ab941002ed9480f3b78aceaa7`
 Previous reviewed head: `4af692490875c66a9a0c7fb32354f10f136889e6`
+Independent-review correction head:
+`1124262dd28e0b51f33259be1b70e1396e3bdb1c`
+Post-ready automated reviewed head:
+`1124262dd28e0b51f33259be1b70e1396e3bdb1c`
 Pull request: [#772](https://github.com/thoth-pub/thoth/pull/772) (draft)
 Expected branch deletion after merge: YES
 Final programme PR required: NO
@@ -34,6 +38,14 @@ observation-comment URL are likewise recorded externally after push. This
 preserves the required one-commit correction without amending history or
 creating an endless evidence-only commit chain.
 
+After the PR was marked ready, the automated review submitted against exact
+head `1124262dd28e0b51f33259be1b70e1396e3bdb1c` opened one P1 finding:
+the active engineering, Metrics and Publisher Services README entry points still
+described ADR-0001 as proposed or as an outstanding approval blocker. The PR
+returned to draft before this correction. The prior exact-head independent
+approval and CTO merge authorization are now historical and inapplicable to the
+new correction head.
+
 ## 2. Scope confirmation
 
 Approved specification:
@@ -43,6 +55,10 @@ Implemented objective: record the CTO approval of ADR-0001 and the final
 publisher package-capability matrix, reconcile only the approved engineering,
 Publisher Services and Metrics records, and prepare PR #772 as the first
 controlled CI-DOCS-01 documentation-only observation.
+
+The CTO-approved post-ready scope amendment additionally reconciles the three
+active README entry points with the normative decision and tracker records while
+preserving every genuine programme blocker.
 
 Out-of-scope changes made: NONE.
 
@@ -122,16 +138,20 @@ Corrected package-change semantics:
 - `4af692490875c66a9a0c7fb32354f10f136889e6` -
   `docs: record ADR-0001 approval evidence`
   - the implementation report at the previous reviewed head.
-- `docs: clarify package distribution and downgrade semantics`
+- `1124262dd28e0b51f33259be1b70e1396e3bdb1c` -
+  `docs: clarify package distribution and downgrade semantics`
   - one bounded correction across the six approved documentation files; its
-    exact SHA and the resulting final head are recorded externally because the
-    commit contains this report.
+    exact SHA is the post-ready automated reviewed head.
+- `docs: reconcile ADR-0001 programme entry points`
+  - one bounded post-ready correction across the five amended documentation
+    files; its exact SHA and the resulting final head are recorded externally
+    because the commit contains this report.
 
 No commit was amended, squashed or rewritten.
 
 ## 5. Files changed
 
-The complete pull request changes exactly the following eleven approved paths:
+The complete pull request changes exactly the following fourteen approved paths:
 
 - `CHANGELOG.md`
   - records the architectural approval and the final OASIS/OBELISK collection
@@ -152,17 +172,27 @@ The complete pull request changes exactly the following eleven approved paths:
 - `docs/engineering/repository-map/control-gaps.md`
   - resolves only the shared-ADR CG-06 gate while preserving all unrelated
     control gaps and implementation blockers.
+- `docs/engineering/README.md`
+  - records both cross-programme ADRs as approved while distinguishing the
+    pending PR #772 merge and preserving genuine implementation blockers.
 - `docs/publisher-services/decisions.md`
   - summarizes the approved architecture and exact final matrix.
 - `docs/publisher-services/task-status.md`
   - removes ADR-0001 as an unresolved dependency while retaining `BE-01` and all
     implementation work as blocked.
+- `docs/publisher-services/README.md`
+  - records the approved ADR-0001 control pending merge and preserves ADR-01,
+    inventory, task-specification and branch-readiness blockers.
 - `docs/metrics/decisions.md`
   - summarizes the exact final matrix, OASIS exclusion, private/non-blocking
     OBELISK collection and upgrade/downgrade/export rules.
 - `docs/metrics/task-status.md`
   - records ADR-0001 approval while retaining `MET-CTRL-01` as
     `CHANGES REQUIRED` and every work package as `BLOCKED`.
+- `docs/metrics/README.md`
+  - records the approved ADR-0001 control pending merge and preserves
+    `MET-CTRL-01`, Sphinx, Diesel, branch, service-role, fixture and OPERAS
+    blockers.
 
 No file outside the approved allowlist changed.
 
@@ -175,6 +205,16 @@ docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
 docs/engineering/decisions/package-capability-matrix.md
 docs/publisher-services/decisions.md
 docs/metrics/decisions.md
+```
+
+The post-ready active-entry-point correction changes exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+docs/engineering/README.md
+docs/metrics/README.md
+docs/publisher-services/README.md
 ```
 
 ## 6. Implementation decisions and deviations
@@ -196,12 +236,16 @@ Implementation decisions within the approved specification:
    distribution configuration and current operational source availability.
 6. The P2 correction evaluates every package change through the resulting
    capability set rather than applying generic downgrade denials.
+7. The post-ready correction treats the three README files as active entry
+   points, not historical evidence, so they must agree with the normative
+   decision and tracker records without erasing genuine implementation
+   blockers.
 
 Deviations from the approved specification: NONE.
 
-Additional stale active references requiring follow-up: NONE found within the
-approved scope. Historical task specifications, implementation reports and
-review records were not rewritten.
+The stale active references found by post-ready review are reconciled under the
+CTO-approved five-file scope amendment. Historical task specifications,
+implementation reports and review records remain intact.
 
 ## 7. Database and migration effects
 
@@ -267,7 +311,7 @@ git diff --name-only bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
 Result:
 
 ```text
-Exactly eleven paths: CHANGELOG.md and the ten approved docs/** paths listed in Section 5.
+Exactly fourteen paths: CHANGELOG.md and the thirteen approved docs/** paths listed in Section 5.
 No runtime or workflow path.
 ```
 
@@ -321,7 +365,7 @@ WP1-WP11 and MET-E2E-01: BLOCKED.
 Command:
 
 ```text
-python3 .github/scripts/classify_ci_changes.py --paths <the exact eleven changed paths>
+python3 .github/scripts/classify_ci_changes.py --paths <the exact fourteen changed paths>
 ```
 
 Result:
@@ -360,6 +404,40 @@ Semantic inspection confirms:
 - in-flight work rechecks the relevant capability at its final boundary;
 - collection does not infer entitlement from an assignment or remote location.
 
+### Post-ready active-entry-point correction
+
+Commands:
+
+```text
+git diff --check bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
+git diff --name-only 1124262dd28e0b51f33259be1b70e1396e3bdb1c...HEAD
+rg -n \
+  'ADR-0001.*PROPOSED|ADR-0001 remains proposed|ADR-0001.*blocking|blocked.*ADR-0001' \
+  docs \
+  --glob '*.md'
+```
+
+Result:
+
+```text
+The cumulative diff is whitespace-clean.
+The post-ready correction changes exactly the five CTO-authorized files.
+No active README describes ADR-0001 as proposed or lists ADR-0001 approval as
+an outstanding blocker.
+Remaining search matches are historical task/report/review evidence,
+baseline/change-history statements in the current specification, or the
+validation command and result text in the current task/report. No result is
+ambiguous.
+```
+
+The engineering, Metrics and Publisher Services README entry points consistently
+record ADR-0001 as approved by Javi, CTO, on 2026-07-28 through PR #772, pending
+merge of the approval record. They preserve Publisher Services ADR-01 and final
+inventory, task-specific specifications including BE-01, branch readiness,
+`MET-CTRL-01`, Sphinx bootstrap, Diesel generation, service-role, fixture,
+COUNTER and OPERAS completeness blockers. No implementation task is marked
+ready.
+
 ### Internal path and terminology inspection
 
 Result:
@@ -368,7 +446,8 @@ Result:
 Referenced repository paths exist.
 Canonical repository and programme names are used.
 No active scoped document claims that approval starts or completes implementation.
-No stale active ADR-0001 PROPOSED reference remains in the approved scope.
+No stale active README describes ADR-0001 as PROPOSED or an outstanding
+approval blocker.
 ```
 
 ### Rust, database and workflow tests
@@ -385,7 +464,8 @@ Verified:
 
 1. the specification is the only file in the first commit;
 2. PR #772 is draft and targets `develop`;
-3. every changed path is allowlisted and documentation-only;
+3. all fourteen cumulative changed paths are allowlisted and
+   documentation-only;
 4. all four matrix copies are identical;
 5. OASIS, OBELISK, SPHINX and PYRAMID match the CTO decision;
 6. every checklist item is complete;
@@ -396,6 +476,10 @@ Verified:
 10. issues #765 and #766 were not modified;
 11. no runtime, migration, workflow, deployment, release or production action
     occurred.
+12. the PR returned to draft before post-ready repository changes;
+13. the post-ready correction changes exactly the five amended files;
+14. active README entry points agree with the normative decision and tracker
+    records while programme implementation remains blocked.
 
 ## 11. CI
 
@@ -465,6 +549,22 @@ conclusions and its own URL. The comment is the authoritative location because
 the correction commit cannot contain its own SHA or CI runs. The historical
 comment above must not be edited.
 
+### 12.3 Post-ready active-entry-point evidence
+
+Status at post-ready correction-report creation: PENDING push and exact-head CI.
+
+The automated post-ready P1 reviewed head
+`1124262dd28e0b51f33259be1b70e1396e3bdb1c`. The correction commit and its new
+final head are recorded in the immutable top-level evidence comment and handoff
+after push because this report is part of that commit.
+
+At the new exact head, all three classifiers must succeed; build, test, lint,
+format, migrations and Docker must be skipped with no executed heavy steps; and
+`check-changelog` must succeed. Only after that evidence is terminal may the
+implementation reply to and resolve the post-ready P1 thread. The previous
+independent approval and CTO authorization remain historical and do not cover
+the new head.
+
 ## 13. Rollout and rollback
 
 Initial state after merge:
@@ -504,19 +604,23 @@ release or production rollback is required.
   completeness and other work-package dependencies remain unresolved.
 - Every Metrics work package remains `BLOCKED`.
 - The CI-DOCS-01 mixed-source and next-three-PR observations remain outstanding.
-- Corrective exact-head CI and fresh independent review remain pending at
-  correction-report creation.
-- Explicit CTO merge authorization remains pending.
+- Post-ready corrective exact-head CI and P1 thread resolution remain pending
+  at correction-report creation.
+- Fresh independent exact-head review and fresh explicit CTO authorization are
+  required for the new head.
 
 ## 15. Unresolved issues
 
-- Corrective exact-final-head CI evidence and the new top-level observation
+- Post-ready corrective exact-final-head CI evidence and the new top-level observation
   comment are pending at correction-report creation.
+- The post-ready P1 reply and resolution are pending exact-head CI.
 - Fresh independent review is pending.
 - Explicit CTO merge authorization is pending.
 
-The previous P1 and P2 documentation findings are addressed by the bounded
-correction. No runtime defect or scope deviation is known.
+The earlier distribution and downgrade findings are addressed. The
+active-entry-point P1 is addressed in the working correction but remains open
+until pushed exact-head validation and CI permit an immutable reply and
+resolution. No runtime defect or scope deviation is known.
 
 ## 16. Agent self-assessment
 
@@ -529,6 +633,8 @@ Suggested independent-review focus:
   bespoke overrides and entitlement/configuration separation;
 - upgrade, downgrade and historical OPERAS export behaviour;
 - residual Publisher Services and Metrics blockers;
+- consistency of the three active README entry points with the normative
+  decision and tracker records;
 - specification-first commit order and exact allowlist;
 - exact-head CI context and job-step evidence;
 - absence of runtime, migration, workflow, issue, deployment, release and

--- a/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
@@ -15,6 +15,8 @@ Independent-review correction head:
 `1124262dd28e0b51f33259be1b70e1396e3bdb1c`
 Post-ready automated reviewed head:
 `1124262dd28e0b51f33259be1b70e1396e3bdb1c`
+Second post-ready automated reviewed head:
+`56c4f873c27fa83e6358c1f207cd718cb3dde679`
 Pull request: [#772](https://github.com/thoth-pub/thoth/pull/772) (draft)
 Expected branch deletion after merge: YES
 Final programme PR required: NO
@@ -46,6 +48,13 @@ returned to draft before this correction. The prior exact-head independent
 approval and CTO merge authorization are now historical and inapplicable to the
 new correction head.
 
+A second post-ready automated review against exact head
+`56c4f873c27fa83e6358c1f207cd718cb3dde679` opened one P1 because the active
+Publisher Services rollout plan still listed `ADR-0001 approval` as outstanding
+Stage 0 evidence. The PR returned to draft before this correction. The
+independent approval and CTO authorization for that reviewed head are now
+historical and inapplicable to the new correction head.
+
 ## 2. Scope confirmation
 
 Approved specification:
@@ -59,6 +68,13 @@ controlled CI-DOCS-01 documentation-only observation.
 The CTO-approved post-ready scope amendment additionally reconciles the three
 active README entry points with the normative decision and tracker records while
 preserving every genuine programme blocker.
+
+The second CTO-approved post-ready amendment additionally reconciles Stage 0 of
+the active Publisher Services rollout control. It moves ADR-0001 approval from
+outstanding to achieved evidence while preserving it as a requirement and
+preserving every genuine rollout blocker. The rollout plan is an active control
+document because it governs the current staged implementation, evidence and
+activation gates rather than recording historical review evidence.
 
 Out-of-scope changes made: NONE.
 
@@ -142,16 +158,20 @@ Corrected package-change semantics:
   `docs: clarify package distribution and downgrade semantics`
   - one bounded correction across the six approved documentation files; its
     exact SHA is the post-ready automated reviewed head.
-- `docs: reconcile ADR-0001 programme entry points`
+- `56c4f873c27fa83e6358c1f207cd718cb3dde679` -
+  `docs: reconcile ADR-0001 programme entry points`
   - one bounded post-ready correction across the five amended documentation
-    files; its exact SHA and the resulting final head are recorded externally
-    because the commit contains this report.
+    files; its exact SHA is the second post-ready automated reviewed head.
+- `docs: reconcile ADR-0001 rollout gate`
+  - one bounded second post-ready correction across the three amended
+    documentation files; its exact SHA and the resulting final head are recorded
+    externally because the commit contains this report.
 
 No commit was amended, squashed or rewritten.
 
 ## 5. Files changed
 
-The complete pull request changes exactly the following fourteen approved paths:
+The complete pull request changes exactly the following fifteen approved paths:
 
 - `CHANGELOG.md`
   - records the architectural approval and the final OASIS/OBELISK collection
@@ -183,6 +203,9 @@ The complete pull request changes exactly the following fourteen approved paths:
 - `docs/publisher-services/README.md`
   - records the approved ADR-0001 control pending merge and preserves ADR-01,
     inventory, task-specification and branch-readiness blockers.
+- `docs/publisher-services/rollout-plan.md`
+  - records ADR-0001 approval as achieved Stage 0 evidence, removes only the
+    stale approval blocker and preserves every genuine rollout gate.
 - `docs/metrics/decisions.md`
   - summarizes the exact final matrix, OASIS exclusion, private/non-blocking
     OBELISK collection and upgrade/downgrade/export rules.
@@ -217,6 +240,14 @@ docs/metrics/README.md
 docs/publisher-services/README.md
 ```
 
+The second post-ready rollout-gate correction changes exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+docs/publisher-services/rollout-plan.md
+```
+
 ## 6. Implementation decisions and deviations
 
 Implementation decisions within the approved specification:
@@ -240,12 +271,15 @@ Implementation decisions within the approved specification:
    points, not historical evidence, so they must agree with the normative
    decision and tracker records without erasing genuine implementation
    blockers.
+8. The second post-ready correction treats the Publisher Services rollout plan
+   as an active control: approval moves to achieved evidence, but Stage 0 and
+   implementation remain blocked by their genuine remaining gates.
 
 Deviations from the approved specification: NONE.
 
-The stale active references found by post-ready review are reconciled under the
-CTO-approved five-file scope amendment. Historical task specifications,
-implementation reports and review records remain intact.
+The stale active references found by both post-ready reviews are reconciled
+under their CTO-approved five-file and three-file scope amendments. Historical
+task specifications, implementation reports and review records remain intact.
 
 ## 7. Database and migration effects
 
@@ -311,7 +345,7 @@ git diff --name-only bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
 Result:
 
 ```text
-Exactly fourteen paths: CHANGELOG.md and the thirteen approved docs/** paths listed in Section 5.
+Exactly fifteen paths: CHANGELOG.md and the fourteen approved docs/** paths listed in Section 5.
 No runtime or workflow path.
 ```
 
@@ -365,7 +399,7 @@ WP1-WP11 and MET-E2E-01: BLOCKED.
 Command:
 
 ```text
-python3 .github/scripts/classify_ci_changes.py --paths <the exact fourteen changed paths>
+python3 .github/scripts/classify_ci_changes.py --paths <the exact fifteen changed paths>
 ```
 
 Result:
@@ -438,6 +472,61 @@ inventory, task-specific specifications including BE-01, branch readiness,
 COUNTER and OPERAS completeness blockers. No implementation task is marked
 ready.
 
+### Second post-ready rollout-gate correction
+
+Commands:
+
+```text
+git diff --check bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
+git diff --name-only 56c4f873c27fa83e6358c1f207cd718cb3dde679...HEAD
+rg -n 'ADR-0001' docs \
+  --glob '*.md' \
+  --glob '!docs/engineering/ai-delivery/tasks/**' \
+  --glob '!docs/engineering/ai-delivery/implementation-reports/**'
+rg -n \
+  'ADR-0001.*(PROPOSED|proposed|outstanding|awaiting|pending approval|block)|((outstanding|awaiting|pending approval|block).*)ADR-0001' \
+  docs \
+  --glob '*.md'
+```
+
+Result:
+
+```text
+The cumulative diff is whitespace-clean.
+The second post-ready correction changes exactly the three CTO-authorized files.
+The cumulative pull request changes exactly fifteen approved documentation paths.
+No runtime, workflow, migration, API, issue or normative decision file changed.
+No active document describes ADR-0001 as proposed, outstanding, awaiting
+approval or a current blocker, and no active document claims runtime
+implementation. No active result is ambiguous.
+```
+
+Every result from the exhaustive active-document search is classified:
+
+- normative approved decision records:
+  `docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md`,
+  `docs/engineering/decisions/package-capability-matrix.md`,
+  `docs/engineering/decisions/decision-register.md`,
+  `docs/publisher-services/decisions.md` and `docs/metrics/decisions.md`;
+- current control and status records that describe approval as satisfied while
+  preserving other blockers:
+  `docs/engineering/README.md`,
+  `docs/engineering/repository-map/control-gaps.md`,
+  `docs/publisher-services/README.md`,
+  `docs/publisher-services/task-status.md`,
+  `docs/publisher-services/rollout-plan.md`,
+  `docs/metrics/README.md` and `docs/metrics/task-status.md`;
+- reference-only historical review brief:
+  `docs/engineering/ai-delivery/reviews/CTRL-FOUNDATION-01-review-brief.md`.
+
+Stage 0 still requires ADR-0001 approval and now records its decision, Javi as
+CTO approver, 2026-07-28 decision date and PR #772 under achieved evidence.
+Only `ADR-0001 approval` was removed from outstanding evidence. Publisher
+Services ADR-01, final inventory approval, applicable repository and branch
+readiness, approved bounded task specifications, independent review assignments
+and absence of unresolved control contradictions remain outstanding. Stage 0,
+Stage 1, `BE-01`, `OAI-01` and the programme remain unready and unactivated.
+
 ### Internal path and terminology inspection
 
 Result:
@@ -464,7 +553,7 @@ Verified:
 
 1. the specification is the only file in the first commit;
 2. PR #772 is draft and targets `develop`;
-3. all fourteen cumulative changed paths are allowlisted and
+3. all fifteen cumulative changed paths are allowlisted and
    documentation-only;
 4. all four matrix copies are identical;
 5. OASIS, OBELISK, SPHINX and PYRAMID match the CTO decision;
@@ -480,6 +569,11 @@ Verified:
 13. the post-ready correction changes exactly the five amended files;
 14. active README entry points agree with the normative decision and tracker
     records while programme implementation remains blocked.
+15. the PR returned to draft before the second post-ready correction;
+16. the second correction changes exactly the three amended files;
+17. every active-document ADR-0001 reference is classified without ambiguity;
+18. Stage 0 records ADR-0001 approval as achieved while all genuine Publisher
+    Services rollout and implementation blockers remain.
 
 ## 11. CI
 
@@ -565,6 +659,25 @@ implementation reply to and resolve the post-ready P1 thread. The previous
 independent approval and CTO authorization remain historical and do not cover
 the new head.
 
+### 12.4 Second post-ready rollout-gate evidence
+
+Status at second post-ready correction-report creation: PENDING push and
+exact-head CI.
+
+The second automated post-ready P1 reviewed exact head
+`56c4f873c27fa83e6358c1f207cd718cb3dde679`. The correction commit, new final
+head, exact-head workflow runs, immutable observation-comment URL and review
+thread reply are recorded externally after push because this report is part of
+the correction commit.
+
+At the new exact head, all three classifiers must succeed; build, test, lint,
+format, migrations and Docker must be skipped with empty step arrays; and
+`check-changelog` must succeed. Only after that terminal evidence may the
+implementation reply to and resolve thread `PRRT_kwDODkn0bc6UtkFD`. The prior
+independent approval and CTO authorization remain historical and do not cover
+the new head. Fresh exact-head independent review, fresh CTO authorization and a
+new automated post-ready review are required before merge.
+
 ## 13. Rollout and rollback
 
 Initial state after merge:
@@ -604,23 +717,23 @@ release or production rollback is required.
   completeness and other work-package dependencies remain unresolved.
 - Every Metrics work package remains `BLOCKED`.
 - The CI-DOCS-01 mixed-source and next-three-PR observations remain outstanding.
-- Post-ready corrective exact-head CI and P1 thread resolution remain pending
-  at correction-report creation.
+- Second post-ready corrective exact-head CI and P1 thread resolution remain
+  pending at correction-report creation.
 - Fresh independent exact-head review and fresh explicit CTO authorization are
   required for the new head.
 
 ## 15. Unresolved issues
 
-- Post-ready corrective exact-final-head CI evidence and the new top-level observation
-  comment are pending at correction-report creation.
-- The post-ready P1 reply and resolution are pending exact-head CI.
+- Second post-ready corrective exact-final-head CI evidence and the new
+  top-level observation comment are pending at correction-report creation.
+- The second post-ready P1 reply and resolution are pending exact-head CI.
 - Fresh independent review is pending.
 - Explicit CTO merge authorization is pending.
 
-The earlier distribution and downgrade findings are addressed. The
-active-entry-point P1 is addressed in the working correction but remains open
-until pushed exact-head validation and CI permit an immutable reply and
-resolution. No runtime defect or scope deviation is known.
+The earlier distribution, downgrade and active-entry-point findings are
+addressed. The rollout-gate P1 is addressed in the working correction but
+remains open until pushed exact-head validation and CI permit an immutable reply
+and resolution. No runtime defect or scope deviation is known.
 
 ## 16. Agent self-assessment
 
@@ -635,6 +748,8 @@ Suggested independent-review focus:
 - residual Publisher Services and Metrics blockers;
 - consistency of the three active README entry points with the normative
   decision and tracker records;
+- exhaustive active-document ADR-0001 classification and the corrected
+  Publisher Services rollout gate;
 - specification-first commit order and exact allowlist;
 - exact-head CI context and job-step evidence;
 - absence of runtime, migration, workflow, issue, deployment, release and

--- a/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
@@ -17,6 +17,12 @@ Post-ready automated reviewed head:
 `1124262dd28e0b51f33259be1b70e1396e3bdb1c`
 Second post-ready automated reviewed head:
 `56c4f873c27fa83e6358c1f207cd718cb3dde679`
+Evidence-basis head:
+`896da62baf7302ecac468b1da87d16a6cd05bb39`
+Implementation-evidence automated reviewed head:
+`896da62baf7302ecac468b1da87d16a6cd05bb39`
+Reporting finalization: Task-specific self-referential evidence exception
+approved by Javi, CTO, on 2026-07-29
 Pull request: [#772](https://github.com/thoth-pub/thoth/pull/772) (draft)
 Expected branch deletion after merge: YES
 Final programme PR required: NO
@@ -26,19 +32,22 @@ Independent reviewer/model: ChatGPT / GPT-5.6 Thinking in a fresh,
 non-implementing context
 Risk: MEDIUM
 
-The exact final branch head necessarily includes the commit containing this
-report, so the report cannot contain its own commit SHA. The immutable final
-head, exact-head workflow run IDs and final conclusions are recorded in the
-top-level PR evidence comment and final implementation handoff. No later
-repository commit is covered by that evidence.
+The exact evidence-basis head is the immediate predecessor commit whose complete
+repository contents, CI and review evidence were known before this report's
+finalization commit. Because the reporting-amendment commit changes this report,
+it cannot embed its own SHA, and its exact-head CI exists only after push.
+Under the task-specific exception approved by Javi, CTO, on 2026-07-29, the
+report therefore records the exact base, exact evidence-basis head and all
+completed evidence through that head. The immutable top-level finalization
+comment and implementation handoff record the reporting-amendment commit, final
+head, post-push exact-head CI and evidence-comment URL. No additional
+evidence-only commit is permitted.
 
-Independent review of the previous head returned `CHANGES REQUIRED` with no P0,
-one P1 finding on distribution/metrics-entitlement coupling and one P2 finding
-on downgrade semantics. The bounded correction commit contains this report, so
-its exact SHA, the new final head, revised exact-head CI and new immutable
-observation-comment URL are likewise recorded externally after push. This
-preserves the required one-commit correction without amending history or
-creating an endless evidence-only commit chain.
+Independent review of the first reviewed head returned `CHANGES REQUIRED` with
+no P0, one P1 finding on distribution/metrics-entitlement coupling and one P2
+finding on downgrade semantics. Those findings and every later correction,
+review and CI record through the evidence-basis head are retained below as
+completed historical evidence.
 
 After the PR was marked ready, the automated review submitted against exact
 head `1124262dd28e0b51f33259be1b70e1396e3bdb1c` opened one P1 finding:
@@ -54,6 +63,20 @@ Publisher Services rollout plan still listed `ADR-0001 approval` as outstanding
 Stage 0 evidence. The PR returned to draft before this correction. The
 independent approval and CTO authorization for that reviewed head are now
 historical and inapplicable to the new correction head.
+
+Automated post-ready review against exact evidence-basis head
+`896da62baf7302ecac468b1da87d16a6cd05bb39` opened one P1:
+
+```text
+Finding: Record the final head in the implementation report
+Review: https://github.com/thoth-pub/thoth/pull/772#pullrequestreview-4807148805
+Thread: PRRT_kwDODkn0bc6UuG-L
+```
+
+This reporting correction resolves the specification/report mismatch by
+approving and documenting the evidence-basis and immutable-finalization
+mechanism. The independent approval and CTO authorization for the evidence-basis
+head are historical and inapplicable to the reporting-amendment head.
 
 ## 2. Scope confirmation
 
@@ -75,6 +98,12 @@ outstanding to achieved evidence while preserving it as a requirement and
 preserving every genuine rollout blocker. The rollout plan is an active control
 document because it governs the current staged implementation, evidence and
 activation gates rather than recording historical review evidence.
+
+The CTO-approved implementation-evidence reporting amendment additionally
+reconciles the report with its specification. It records the exact
+evidence-basis head and all completed evidence through that head, replaces stale
+current-state `PENDING` statements, documents the approved self-referential
+exception and defines the immutable post-push finalization evidence.
 
 Out-of-scope changes made: NONE.
 
@@ -162,12 +191,19 @@ Corrected package-change semantics:
   `docs: reconcile ADR-0001 programme entry points`
   - one bounded post-ready correction across the five amended documentation
     files; its exact SHA is the second post-ready automated reviewed head.
-- `docs: reconcile ADR-0001 rollout gate`
+- `896da62baf7302ecac468b1da87d16a6cd05bb39` -
+  `docs: reconcile ADR-0001 rollout gate`
   - one bounded second post-ready correction across the three amended
-    documentation files; its exact SHA and the resulting final head are recorded
-    externally because the commit contains this report.
+    documentation files; its exact SHA is the implementation-evidence automated
+    reviewed head and the evidence-basis head for the reporting amendment.
+- `docs: clarify implementation evidence finalization`
+  - one bounded reporting correction across the two CTO-authorized files. Under
+    the approved self-referential exception, its exact SHA and the resulting
+    final head are recorded in the immutable finalization comment and
+    implementation handoff after push.
 
-No commit was amended, squashed or rewritten.
+No commit was amended, squashed or rewritten. No later evidence-only commit is
+permitted.
 
 ## 5. Files changed
 
@@ -248,6 +284,13 @@ docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementa
 docs/publisher-services/rollout-plan.md
 ```
 
+The implementation-evidence reporting correction changes exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+```
+
 ## 6. Implementation decisions and deviations
 
 Implementation decisions within the approved specification:
@@ -274,12 +317,26 @@ Implementation decisions within the approved specification:
 8. The second post-ready correction treats the Publisher Services rollout plan
    as an active control: approval moves to achieved evidence, but Stage 0 and
    implementation remain blocked by their genuine remaining gates.
+9. The implementation-evidence correction uses the exact predecessor
+   `896da62baf7302ecac468b1da87d16a6cd05bb39` as the evidence-basis head and
+   records the reporting-amendment commit's self-referential final fields
+   through the required immutable comment and handoff.
 
-Deviations from the approved specification: NONE.
+Approved task-specific reporting deviation:
+
+Because a commit cannot embed its own SHA or the CI generated only after that
+commit is pushed, the report records the exact evidence-basis head and all
+completed evidence through that head. The final reporting-amendment commit, its
+exact-head CI and immutable evidence-comment URL are recorded externally in the
+required top-level PR comment and implementation handoff.
+
+Approved by Javi, CTO, on 2026-07-29.
 
 The stale active references found by both post-ready reviews are reconciled
 under their CTO-approved five-file and three-file scope amendments. Historical
 task specifications, implementation reports and review records remain intact.
+The reporting exception is approved and task-specific; it does not amend
+`AGENTS.md` or the general implementation-report template.
 
 ## 7. Database and migration effects
 
@@ -539,6 +596,45 @@ No stale active README describes ADR-0001 as PROPOSED or an outstanding
 approval blocker.
 ```
 
+### Implementation-evidence reporting correction
+
+Commands:
+
+```text
+git diff --check
+git diff --check bafd4cbf752f9d6153036fc7f47115220fed3fbd
+git diff --name-only
+git diff --name-only bafd4cbf752f9d6153036fc7f47115220fed3fbd
+python3 .github/scripts/classify_ci_changes.py --paths <the exact fifteen paths>
+rg -n 'PENDING|pending' \
+  docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+```
+
+Pre-finalization result:
+
+```text
+Working correction and cumulative diff: whitespace-clean.
+Working correction: exactly the two CTO-authorized files.
+Cumulative pull request: exactly the existing fifteen approved paths.
+Classifier:
+{"docs_only": "true", "run_build": "false", "run_docker": "false", "run_migrations": "false"}
+```
+
+The `PENDING|pending` search returned only:
+
+- historical explanation of the stale `PENDING` wording removed by this
+  correction;
+- active approval records whose merge is genuinely still future;
+- the validation expression itself;
+- validation statements confirming that no completed evidence remains pending;
+- `BE-01`'s genuine future bounded-specification gate.
+
+No completed CI or completed review evidence is currently labelled pending.
+The evidence-basis head, approved self-referential deviation, approver,
+completed evidence and immutable finalization mechanism are explicit. The
+report does not claim to embed the reporting-amendment commit's own SHA, and no
+additional evidence-only commit is planned.
+
 ### Rust, database and workflow tests
 
 Not run and not applicable. This task changes no Rust, SQL, migration, GraphQL,
@@ -574,47 +670,47 @@ Verified:
 17. every active-document ADR-0001 reference is classified without ambiguity;
 18. Stage 0 records ADR-0001 approval as achieved while all genuine Publisher
     Services rollout and implementation blockers remain.
+19. the PR returned to draft before the implementation-evidence correction;
+20. the working reporting correction changes exactly the two amended files;
+21. the exact evidence-basis head and its completed CI/review evidence are
+    recorded without stale current-state `PENDING` claims;
+22. the approved deviation and immutable finalization mechanism are explicit,
+    with no later evidence-only commit permitted.
 
 ## 11. CI
 
-CI status at report creation: PENDING
+Evidence-basis CI status: COMPLETE
 
-Required final exact-head conclusions:
+Exact evidence-basis head:
+`896da62baf7302ecac468b1da87d16a6cd05bb39`
 
-| Workflow/job | Required conclusion |
-|---|---|
-| all three classifier jobs | `success` |
-| `build` | `skipped` |
-| `test` | `skipped` |
-| `lint` | `skipped` |
-| `format_check` | `skipped` |
-| `run_migrations` | `skipped` |
-| `build_and_push_staging_docker_image` | `skipped` |
-| `check-changelog` | `success` |
+| Workflow | Run | Classifier | Protected or mandatory jobs |
+|---|---:|---|---|
+| `build-test-and-check` | `30443967190` | `success` | `build`, `test`, `lint`, `format_check`: `skipped` |
+| `run-migrations` | `30443967171` | `success` | `run_migrations`: `skipped` |
+| `publish-to-dockerhub` | `30443967257` | `success` | `build_and_push_staging_docker_image`: `skipped` |
+| `check-changelog` | `30443969310` | Not applicable | `check-changelog`: `success` |
 
-The exact final head, workflow run IDs, classifier conclusions, protected and
-mandatory job conclusions, step-level heavy-work inspection and evidence-comment
-URL are recorded externally after CI completes. A failure, missing/pending
-context or executed heavy step is a stop condition.
+Immutable evidence:
+[issue comment 5116555883](https://github.com/thoth-pub/thoth/pull/772#issuecomment-5116555883)
+
+Every skipped heavy job had an empty step array. No Rust build, test, lint or
+format step executed; no migration build, apply or revert step executed; and no
+Docker checkout, registry-login, image-build or image-push step executed. All
+protected and mandatory contexts were terminal and merge-safe at the
+evidence-basis head.
+
+The reporting-amendment commit creates a new exact head after this report is
+finalized. Under the approved self-referential exception, that commit SHA, the
+final head, exact-head workflow runs and conclusions, step-array evidence and
+immutable evidence-comment URL are recorded in the required top-level
+finalization comment and implementation handoff.
 
 ## 12. CI-DOCS-01 observation
 
-Observation at report creation: PENDING exact-final-head CI.
-
-PR #772 is the first controlled documentation-only observation after CI-DOCS-01
-merged through PR #771. The final evidence comment must prove:
-
-- no Rust build, test or lint step executed;
-- no migration build, apply or revert step executed;
-- no Docker login, build or push step executed;
-- all six protected contexts and the additional mandatory Docker context reached
-  terminal merge-safe conclusions;
-- `check-changelog` remained active;
-- no required context remained pending.
-
-Successful evidence satisfies only the controlled documentation-only
-observation. The mixed-source and next-three-PR observations remain outstanding,
-and CI-DOCS-01 must not be marked operationally complete.
+The controlled documentation-only observation is complete through the exact
+evidence-basis head. It does not mark CI-DOCS-01 operationally complete: the
+mixed-source and next-three-PR observations remain outstanding.
 
 ### 12.1 Historical reviewed-head evidence
 
@@ -627,56 +723,85 @@ The immutable observation for previous reviewed head
 - check-changelog run `30390801277`;
 - [historical observation comment](https://github.com/thoth-pub/thoth/pull/772#issuecomment-5108602642).
 
-That evidence is historical and does not cover the correction commit.
+That completed evidence is historical and does not cover later correction
+commits.
 
-### 12.2 Corrective exact-head evidence
+### 12.2 Independent-review correction evidence
 
-Status at correction-report creation: PENDING push and exact-head CI.
+The immutable observation for exact head
+`1124262dd28e0b51f33259be1b70e1396e3bdb1c` records:
 
-The correction remains documentation-only. At its new exact head, all three
-classifiers must succeed; build, test, lint, format, migrations and Docker must
-be skipped with no executed heavy steps; and `check-changelog` must succeed.
+- build-test-and-check run `30392747002`;
+- run-migrations run `30392747178`;
+- publish-to-dockerhub run `30392746874`;
+- check-changelog run `30392747661`;
+- [historical correction observation](https://github.com/thoth-pub/thoth/pull/772#issuecomment-5108844930).
 
-After those terminal conclusions, a new immutable top-level PR comment records
-the correction commit, new final head, revised workflow run IDs, job/step
-conclusions and its own URL. The comment is the authoritative location because
-the correction commit cannot contain its own SHA or CI runs. The historical
-comment above must not be edited.
+All classifiers succeeded, every heavy job was skipped with an empty step array,
+and `check-changelog` succeeded. That completed evidence is historical and does
+not cover later correction commits.
 
-### 12.3 Post-ready active-entry-point evidence
+### 12.3 Active-entry-point correction evidence
 
-Status at post-ready correction-report creation: PENDING push and exact-head CI.
+The immutable observation for exact head
+`56c4f873c27fa83e6358c1f207cd718cb3dde679` records:
 
-The automated post-ready P1 reviewed head
-`1124262dd28e0b51f33259be1b70e1396e3bdb1c`. The correction commit and its new
-final head are recorded in the immutable top-level evidence comment and handoff
-after push because this report is part of that commit.
+- build-test-and-check run `30395532247`;
+- run-migrations run `30395530997`;
+- publish-to-dockerhub run `30395530567`;
+- check-changelog run `30395532530`;
+- [historical active-entry-point observation](https://github.com/thoth-pub/thoth/pull/772#issuecomment-5109211041).
 
-At the new exact head, all three classifiers must succeed; build, test, lint,
-format, migrations and Docker must be skipped with no executed heavy steps; and
-`check-changelog` must succeed. Only after that evidence is terminal may the
-implementation reply to and resolve the post-ready P1 thread. The previous
-independent approval and CTO authorization remain historical and do not cover
-the new head.
+All classifiers succeeded, every heavy job was skipped with an empty step array,
+and `check-changelog` succeeded. That completed evidence is historical and does
+not cover later correction commits.
 
-### 12.4 Second post-ready rollout-gate evidence
+### 12.4 Evidence-basis rollout-gate correction evidence
 
-Status at second post-ready correction-report creation: PENDING push and
-exact-head CI.
+The immutable observation for exact evidence-basis head
+`896da62baf7302ecac468b1da87d16a6cd05bb39` records:
 
-The second automated post-ready P1 reviewed exact head
-`56c4f873c27fa83e6358c1f207cd718cb3dde679`. The correction commit, new final
-head, exact-head workflow runs, immutable observation-comment URL and review
-thread reply are recorded externally after push because this report is part of
-the correction commit.
+- build-test-and-check run `30443967190`: classifier `success`; `build`, `test`,
+  `lint` and `format_check` `skipped`;
+- run-migrations run `30443967171`: classifier `success`; `run_migrations`
+  `skipped`;
+- publish-to-dockerhub run `30443967257`: classifier `success`;
+  `build_and_push_staging_docker_image` `skipped`;
+- check-changelog run `30443969310`: `check-changelog` `success`;
+- [immutable evidence-basis observation](https://github.com/thoth-pub/thoth/pull/772#issuecomment-5116555883).
 
-At the new exact head, all three classifiers must succeed; build, test, lint,
-format, migrations and Docker must be skipped with empty step arrays; and
-`check-changelog` must succeed. Only after that terminal evidence may the
-implementation reply to and resolve thread `PRRT_kwDODkn0bc6UtkFD`. The prior
-independent approval and CTO authorization remain historical and do not cover
-the new head. Fresh exact-head independent review, fresh CTO authorization and a
-new automated post-ready review are required before merge.
+Every skipped heavy job had an empty step array. No Rust, migration,
+Docker-login, image-build or image-push step executed. The rollout-gate P1 reply
+was posted and thread `PRRT_kwDODkn0bc6UtkFD` was resolved. This evidence is
+complete for the evidence-basis head.
+
+### 12.5 Finalization evidence mechanism
+
+After the reporting-amendment commit is pushed and its exact-head CI is
+terminal, a new immutable top-level PR comment records:
+
+- exact base SHA;
+- evidence-basis head;
+- reporting-amendment commit SHA;
+- final exact PR head;
+- complete seven-commit sequence;
+- exact two-file correction diff;
+- cumulative fifteen-file scope;
+- exact workflow run IDs;
+- classifier conclusions;
+- protected and Docker job conclusions;
+- empty step arrays and confirmation that no Rust, migration, Docker-login,
+  image-build or image-push step executed;
+- reporting P1 thread `PRRT_kwDODkn0bc6UuG-L`, its top-level reply target and
+  the required reply-then-resolution sequence;
+- unresolved-thread result, draft state and unmerged state;
+- no runtime, migration, API, workflow, issue, deployment, release, production,
+  secret or override effect.
+
+The immutable comment is posted before the P1 reply because that reply must link
+to the comment. The implementation handoff records the resulting reply URL,
+resolved thread and final unresolved-thread count without editing the immutable
+comment. No later evidence-only commit is permitted.
 
 ## 13. Rollout and rollback
 
@@ -697,14 +822,19 @@ Migration sequence: none.
 
 Deployment/release: none.
 
-Merge gate: fresh independent `APPROVED` review followed by explicit CTO
-authorization. The implementing agent must not approve or merge.
+Merge gate: fresh independent `APPROVED` review, fresh explicit CTO
+authorization and a new automated post-ready review against the same exact head
+with no P0/P1 finding. The implementing agent must not approve or merge.
 
 Rollback: normal revert of PR #772, preserving unrelated later changes. No
 database, data, source-account, API, authorization, distribution, deployment,
 release or production rollback is required.
 
 ## 14. Known limitations and remaining blockers
+
+Implementation defects within approved scope: NONE KNOWN
+
+Genuine programme and control limitations:
 
 - Publisher Services `ADR-01` and the final distribution-platform inventory
   remain unresolved.
@@ -717,23 +847,32 @@ release or production rollback is required.
   completeness and other work-package dependencies remain unresolved.
 - Every Metrics work package remains `BLOCKED`.
 - The CI-DOCS-01 mixed-source and next-three-PR observations remain outstanding.
-- Second post-ready corrective exact-head CI and P1 thread resolution remain
-  pending at correction-report creation.
-- Fresh independent exact-head review and fresh explicit CTO authorization are
-  required for the new head.
+
+Remaining delivery gates:
+
+- push the reporting-amendment commit;
+- complete exact-head CI;
+- post immutable finalization evidence;
+- reply to and resolve the reporting P1;
+- complete fresh independent exact-head review;
+- obtain fresh CTO authorization;
+- complete a new post-ready automated review.
+
+These are future delivery gates for the reporting-amendment head, not missing
+implementation evidence for the completed evidence-basis head.
 
 ## 15. Unresolved issues
 
-- Second post-ready corrective exact-final-head CI evidence and the new
-  top-level observation comment are pending at correction-report creation.
-- The second post-ready P1 reply and resolution are pending exact-head CI.
-- Fresh independent review is pending.
-- Explicit CTO merge authorization is pending.
+Implementation defects within approved scope: NONE KNOWN
 
-The earlier distribution, downgrade and active-entry-point findings are
-addressed. The rollout-gate P1 is addressed in the working correction but
-remains open until pushed exact-head validation and CI permit an immutable reply
-and resolution. No runtime defect or scope deviation is known.
+The distribution, downgrade, active-entry-point and rollout-gate findings are
+resolved historical findings with completed evidence. The current reporting P1
+is addressed by this working two-file correction and remains a delivery gate
+until the correction is pushed, exact-head CI is terminal, immutable
+finalization evidence is posted, and the reply and thread resolution are
+complete. Fresh independent review, CTO authorization and post-ready automated
+review are then required. No runtime defect or unapproved scope deviation is
+known.
 
 ## 16. Agent self-assessment
 
@@ -750,6 +889,8 @@ Suggested independent-review focus:
   decision and tracker records;
 - exhaustive active-document ADR-0001 classification and the corrected
   Publisher Services rollout gate;
+- exact evidence-basis reporting, completed evidence through that head, the
+  approved self-referential deviation and immutable finalization mechanism;
 - specification-first commit order and exact allowlist;
 - exact-head CI context and job-step evidence;
 - absence of runtime, migration, workflow, issue, deployment, release and

--- a/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
@@ -1,0 +1,430 @@
+# ADR-0001-APPROVAL Implementation Report
+
+## 1. Repository state
+
+Repository: `thoth-pub/thoth`
+Workflow: STANDARD
+Base branch: `develop`
+Base commit: `bafd4cbf752f9d6153036fc7f47115220fed3fbd`
+PR target: `develop`
+Programme integration branch: None
+Task branch: `feature/engineering/adr-0001-approval`
+Approval content commit: `55fc33fe4ea5251ab941002ed9480f3b78aceaa7`
+Pull request: [#772](https://github.com/thoth-pub/thoth/pull/772) (draft)
+Expected branch deletion after merge: YES
+Final programme PR required: NO
+Implementing agent/model: Codex / GPT-5
+Reasoning level: High
+Independent reviewer/model: ChatGPT / GPT-5.6 Thinking in a fresh,
+non-implementing context
+Risk: MEDIUM
+
+The exact final branch head necessarily includes the commit containing this
+report, so the report cannot contain its own commit SHA. The immutable final
+head, exact-head workflow run IDs and final conclusions are recorded in the
+top-level PR evidence comment and final implementation handoff. No later
+repository commit is covered by that evidence.
+
+## 2. Scope confirmation
+
+Approved specification:
+[`docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md`](../tasks/ADR-0001-APPROVAL.md)
+
+Implemented objective: record the CTO approval of ADR-0001 and the final
+publisher package-capability matrix, reconcile only the approved engineering,
+Publisher Services and Metrics records, and prepare PR #772 as the first
+controlled CI-DOCS-01 documentation-only observation.
+
+Out-of-scope changes made: NONE.
+
+No GitHub issue, branch-protection rule, ruleset, workflow, runtime, migration,
+API, source account, deployment, release or production state was changed.
+
+## 3. Approved decisions
+
+Approved by: Javi, CTO
+
+Approval date: 2026-07-28
+
+Approval PR: [#772](https://github.com/thoth-pub/thoth/pull/772)
+
+The final normative matrix is:
+
+| Package | OAI_PMH | METRICS_COLLECT | METRICS_IMPORT | METRICS_DASHBOARD | METRICS_WIDGET | METRICS_OPERAS_EXPORT |
+|---|---:|---:|---:|---:|---:|---:|
+| OASIS | No | No | No | No | No | No |
+| OBELISK | Yes | Yes | No | No | No | No |
+| SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
+| PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
+
+The recorded decision preserves:
+
+- code-owned exhaustive package/capability mapping in Thoth;
+- closed package and capability enums with stable GraphQL codes;
+- no independent database capability rows;
+- no bespoke per-publisher capability overrides;
+- separation between product entitlement and operational configuration;
+- no coupling between package changes and distribution-platform assignments.
+
+The final operational decisions are:
+
+- Thoth has no managed OASIS collection because it does not distribute OASIS
+  files;
+- OBELISK collection is configured, private and non-blocking for unrelated
+  operations;
+- missing source configuration or source outages do not become zero and do not
+  block distribution, metadata, package changes or unrelated publisher
+  services;
+- SPHINX and PYRAMID have all six capabilities;
+- retained canonical history becomes available after upgrade only through the
+  relevant serving capability;
+- historical OPERAS export requires a separately scoped, reviewed and activated
+  backfill;
+- downgrades retain canonical history and stop newly prohibited behaviour;
+- configured private collection may continue after downgrade to OBELISK;
+- managed collection stops after downgrade to OASIS.
+
+## 4. Commits
+
+- `b81c5eecabf2c1ca9761a5b5651f8ea97cecf18b` -
+  `docs: specify ADR-0001 approval`
+  - the approved task specification was the only file in the first commit.
+- `55fc33fe4ea5251ab941002ed9480f3b78aceaa7` -
+  `docs: approve publisher package capability model`
+  - the ADR, matrix, changelog and bounded control/programme records were
+    reconciled after draft PR #772 supplied the actual approval PR number.
+- `docs: record ADR-0001 approval evidence`
+  - this report; its exact SHA is recorded externally because a commit cannot
+    contain its own SHA.
+
+No commit was amended, squashed or rewritten.
+
+## 5. Files changed
+
+The complete pull request changes exactly the following eleven approved paths:
+
+- `CHANGELOG.md`
+  - records the architectural approval and the final OASIS/OBELISK collection
+    distinction without claiming implementation.
+- `docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md`
+  - records the approved specification, task identity, scope, invariants,
+    acceptance criteria, validation, CI observation, review and merge gates.
+- `docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md`
+  - records implementation and validation evidence.
+- `docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md`
+  - records `APPROVED`, the final matrix, operational decisions and approval
+    metadata while preserving the approved architecture.
+- `docs/engineering/decisions/package-capability-matrix.md`
+  - records the approved matrix, OASIS/OBELISK rationale, upgrade/downgrade
+    semantics and completed CTO checklist.
+- `docs/engineering/decisions/decision-register.md`
+  - records ADR-0001 approval and PR #772.
+- `docs/engineering/repository-map/control-gaps.md`
+  - resolves only the shared-ADR CG-06 gate while preserving all unrelated
+    control gaps and implementation blockers.
+- `docs/publisher-services/decisions.md`
+  - summarizes the approved architecture and exact final matrix.
+- `docs/publisher-services/task-status.md`
+  - removes ADR-0001 as an unresolved dependency while retaining `BE-01` and all
+    implementation work as blocked.
+- `docs/metrics/decisions.md`
+  - summarizes the exact final matrix, OASIS exclusion, private/non-blocking
+    OBELISK collection and upgrade/downgrade/export rules.
+- `docs/metrics/task-status.md`
+  - records ADR-0001 approval while retaining `MET-CTRL-01` as
+    `CHANGES REQUIRED` and every work package as `BLOCKED`.
+
+No file outside the approved allowlist changed.
+
+## 6. Implementation decisions and deviations
+
+Implementation decisions within the approved specification:
+
+1. The ADR, matrix appendix and both programme decision summaries use a
+   byte-identical Markdown matrix so their values can be compared
+   deterministically.
+2. Resolved ADR-0001 dependencies were removed from tracker rows, while each row
+   retained or gained its remaining explicit bounded-specification and
+   readiness dependencies.
+3. CG-06 is recorded as resolved for shared ADR approval, with dependent
+   implementation still gated on PR merge, fresh independent review, approved
+   bounded specifications and remaining programme controls.
+4. Exact-head CI evidence is kept in one immutable top-level PR comment, avoiding
+   evidence-only commits that would create a new unevidenced head.
+
+Deviations from the approved specification: NONE.
+
+Additional stale active references requiring follow-up: NONE found within the
+approved scope. Historical task specifications, implementation reports and
+review records were not rewritten.
+
+## 7. Database and migration effects
+
+Migration added: NO
+
+Schema effect: NONE
+
+Existing-data effect: NONE
+
+Locking/downtime: NONE
+
+Backfill: NONE
+
+Empty/populated database testing: Not applicable to this documentation-only
+task.
+
+Rollback/forward repair: normal documentation PR revert; no database action.
+
+## 8. API, authorization and security effects
+
+GraphQL/API changes: NONE
+
+Generated schema/client updates: NONE
+
+Backwards compatibility effect: NONE
+
+Authorization paths changed: NONE
+
+Roles/scopes changed: NONE
+
+Negative authorization tests: Not applicable; no authorization code or contract
+changed.
+
+Secret or personal-data handling: no production secrets, credentials, personal
+data or sensitive object URLs were accessed or recorded.
+
+## 9. Local tests and checks
+
+### Documentation diff
+
+Command:
+
+```text
+git diff --check bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
+```
+
+Result:
+
+```text
+Exit 0; no output.
+```
+
+The command is rerun after the report commit before push.
+
+### Changed-file scope
+
+Command:
+
+```text
+git diff --name-only bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
+```
+
+Result:
+
+```text
+Exactly eleven paths: CHANGELOG.md and the ten approved docs/** paths listed in Section 5.
+No runtime or workflow path.
+```
+
+### Deterministic matrix comparison
+
+Command:
+
+```text
+for each of the ADR, appendix, Publisher Services summary and Metrics summary:
+  extract the table from "| Package | OAI_PMH" through "| PYRAMID"
+  hash it with shasum -a 256
+```
+
+Result:
+
+```text
+All four hashes:
+e2225da6575b484e79555fc23045c8ac2685d68ab088e831418cea9252a77cf7
+```
+
+The rows are OASIS all `No`; OBELISK only `OAI_PMH` and
+`METRICS_COLLECT`; SPHINX and PYRAMID all `Yes`.
+
+### Status, checklist and readiness inspection
+
+Commands:
+
+```text
+rg -n '^Status: APPROVED$|^Approved by: Javi, CTO$|^Approval date: 2026-07-28$|Approval PR:.*#772' \
+  docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md \
+  docs/engineering/decisions/package-capability-matrix.md
+
+rg -n 'MET-CTRL-01.*CHANGES REQUIRED' docs/metrics/task-status.md
+rg -n '^\s*- \[ \]' docs/engineering/decisions/package-capability-matrix.md
+rg -n '\| READY \|' docs/publisher-services/task-status.md docs/metrics/task-status.md
+```
+
+Result:
+
+```text
+ADR and appendix status/approver/date/PR: present and consistent.
+MET-CTRL-01: CHANGES REQUIRED.
+Unchecked CTO checklist items: none.
+READY tracker rows: none.
+BE-01: BLOCKED by its own approved bounded specification.
+WP1-WP11 and MET-E2E-01: BLOCKED.
+```
+
+### Documentation-only classifier
+
+Command:
+
+```text
+python3 .github/scripts/classify_ci_changes.py --paths <the exact eleven changed paths>
+```
+
+Result:
+
+```json
+{"docs_only": "true", "run_build": "false", "run_docker": "false", "run_migrations": "false"}
+```
+
+### Internal path and terminology inspection
+
+Result:
+
+```text
+Referenced repository paths exist.
+Canonical repository and programme names are used.
+No active scoped document claims that approval starts or completes implementation.
+No stale active ADR-0001 PROPOSED reference remains in the approved scope.
+```
+
+### Rust, database and workflow tests
+
+Not run and not applicable. This task changes no Rust, SQL, migration, GraphQL,
+JavaScript, generated or workflow file. GitHub Actions must confirm the merged
+CI-DOCS-01 documentation-only gating at the exact final head.
+
+## 10. Manual verification
+
+Environment: local task branch based on the exact approved `develop` commit.
+
+Verified:
+
+1. the specification is the only file in the first commit;
+2. PR #772 is draft and targets `develop`;
+3. every changed path is allowlisted and documentation-only;
+4. all four matrix copies are identical;
+5. OASIS, OBELISK, SPHINX and PYRAMID match the CTO decision;
+6. every checklist item is complete;
+7. approver, date and actual PR number are consistent;
+8. ADR-01 and the final distribution-platform inventory remain unresolved;
+9. `BE-01`, `MET-CTRL-01` and all Metrics work packages retain their required
+   non-ready status;
+10. issues #765 and #766 were not modified;
+11. no runtime, migration, workflow, deployment, release or production action
+    occurred.
+
+## 11. CI
+
+CI status at report creation: PENDING
+
+Required final exact-head conclusions:
+
+| Workflow/job | Required conclusion |
+|---|---|
+| all three classifier jobs | `success` |
+| `build` | `skipped` |
+| `test` | `skipped` |
+| `lint` | `skipped` |
+| `format_check` | `skipped` |
+| `run_migrations` | `skipped` |
+| `build_and_push_staging_docker_image` | `skipped` |
+| `check-changelog` | `success` |
+
+The exact final head, workflow run IDs, classifier conclusions, protected and
+mandatory job conclusions, step-level heavy-work inspection and evidence-comment
+URL are recorded externally after CI completes. A failure, missing/pending
+context or executed heavy step is a stop condition.
+
+## 12. CI-DOCS-01 observation
+
+Observation at report creation: PENDING exact-final-head CI.
+
+PR #772 is the first controlled documentation-only observation after CI-DOCS-01
+merged through PR #771. The final evidence comment must prove:
+
+- no Rust build, test or lint step executed;
+- no migration build, apply or revert step executed;
+- no Docker login, build or push step executed;
+- all six protected contexts and the additional mandatory Docker context reached
+  terminal merge-safe conclusions;
+- `check-changelog` remained active;
+- no required context remained pending.
+
+Successful evidence satisfies only the controlled documentation-only
+observation. The mixed-source and next-three-PR observations remain outstanding,
+and CI-DOCS-01 must not be marked operationally complete.
+
+## 13. Rollout and rollback
+
+Initial state after merge:
+
+- ADR-0001 becomes an approved merged architectural dependency;
+- no package, capability, metrics or OAI-PMH runtime behaviour is implemented or
+  activated by this documentation;
+- Publisher Services and Metrics work remains blocked by task-specific and
+  programme-readiness dependencies;
+- CI-DOCS-01 has one controlled documentation-only observation only.
+
+Activation required: none.
+
+Feature flag/configuration: none.
+
+Migration sequence: none.
+
+Deployment/release: none.
+
+Merge gate: fresh independent `APPROVED` review followed by explicit CTO
+authorization. The implementing agent must not approve or merge.
+
+Rollback: normal revert of PR #772, preserving unrelated later changes. No
+database, data, source-account, API, authorization, distribution, deployment,
+release or production rollback is required.
+
+## 14. Known limitations and remaining blockers
+
+- Publisher Services `ADR-01` and the final distribution-platform inventory
+  remain unresolved.
+- `BE-01` remains `BLOCKED` pending its own approved bounded specification.
+- `MET-CTRL-01` remains `CHANGES REQUIRED`.
+- THOTH-DB-CTRL-01 Diesel generation procedure remains unresolved.
+- SPHINX bootstrap and branch readiness remain blocked.
+- Dashboard, widget and app branch-readiness gates remain blocked.
+- Metrics service-role codes, source fixtures, COUNTER decisions, OPERAS
+  completeness and other work-package dependencies remain unresolved.
+- Every Metrics work package remains `BLOCKED`.
+- The CI-DOCS-01 mixed-source and next-three-PR observations remain outstanding.
+- Exact-head CI and fresh independent review remain pending at report creation.
+- Explicit CTO merge authorization remains pending.
+
+## 15. Unresolved issues
+
+- Exact-final-head CI evidence and the top-level observation comment are pending.
+- Fresh independent review is pending.
+- Explicit CTO merge authorization is pending.
+
+No implementation defect or scope deviation is known at report creation.
+
+## 16. Agent self-assessment
+
+The implementing agent does not issue an approval decision.
+
+Suggested independent-review focus:
+
+- exact matrix identity and OASIS/OBELISK semantics;
+- preservation of code ownership, stable capability codes, no mapping rows, no
+  bespoke overrides and entitlement/configuration separation;
+- upgrade, downgrade and historical OPERAS export behaviour;
+- residual Publisher Services and Metrics blockers;
+- specification-first commit order and exact allowlist;
+- exact-head CI context and job-step evidence;
+- absence of runtime, migration, workflow, issue, deployment, release and
+  production effects.

--- a/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+++ b/docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
@@ -10,6 +10,7 @@ PR target: `develop`
 Programme integration branch: None
 Task branch: `feature/engineering/adr-0001-approval`
 Approval content commit: `55fc33fe4ea5251ab941002ed9480f3b78aceaa7`
+Previous reviewed head: `4af692490875c66a9a0c7fb32354f10f136889e6`
 Pull request: [#772](https://github.com/thoth-pub/thoth/pull/772) (draft)
 Expected branch deletion after merge: YES
 Final programme PR required: NO
@@ -24,6 +25,14 @@ report, so the report cannot contain its own commit SHA. The immutable final
 head, exact-head workflow run IDs and final conclusions are recorded in the
 top-level PR evidence comment and final implementation handoff. No later
 repository commit is covered by that evidence.
+
+Independent review of the previous head returned `CHANGES REQUIRED` with no P0,
+one P1 finding on distribution/metrics-entitlement coupling and one P2 finding
+on downgrade semantics. The bounded correction commit contains this report, so
+its exact SHA, the new final head, revised exact-head CI and new immutable
+observation-comment URL are likewise recorded externally after push. This
+preserves the required one-commit correction without amending history or
+creating an endless evidence-only commit chain.
 
 ## 2. Scope confirmation
 
@@ -68,8 +77,17 @@ The recorded decision preserves:
 
 The final operational decisions are:
 
-- Thoth has no managed OASIS collection because it does not distribute OASIS
-  files;
+- OASIS has no `METRICS_COLLECT` capability as an independent entitlement
+  decision; under current operations Thoth has no managed OASIS usage-data
+  source because it does not operationally distribute OASIS files;
+- that operational context does not disable or remove OASIS distribution
+  assignments, prevent superuser platform configuration, define dissemination
+  eligibility, create a distribution capability or change distribution-job
+  behaviour;
+- any permanent prohibition on OASIS distribution requires ADR-01 or another
+  separately approved cross-programme ADR;
+- metrics collection does not infer entitlement from a distribution assignment
+  or remote location;
 - OBELISK collection is configured, private and non-blocking for unrelated
   operations;
 - missing source configuration or source outages do not become zero and do not
@@ -80,9 +98,17 @@ The final operational decisions are:
   relevant serving capability;
 - historical OPERAS export requires a separately scoped, reviewed and activated
   backfill;
-- downgrades retain canonical history and stop newly prohibited behaviour;
-- configured private collection may continue after downgrade to OBELISK;
-- managed collection stops after downgrade to OASIS.
+- every package change uses the resulting package's capabilities;
+- every downgrade retains canonical history, leaves distribution assignments
+  unchanged and rechecks the relevant capability at the final boundary.
+
+Corrected package-change semantics:
+
+| Package change | Capability effect |
+|---|---|
+| `PYRAMID -> SPHINX` | No initial capability is removed; collection, import, dashboard, widget, OAI-PMH and eligible OPERAS export remain permitted subject to normal configuration, authorization and rollout requirements |
+| `SPHINX` or `PYRAMID -> OBELISK` | OAI-PMH and configured private collection remain permitted; publisher import, dashboard, widget and OPERAS export are denied |
+| Any package `-> OASIS` | All six initial capabilities are denied and Thoth-managed collection stops |
 
 ## 4. Commits
 
@@ -93,9 +119,13 @@ The final operational decisions are:
   `docs: approve publisher package capability model`
   - the ADR, matrix, changelog and bounded control/programme records were
     reconciled after draft PR #772 supplied the actual approval PR number.
-- `docs: record ADR-0001 approval evidence`
-  - this report; its exact SHA is recorded externally because a commit cannot
-    contain its own SHA.
+- `4af692490875c66a9a0c7fb32354f10f136889e6` -
+  `docs: record ADR-0001 approval evidence`
+  - the implementation report at the previous reviewed head.
+- `docs: clarify package distribution and downgrade semantics`
+  - one bounded correction across the six approved documentation files; its
+    exact SHA and the resulting final head are recorded externally because the
+    commit contains this report.
 
 No commit was amended, squashed or rewritten.
 
@@ -136,6 +166,17 @@ The complete pull request changes exactly the following eleven approved paths:
 
 No file outside the approved allowlist changed.
 
+The independent-review correction changes exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+docs/engineering/decisions/package-capability-matrix.md
+docs/publisher-services/decisions.md
+docs/metrics/decisions.md
+```
+
 ## 6. Implementation decisions and deviations
 
 Implementation decisions within the approved specification:
@@ -151,6 +192,10 @@ Implementation decisions within the approved specification:
    bounded specifications and remaining programme controls.
 4. Exact-head CI evidence is kept in one immutable top-level PR comment, avoiding
    evidence-only commits that would create a new unevidenced head.
+5. The P1 correction treats OASIS metrics entitlement as independent from
+   distribution configuration and current operational source availability.
+6. The P2 correction evaluates every package change through the resulting
+   capability set rather than applying generic downgrade denials.
 
 Deviations from the approved specification: NONE.
 
@@ -285,6 +330,36 @@ Result:
 {"docs_only": "true", "run_build": "false", "run_docker": "false", "run_migrations": "false"}
 ```
 
+### Independent-review correction
+
+Commands:
+
+```text
+git diff --check bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
+git diff --name-only 4af692490875c66a9a0c7fb32354f10f136889e6...HEAD
+```
+
+Result:
+
+```text
+The cumulative diff is whitespace-clean.
+The correction changes exactly the six approved documentation files.
+The four normative matrix copies remain byte-identical and unchanged.
+No runtime, workflow, migration, tracker, register, control-gap, changelog or issue file changes in the correction.
+```
+
+Semantic inspection confirms:
+
+- OASIS retains no initial capability without creating a distribution rule;
+- OBELISK retains only OAI-PMH and configured private collection;
+- SPHINX and PYRAMID retain all six capabilities;
+- `PYRAMID -> SPHINX` removes no initial capability;
+- downgrade to OBELISK and transition to OASIS are explicitly
+  capability-scoped;
+- every downgrade retains canonical history and distribution assignments;
+- in-flight work rechecks the relevant capability at its final boundary;
+- collection does not infer entitlement from an assignment or remote location.
+
 ### Internal path and terminology inspection
 
 Result:
@@ -363,6 +438,33 @@ Successful evidence satisfies only the controlled documentation-only
 observation. The mixed-source and next-three-PR observations remain outstanding,
 and CI-DOCS-01 must not be marked operationally complete.
 
+### 12.1 Historical reviewed-head evidence
+
+The immutable observation for previous reviewed head
+`4af692490875c66a9a0c7fb32354f10f136889e6` remains unchanged:
+
+- build-test-and-check run `30390801269`;
+- run-migrations run `30390801250`;
+- publish-to-dockerhub run `30390801048`;
+- check-changelog run `30390801277`;
+- [historical observation comment](https://github.com/thoth-pub/thoth/pull/772#issuecomment-5108602642).
+
+That evidence is historical and does not cover the correction commit.
+
+### 12.2 Corrective exact-head evidence
+
+Status at correction-report creation: PENDING push and exact-head CI.
+
+The correction remains documentation-only. At its new exact head, all three
+classifiers must succeed; build, test, lint, format, migrations and Docker must
+be skipped with no executed heavy steps; and `check-changelog` must succeed.
+
+After those terminal conclusions, a new immutable top-level PR comment records
+the correction commit, new final head, revised workflow run IDs, job/step
+conclusions and its own URL. The comment is the authoritative location because
+the correction commit cannot contain its own SHA or CI runs. The historical
+comment above must not be edited.
+
 ## 13. Rollout and rollback
 
 Initial state after merge:
@@ -402,16 +504,19 @@ release or production rollback is required.
   completeness and other work-package dependencies remain unresolved.
 - Every Metrics work package remains `BLOCKED`.
 - The CI-DOCS-01 mixed-source and next-three-PR observations remain outstanding.
-- Exact-head CI and fresh independent review remain pending at report creation.
+- Corrective exact-head CI and fresh independent review remain pending at
+  correction-report creation.
 - Explicit CTO merge authorization remains pending.
 
 ## 15. Unresolved issues
 
-- Exact-final-head CI evidence and the top-level observation comment are pending.
+- Corrective exact-final-head CI evidence and the new top-level observation
+  comment are pending at correction-report creation.
 - Fresh independent review is pending.
 - Explicit CTO merge authorization is pending.
 
-No implementation defect or scope deviation is known at report creation.
+The previous P1 and P2 documentation findings are addressed by the bounded
+correction. No runtime defect or scope deviation is known.
 
 ## 16. Agent self-assessment
 

--- a/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+++ b/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
@@ -271,6 +271,74 @@ authorization and a new automated post-ready review are required. Existing
 commits, reviews, authorizations and CI comments remain immutable historical
 evidence.
 
+### 3.4 Post-ready implementation-evidence reporting correction
+
+Automated post-ready review of PR
+[#772](https://github.com/thoth-pub/thoth/pull/772) at exact head
+`896da62baf7302ecac468b1da87d16a6cd05bb39` returned one unresolved P1:
+
+```text
+P1 - Record the final head in the implementation report
+Review: https://github.com/thoth-pub/thoth/pull/772#pullrequestreview-4807148805
+Thread: PRRT_kwDODkn0bc6UuG-L
+```
+
+The implementation report correctly identified the self-referential
+commit-SHA and post-push CI problem, but the approved specification still
+required the report itself to contain the final head, exact-head CI status and
+evidence-comment link. It also left completed evidence described as `PENDING`
+and claimed there was no deviation from the approved specification. Those
+requirements could not simultaneously be satisfied.
+
+Javi, CTO, approved a task-specific reporting amendment on 2026-07-29. The
+correction may modify exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+```
+
+The implementation report must use
+`896da62baf7302ecac468b1da87d16a6cd05bb39` as its exact evidence-basis head:
+the immediate predecessor whose complete repository contents, CI and review
+evidence are known when the report-finalization commit is created.
+
+When a final corrective commit modifies the implementation report itself:
+
+1. the report cannot embed that commit's own SHA because the SHA depends on the
+   report's contents;
+2. the report cannot embed that commit's exact-head CI results because those
+   runs exist only after the commit is pushed;
+3. the report must record the exact base, exact evidence-basis head, all
+   completed evidence through that head, this approved exception and the exact
+   immutable-finalization fields;
+4. the final PR head, exact-head CI conclusions and immutable evidence-comment
+   URL must be recorded after push in a new immutable top-level PR evidence
+   comment and the implementation handoff;
+5. completed evidence must not remain described as currently `PENDING`;
+6. the exception must be listed as an approved implementation deviation;
+7. no additional evidence-only commit may be created merely to insert the
+   reporting-finalization commit's own SHA or subsequent CI into the report.
+
+The immutable finalization comment is required acceptance evidence. It must
+record the exact base, evidence-basis head, reporting-amendment commit and final
+head, complete seven-commit sequence, exact two-file correction diff,
+cumulative fifteen-file scope, exact workflow runs and job conclusions,
+classifier and empty-step-array evidence, the P1 reply-and-resolution gate,
+draft/unmerged state, unresolved-thread result and the complete no-effect
+assessment. Because the P1 reply must link to that immutable comment, the
+comment records the thread, reply target and resolution sequence; the
+resulting reply URL and resolved state are then recorded in the implementation
+handoff without editing the immutable comment.
+
+Creating the reporting-amendment commit invalidates the independent approval and
+CTO authorization for `896da62baf7302ecac468b1da87d16a6cd05bb39`.
+Fresh exact-head CI, a new immutable finalization comment, a reply to and
+resolution of the reporting P1, fresh independent review, fresh CTO
+authorization and a new post-ready automated review are required. The PR must
+remain draft at handoff. Existing commits, reviews, authorizations, comments and
+resolved threads remain immutable historical evidence.
+
 ## 4. Explicit scope
 
 The task must:
@@ -322,6 +390,17 @@ The task must:
 17. Preserve Publisher Services ADR-01, inventory, repository/branch-readiness,
     bounded-task-specification, independent-review-assignment and
     control-consistency blockers without marking any stage or task ready.
+18. Record the automated reporting P1 against exact head
+    `896da62baf7302ecac468b1da87d16a6cd05bb39` and the CTO-approved
+    evidence-basis/finalization mechanism.
+19. Replace stale current-state `PENDING` evidence with completed outcomes or
+    clearly labelled historical state, and list the reporting exception as an
+    approved task-specific deviation.
+20. Create one bounded two-file reporting-amendment commit, complete fresh
+    exact-head CI, post a new immutable finalization comment, and reply to and
+    resolve thread `PRRT_kwDODkn0bc6UuG-L`.
+21. Return the draft, unmerged PR for fresh independent exact-head review,
+    fresh CTO authorization and a new post-ready automated review.
 
 ## 5. Approved file allowlist
 
@@ -355,6 +434,10 @@ allowlist.
 
 The second post-ready rollout-gate correction is restricted to the exact three
 files listed in Section 3.3. It must not modify any other file in the cumulative
+allowlist.
+
+The implementation-evidence reporting correction is restricted to the exact two
+files listed in Section 3.4. It must not modify any other file in the cumulative
 allowlist.
 
 ## 6. Non-goals
@@ -521,8 +604,15 @@ implementation readiness and retain all remaining blockers specified in Section
 - [ ] No document claims implementation is ready, started or complete.
 - [ ] The changelog records approval without describing runtime functionality as
   implemented.
-- [ ] The implementation report records the exact final head, commits, changed
-  files, validation, CI and no-effect assessment.
+- [ ] The implementation report records the exact base and exact evidence-basis
+  head, all completed evidence available before its finalization commit, and the
+  approved self-referential finalization mechanism.
+- [ ] When the report is not changed by the final commit, it records the exact
+  final head and exact-head CI directly.
+- [ ] When the report is changed by the final commit, the exact final PR head,
+  post-push CI conclusions and immutable evidence-comment URL are recorded in
+  the required top-level PR evidence comment and implementation handoff. This is
+  an approved task-specific exception and is listed as such in the report.
 - [ ] Local documentation validation passes.
 - [ ] Exact-head CI satisfies Section 11.
 - [ ] One top-level immutable PR evidence comment satisfies Section 11.
@@ -616,6 +706,25 @@ Rust, database, migration, GraphQL and authorization tests are not applicable
 because the approved task is documentation-only and changes none of those
 surfaces.
 
+For the implementation-evidence reporting correction, also run:
+
+```bash
+git diff --name-only \
+  896da62baf7302ecac468b1da87d16a6cd05bb39...HEAD
+
+rg -n 'PENDING|pending' \
+  docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+```
+
+The correction diff must contain exactly the two files in Section 3.4. Every
+`PENDING` or `pending` match must refer only to a genuinely future delivery gate
+or clearly marked historical state. Completed CI or review evidence must not be
+currently labelled pending. The report must explicitly record the evidence-basis
+head, completed evidence through that head, the approved deviation, its
+approver, and the immutable finalization mechanism. No report statement may
+claim that the reporting-amendment commit embeds its own SHA, and no additional
+evidence-only commit may be planned.
+
 ## 11. Documentation-only CI observation
 
 This pull request is the first controlled documentation-only observation for
@@ -675,18 +784,28 @@ Create:
 The report must record:
 
 - task and actual draft pull request;
-- exact base and final head;
 - implementing agent/model and independent-review requirement;
 - approved decisions and normative matrix;
 - ordered commits and actual changed files;
 - exact local validation commands and results;
-- exact-head CI status and the evidence-comment link;
 - CI-DOCS-01 documentation-only observation status;
 - absence of runtime, migration, API, authorization, workflow, production,
   deployment and release effects;
 - rollout and rollback;
 - all remaining Publisher Services, Metrics, Diesel and repository-readiness
   blockers.
+
+The implementation report must record the exact base and exact evidence-basis
+head, all completed evidence available before its finalization commit, and the
+approved self-referential finalization mechanism.
+
+When the report is not changed by the final commit, it must record the exact
+final head and exact-head CI directly.
+
+When the report is changed by the final commit, the exact final PR head,
+post-push CI conclusions and immutable evidence-comment URL must be recorded in
+the required top-level PR evidence comment and implementation handoff. This is
+an approved task-specific exception and must be listed as such in the report.
 
 The implementing agent may self-assess risks but may not approve the task.
 
@@ -734,6 +853,18 @@ docs: reconcile ADR-0001 rollout gate
 That commit must contain exactly the three files listed in Section 3.3. Do not
 amend, squash, rebase, reset, force-push or rewrite any existing commit.
 
+Implementation-evidence reporting remediation adds exactly one further bounded
+commit:
+
+```text
+docs: clarify implementation evidence finalization
+```
+
+That commit must contain exactly the two files listed in Section 3.4. Its SHA,
+the resulting final head and post-push CI are recorded through the approved
+immutable-finalization mechanism. Do not create a later evidence-only commit and
+do not amend, squash, rebase, reset, force-push or rewrite any existing commit.
+
 ## 14. Rollout
 
 Initial state after merge:
@@ -752,7 +883,8 @@ Pilot: none.
 Production activation: none.
 
 Merge requires a fresh independent `APPROVED` review followed by explicit CTO
-authorization. The implementing agent must not merge.
+authorization and a new automated post-ready review against the same exact head
+with no P0/P1 finding. The implementing agent must not merge.
 
 ## 15. Rollback
 
@@ -803,6 +935,8 @@ A fresh non-implementing reviewer must inspect:
 - exhaustive active-document ADR-0001 search results and classification;
 - the corrected Publisher Services Stage 0 achieved/outstanding evidence and
   preservation of all genuine rollout blockers;
+- the approved evidence-basis/finalization exception, completed evidence through
+  the evidence-basis head, immutable finalization comment and P1 resolution;
 - remaining blockers and the absence of implementation/readiness claims;
 - absence of runtime, migration, workflow, issue, deployment, release and
   production changes;
@@ -823,3 +957,11 @@ Decision date: 2026-07-28
 
 Notes: This approval authorizes only the bounded documentation and CI-observation
 task defined above.
+
+Reporting amendment approved by: Javi, CTO
+
+Reporting amendment decision date: 2026-07-29
+
+Reporting amendment notes: this task-specific exception authorizes only the
+two-file evidence-basis/finalization mechanism in Section 3.4. It does not amend
+the repository-wide implementation-report controls.

--- a/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+++ b/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
@@ -85,9 +85,10 @@ The following matrix is final and normative:
 
 Approved decisions:
 
-1. OASIS has no metrics-collection capability because Thoth does not distribute
-   OASIS files and therefore has no managed usage-data source for those
-   publishers.
+1. OASIS has no `METRICS_COLLECT` capability as an independent
+   package-entitlement decision. At the time of approval, Thoth has no managed
+   OASIS usage-data source because it does not operationally distribute OASIS
+   files. That operational context does not create a package-to-platform rule.
 2. OBELISK permits background collection when a valid source and operational
    configuration exist.
 3. Metrics collected for OBELISK remain private:
@@ -115,10 +116,64 @@ Approved decisions:
 10. Historical OPERAS export requires a separately scoped, reviewed and
     explicitly activated backfill.
 11. Downgrades retain canonical metrics.
-12. Downgrades stop newly prohibited import, serving and export behaviour.
+12. Downgrades stop only import, serving, collection or export behaviour whose
+    capability is absent from the resulting package.
 13. Package changes never modify distribution-platform assignments.
+14. ADR-0001 does not disable or remove OASIS distribution assignments, prevent
+    superuser platform configuration, define dissemination eligibility, create
+    a distribution capability or change distribution-job behaviour.
+15. Metrics collection must not infer entitlement from a distribution-platform
+    assignment or remote location.
 
 Approved by: Javi, CTO. Approval date: 2026-07-28.
+
+### 3.1 Independent-review correction
+
+Independent review of draft PR [#772](https://github.com/thoth-pub/thoth/pull/772)
+at reviewed head `4af692490875c66a9a0c7fb32354f10f136889e6` returned:
+
+```text
+Decision: CHANGES REQUIRED
+P0: none
+P1: one - decouple OASIS metrics entitlement from distribution
+P2: one - make package-change behaviour capability-based
+```
+
+The correction preserves the normative matrix byte-for-byte. It clarifies:
+
+- OASIS metrics entitlement is independent from distribution configuration and
+  dissemination behaviour;
+- the absence of a managed OASIS metrics source is current operational context,
+  not a permanent distribution invariant created by ADR-0001;
+- any permanent rule prohibiting OASIS distribution requires a separately
+  approved Publisher Services decision through ADR-01 or another
+  cross-programme ADR;
+- every package change is evaluated from the resulting package's capabilities:
+  - `PYRAMID -> SPHINX` removes no initial capability;
+  - `SPHINX` or `PYRAMID -> OBELISK` retains `OAI_PMH` and configured private
+    collection while denying import, dashboard, widget and OPERAS export;
+  - any package `-> OASIS` denies all six initial capabilities and stops
+    Thoth-managed collection;
+- every downgrade retains canonical history, leaves distribution-platform
+  assignments unchanged and rechecks the relevant capability at the final
+  boundary.
+
+The correction may modify exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+docs/engineering/decisions/package-capability-matrix.md
+docs/publisher-services/decisions.md
+docs/metrics/decisions.md
+```
+
+It requires one new bounded commit,
+`docs: clarify package distribution and downgrade semantics`, fresh exact-head
+CI, a new immutable observation comment, fresh independent exact-head review and
+explicit CTO authorization before merge. The existing three commits and
+historical CI observation comment must not be amended, rewritten or replaced.
 
 ## 4. Explicit scope
 
@@ -214,8 +269,11 @@ The final branch must preserve:
 5. Product entitlement remains separate from source accounts, credentials,
    source-specific configuration, feature flags, schedules and rollout
    approval.
-6. Package changes never alter distribution-platform assignments.
-7. OASIS has no managed collection source and no initial capability.
+6. Package changes never alter distribution-platform assignments,
+   distribution-job eligibility or dissemination behaviour.
+7. OASIS has no initial capability. At approval time, Thoth has no managed OASIS
+   usage-data source; that operational fact is not a permanent
+   package-to-platform rule.
 8. OBELISK private collection is permitted only when configured and is
    operationally non-blocking for unrelated work.
 9. Missing or unavailable metric data is never fabricated or treated as zero.
@@ -227,6 +285,14 @@ The final branch must preserve:
 13. No documentation claim treats approval as implementation or readiness.
 14. No runtime, migration, API, workflow, production, deployment or release
     effect occurs.
+15. OASIS distribution assignments and superuser platform configuration remain
+    unaffected; any permanent distribution prohibition requires ADR-01 or
+    another approved cross-programme ADR.
+16. Metrics collection never infers package entitlement from a distribution
+    assignment or remote location.
+17. Every package change uses the resulting package's capabilities, retains
+    canonical history on downgrade and rechecks the relevant capability at the
+    final boundary.
 
 ## 8. Required documentation behaviour
 
@@ -237,8 +303,10 @@ The ADR must:
 - show `Status: APPROVED`;
 - contain the exact matrix in Section 3;
 - remove statements suggesting OASIS permits collection;
-- explain that Thoth has no managed OASIS collection because it does not
-  distribute OASIS files;
+- state that OASIS is not entitled to Thoth-managed metrics collection and that,
+  under current operations, Thoth has no managed OASIS usage-data source;
+- state that this operational context does not define or alter distribution
+  assignments, distribution-job eligibility or dissemination behaviour;
 - define OBELISK background collection as private, configured and non-blocking;
 - distinguish downgrade to OBELISK, where configured private collection may
   continue, from downgrade to OASIS, where managed collection stops;
@@ -297,6 +365,14 @@ implementation readiness and retain all remaining blockers specified in Section
   credentials, and is non-blocking for unrelated work.
 - [ ] Upgrade, historical export and both downgrade paths match the approved CTO
   decisions.
+- [ ] `PYRAMID -> SPHINX` preserves all six initial capabilities.
+- [ ] A resulting OBELISK package permits only `OAI_PMH` and configured private
+  collection; a resulting OASIS package denies all six initial capabilities.
+- [ ] Every downgrade retains canonical history, leaves distribution assignments
+  unchanged and rechecks the relevant capability at its final boundary.
+- [ ] No text makes ADR-0001 define OASIS distribution or dissemination
+  eligibility, and collection never infers entitlement from an assignment or
+  remote location.
 - [ ] Every package-capability approval checklist item is checked.
 - [ ] Approver, approval date and actual approval PR are consistent.
 - [ ] The ADR's code-owned mapping, ownership, API-code, no-row, no-override and
@@ -337,6 +413,14 @@ Verify:
 - OASIS has no capability;
 - OBELISK has only `OAI_PMH` and `METRICS_COLLECT`;
 - SPHINX and PYRAMID have all six capabilities;
+- `PYRAMID -> SPHINX` removes no initial capability;
+- transition to OBELISK and transition to OASIS use the resulting capability
+  set;
+- canonical history and distribution assignments remain unchanged on downgrade;
+- in-flight work rechecks the relevant capability at its final boundary;
+- no text makes package choice define distribution or dissemination eligibility;
+- metrics collection does not infer entitlement from a distribution assignment
+  or remote location;
 - every checklist item is checked;
 - approver, approval date and actual PR number are consistent;
 - internal links and paths resolve;
@@ -394,6 +478,8 @@ Post one top-level PR evidence comment containing:
 
 Do not mark CI-DOCS-01 operationally complete. Exact final-head run IDs belong in
 the immutable PR evidence comment, not in a later evidence-only commit.
+If remediation creates a new exact head, post a new immutable top-level evidence
+comment and leave every earlier observation comment unchanged.
 
 ## 12. Implementation report
 
@@ -436,6 +522,14 @@ docs: record ADR-0001 approval evidence
 ```
 
 Do not amend, squash or rewrite the specification-first commit.
+
+Independent-review remediation adds exactly one further bounded commit:
+
+```text
+docs: clarify package distribution and downgrade semantics
+```
+
+Do not amend, squash, rebase or rewrite any of the existing three commits.
 
 ## 14. Rollout
 

--- a/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+++ b/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
@@ -1,0 +1,523 @@
+# ADR-0001-APPROVAL - Approve the Publisher Package Capability Model
+
+Status: APPROVED
+Programme: Shared Publisher Services / Thoth Metrics foundation
+Repository: thoth-pub/thoth
+Workflow: STANDARD
+Base branch: develop
+Verified base commit: `bafd4cbf752f9d6153036fc7f47115220fed3fbd`
+PR target: develop
+Programme integration branch: None
+Risk: MEDIUM
+Owner: CTO
+Approved by: Javi, CTO
+Approval date: 2026-07-28
+Target branch name: `feature/engineering/adr-0001-approval`
+
+Dependencies:
+
+- the ADR-0001 proposal and package-capability appendix introduced through the
+  merged engineering-control foundation;
+- the CTO decisions recorded in this specification;
+- merged CI-DOCS-01 pull request
+  [#771](https://github.com/thoth-pub/thoth/pull/771) at merge commit
+  `bafd4cbf752f9d6153036fc7f47115220fed3fbd`;
+- a fresh independent reviewer who did not implement this task;
+- explicit CTO authorization before merge.
+
+Recommended execution:
+
+- Implementing agent/model: Codex / GPT-5
+- Implementation reasoning: High
+- Independent reviewer/model: ChatGPT / GPT-5.6 Thinking
+- Independent review reasoning: High
+
+## 1. Objective
+
+Record the CTO's approval of ADR-0001 and its final normative package-capability
+matrix, reconcile the bounded Publisher Services, Metrics and engineering-control
+records, and perform the first controlled documentation-only CI observation
+required by CI-DOCS-01.
+
+This task records an approved architectural decision. It does not implement
+package storage, capability enforcement, metrics collection, GraphQL fields,
+OAI-PMH gating or any runtime behaviour.
+
+## 2. Background and authority
+
+Authoritative sources, in precedence order:
+
+1. `thoth-pub/thoth` branch `develop` at
+   `bafd4cbf752f9d6153036fc7f47115220fed3fbd`;
+2. the CTO decisions in Section 3 of this approved specification;
+3. the proposed ADR-0001 and package-capability appendix;
+4. the merged CI-DOCS-01 specification and implementation at the approved base;
+5. the engineering-control, Publisher Services and Metrics repository records;
+6. repository agent instructions and delivery controls.
+
+Verified baseline:
+
+- live `origin/develop` and local `develop` both point to the exact approved
+  base;
+- the working tree is clean before branching;
+- no local or remote
+  `feature/engineering/adr-0001-approval` branch exists before branching;
+- ADR-0001 and its matrix are `PROPOSED`;
+- ADR-0002 is `APPROVED`;
+- Publisher Services `ADR-01` and the final distribution-platform inventory
+  remain unresolved;
+- Publisher Services `BE-01` is `BLOCKED`;
+- Metrics `MET-CTRL-01` is `CHANGES REQUIRED`;
+- every Metrics work package remains `BLOCKED`;
+- CI-DOCS-01 is merged, but its controlled documentation-only, mixed-source and
+  next-three-PR observations remain outstanding.
+
+## 3. Approved CTO decisions
+
+The following matrix is final and normative:
+
+| Package | OAI_PMH | METRICS_COLLECT | METRICS_IMPORT | METRICS_DASHBOARD | METRICS_WIDGET | METRICS_OPERAS_EXPORT |
+|---|---:|---:|---:|---:|---:|---:|
+| OASIS | No | No | No | No | No | No |
+| OBELISK | Yes | Yes | No | No | No | No |
+| SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
+| PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
+
+Approved decisions:
+
+1. OASIS has no metrics-collection capability because Thoth does not distribute
+   OASIS files and therefore has no managed usage-data source for those
+   publishers.
+2. OBELISK permits background collection when a valid source and operational
+   configuration exist.
+3. Metrics collected for OBELISK remain private:
+   - no publisher import;
+   - no dashboard serving;
+   - no widget serving;
+   - no OPERAS export.
+4. OBELISK collection is operationally non-blocking:
+   - missing source configuration must not block unrelated operations;
+   - source outages must not block unrelated operations;
+   - retries or reconciliation must not block distribution or metadata
+     workflows;
+   - collection failure must not block package changes;
+   - collection must not become a prerequisite for unrelated publisher
+     services.
+5. Non-blocking does not mean unconfigured collection:
+   - a source account, credentials and source-specific configuration are still
+     required;
+   - the system must not fabricate data or treat missing data as zero.
+6. SPHINX has all initial metrics capabilities.
+7. PYRAMID includes all SPHINX metrics capabilities.
+8. Retained canonical history becomes available when a publisher upgrades to a
+   package with the relevant serving capability.
+9. An upgrade must not automatically create historical OPERAS exports.
+10. Historical OPERAS export requires a separately scoped, reviewed and
+    explicitly activated backfill.
+11. Downgrades retain canonical metrics.
+12. Downgrades stop newly prohibited import, serving and export behaviour.
+13. Package changes never modify distribution-platform assignments.
+
+Approved by: Javi, CTO. Approval date: 2026-07-28.
+
+## 4. Explicit scope
+
+The task must:
+
+1. Commit this approved task specification before any other change.
+2. Push the specification-only commit and open a draft pull request targeting
+   `develop`.
+3. Use the actual draft pull-request number, without a placeholder, in the ADR,
+   decision register, changelog, approval records and implementation report.
+4. Change ADR-0001 from `PROPOSED` to `APPROVED`, preserve its code-owned
+   exhaustive mapping, Thoth ownership, stable GraphQL capability codes, absence
+   of database capability rows, absence of bespoke publisher overrides and
+   entitlement/configuration separation, and record the final approved matrix
+   and approval metadata.
+5. Change the package-capability appendix to `APPROVED`, make its matrix
+   identical to the ADR, replace the proposed collection rationale, update
+   upgrade/downgrade rules, record the OBELISK non-blocking invariant and valid
+   source requirement, complete every CTO checklist item, and record the
+   approver and approval date.
+6. Reconcile the engineering decision register and only the ADR-0001 portion of
+   control gap CG-06.
+7. Reconcile Publisher Services records so ADR-0001 is approved, `BE-01` no
+   longer lists it as unresolved, and `BE-01` remains blocked by its own missing
+   approved bounded specification. Preserve the unresolved ADR-01 and
+   distribution-platform inventory gates and do not mark any implementation
+   task ready.
+8. Reconcile Metrics records so ADR-0001 is approved, the final matrix is
+   accurate, OASIS collection is excluded, OBELISK collection is private and
+   non-blocking, `MET-CTRL-01` remains `CHANGES REQUIRED`, and WP1 and later work
+   remain blocked by their remaining control, Diesel and repository-readiness
+   dependencies.
+9. Add one concise `Unreleased` changelog entry describing the approval and the
+   final OASIS/OBELISK distinction without claiming runtime implementation.
+10. Create the required implementation report and record exact repository,
+    validation, no-effect, review and CI observation evidence.
+11. Observe the final exact-head GitHub Actions jobs and post one top-level PR
+    evidence comment with immutable CI evidence.
+12. Keep the pull request draft and hand it off for fresh independent review.
+
+## 5. Approved file allowlist
+
+The complete pull request may change exactly these paths:
+
+```text
+CHANGELOG.md
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+docs/engineering/decisions/package-capability-matrix.md
+docs/engineering/decisions/decision-register.md
+docs/engineering/repository-map/control-gaps.md
+docs/publisher-services/decisions.md
+docs/publisher-services/task-status.md
+docs/metrics/decisions.md
+docs/metrics/task-status.md
+```
+
+The actual changed-file set may be a subset of this allowlist. If another
+repository file requires modification, stop and report the exact stale reference
+as follow-up work rather than expanding scope.
+
+## 6. Non-goals
+
+This task must not:
+
+- modify Rust, SQL, GraphQL, JavaScript, generated code or workflow files;
+- create package enums, capability mappings, database columns or migrations;
+- implement package storage, capability checks or authorization;
+- implement metrics collection, imports, serving or OPERAS export;
+- alter OAI-PMH behaviour;
+- change distribution-platform assignments;
+- create or modify source accounts or credentials;
+- change branch protection or rulesets;
+- dispatch production or write-capable workflows;
+- deploy, release or activate production behaviour;
+- access production secrets or services;
+- edit GitHub issues #765 or #766;
+- mark any Publisher Services or Metrics implementation task ready;
+- broaden the approved file scope;
+- approve its own work;
+- merge the pull request.
+
+## 7. Invariants
+
+The final branch must preserve:
+
+1. Package/capability mapping remains code-owned and exhaustive in Thoth.
+2. `ThothPackage` and `PublisherCapability` remain closed Rust enums with stable
+   GraphQL codes in the approved target architecture.
+3. Capability mappings are not persisted as independent database rows.
+4. Bespoke per-publisher capability overrides remain excluded.
+5. Product entitlement remains separate from source accounts, credentials,
+   source-specific configuration, feature flags, schedules and rollout
+   approval.
+6. Package changes never alter distribution-platform assignments.
+7. OASIS has no managed collection source and no initial capability.
+8. OBELISK private collection is permitted only when configured and is
+   operationally non-blocking for unrelated work.
+9. Missing or unavailable metric data is never fabricated or treated as zero.
+10. Canonical metric history is retained after downgrade.
+11. Historical OPERAS export is never an automatic upgrade side effect.
+12. ADR-01, the distribution-platform inventory, `MET-CTRL-01`, Diesel schema
+    generation and repository-readiness gaps retain their existing independent
+    status.
+13. No documentation claim treats approval as implementation or readiness.
+14. No runtime, migration, API, workflow, production, deployment or release
+    effect occurs.
+
+## 8. Required documentation behaviour
+
+### 8.1 ADR-0001
+
+The ADR must:
+
+- show `Status: APPROVED`;
+- contain the exact matrix in Section 3;
+- remove statements suggesting OASIS permits collection;
+- explain that Thoth has no managed OASIS collection because it does not
+  distribute OASIS files;
+- define OBELISK background collection as private, configured and non-blocking;
+- distinguish downgrade to OBELISK, where configured private collection may
+  continue, from downgrade to OASIS, where managed collection stops;
+- preserve canonical history on either downgrade;
+- record:
+
+```text
+Approved by: Javi, CTO
+Approval date: 2026-07-28
+Approval PR: #<actual PR number>
+```
+
+It must not claim implementation has started or completed.
+
+### 8.2 Package-capability appendix
+
+The appendix must:
+
+- show `Status: APPROVED`;
+- contain the exact matrix in Section 3;
+- replace the “Collection for every package” proposal with the approved OASIS,
+  OBELISK and SPHINX/PYRAMID rationale;
+- state the OBELISK non-blocking invariant and valid-source/configuration
+  requirement;
+- update upgrade and downgrade behaviour;
+- mark every CTO approval-checklist item complete;
+- record Javi, CTO and 2026-07-28.
+
+### 8.3 Control and programme records
+
+The decision register must show ADR-0001 approved and reference the actual
+approval PR. CG-06 must record the ADR-0001 approval while preserving every
+unrelated control gap.
+
+Publisher Services and Metrics records must accurately distinguish approval from
+implementation readiness and retain all remaining blockers specified in Section
+7.
+
+## 9. Acceptance criteria
+
+- [ ] The exact-base, clean-tree and absent-branch preconditions passed before
+  branch creation.
+- [ ] This task specification is the only file in the first commit.
+- [ ] The first commit message is `docs: specify ADR-0001 approval`.
+- [ ] A draft pull request targets `develop`.
+- [ ] Every changed path is in the approved allowlist and under `docs/**` or is
+  exactly `CHANGELOG.md`.
+- [ ] No runtime or workflow file changed.
+- [ ] ADR-0001 and the matrix appendix show `APPROVED`.
+- [ ] The ADR, appendix and programme summaries contain the identical normative
+  matrix.
+- [ ] OASIS never has `METRICS_COLLECT`.
+- [ ] OBELISK has only `OAI_PMH` and `METRICS_COLLECT`.
+- [ ] SPHINX and PYRAMID have all six capabilities.
+- [ ] OBELISK collection is private, requires valid source configuration and
+  credentials, and is non-blocking for unrelated work.
+- [ ] Upgrade, historical export and both downgrade paths match the approved CTO
+  decisions.
+- [ ] Every package-capability approval checklist item is checked.
+- [ ] Approver, approval date and actual approval PR are consistent.
+- [ ] The ADR's code-owned mapping, ownership, API-code, no-row, no-override and
+  entitlement/configuration architecture is preserved.
+- [ ] ADR-01 and the distribution-platform inventory remain unresolved.
+- [ ] `BE-01` remains `BLOCKED` pending its own approved bounded specification.
+- [ ] `MET-CTRL-01` remains `CHANGES REQUIRED`.
+- [ ] Metrics WP1 and later work packages remain `BLOCKED`.
+- [ ] No document claims implementation is ready, started or complete.
+- [ ] The changelog records approval without describing runtime functionality as
+  implemented.
+- [ ] The implementation report records the exact final head, commits, changed
+  files, validation, CI and no-effect assessment.
+- [ ] Local documentation validation passes.
+- [ ] Exact-head CI satisfies Section 11.
+- [ ] One top-level immutable PR evidence comment satisfies Section 11.
+- [ ] The pull request remains draft with zero unresolved review threads at
+  handoff.
+- [ ] A fresh independent reviewer returns `APPROVED` before merge.
+- [ ] Explicit CTO authorization is obtained after independent approval and
+  before merge.
+
+## 10. Local validation
+
+Run:
+
+```bash
+git diff --check bafd4cbf752f9d6153036fc7f47115220fed3fbd...HEAD
+```
+
+Verify:
+
+- every changed path is under `docs/**` or exactly `CHANGELOG.md`;
+- the changed-file set is a subset of Section 5;
+- no runtime or workflow file changed;
+- every active ADR-0001 status in the approved scope is consistent;
+- matrices are identical in the ADR, appendix and programme summaries;
+- OASIS has no capability;
+- OBELISK has only `OAI_PMH` and `METRICS_COLLECT`;
+- SPHINX and PYRAMID have all six capabilities;
+- every checklist item is checked;
+- approver, approval date and actual PR number are consistent;
+- internal links and paths resolve;
+- canonical repository and programme terminology is used;
+- no active document claims implementation readiness.
+
+Rust, database, migration, GraphQL and authorization tests are not applicable
+because the approved task is documentation-only and changes none of those
+surfaces.
+
+## 11. Documentation-only CI observation
+
+This pull request is the first controlled documentation-only observation for
+merged task CI-DOCS-01.
+
+At the exact final head, require:
+
+```text
+all classifier jobs: success
+build: skipped
+test: skipped
+lint: skipped
+format_check: skipped
+run_migrations: skipped
+build_and_push_staging_docker_image: skipped
+check-changelog: success
+```
+
+Inspect job steps and prove:
+
+- no Rust build step executed;
+- no test step executed;
+- no lint step executed;
+- no migration build, apply or revert step executed;
+- no Docker registry login executed;
+- no Docker image build or push executed;
+- all six protected contexts reached terminal merge-safe conclusions;
+- the additional mandatory Docker workflow context reached a terminal
+  conclusion;
+- no required context remained pending;
+- `check-changelog` remained active.
+
+Post one top-level PR evidence comment containing:
+
+- exact base and final head;
+- workflow run IDs;
+- all classifier conclusions;
+- each protected and mandatory job conclusion;
+- confirmation that heavy steps did not execute;
+- confirmation that `check-changelog` remained active;
+- a statement that this satisfies only the controlled documentation-only
+  observation;
+- a statement that the mixed-source and next-three-PR observations remain
+  outstanding.
+
+Do not mark CI-DOCS-01 operationally complete. Exact final-head run IDs belong in
+the immutable PR evidence comment, not in a later evidence-only commit.
+
+## 12. Implementation report
+
+Create:
+
+`docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md`
+
+The report must record:
+
+- task and actual draft pull request;
+- exact base and final head;
+- implementing agent/model and independent-review requirement;
+- approved decisions and normative matrix;
+- ordered commits and actual changed files;
+- exact local validation commands and results;
+- exact-head CI status and the evidence-comment link;
+- CI-DOCS-01 documentation-only observation status;
+- absence of runtime, migration, API, authorization, workflow, production,
+  deployment and release effects;
+- rollout and rollback;
+- all remaining Publisher Services, Metrics, Diesel and repository-readiness
+  blockers.
+
+The implementing agent may self-assess risks but may not approve the task.
+
+## 13. Commit structure
+
+Required first commit:
+
+```text
+docs: specify ADR-0001 approval
+```
+
+After the draft pull request exists and its actual number is known, use bounded
+commits such as:
+
+```text
+docs: approve publisher package capability model
+docs: record ADR-0001 approval evidence
+```
+
+Do not amend, squash or rewrite the specification-first commit.
+
+## 14. Rollout
+
+Initial state after merge:
+
+- ADR-0001 is an approved architectural dependency;
+- no package, capability, metrics or OAI-PMH runtime behaviour exists merely
+  because the ADR is approved;
+- Publisher Services and Metrics implementation remains blocked by the
+  remaining task-specific and programme-readiness dependencies;
+- CI-DOCS-01 has one controlled documentation-only observation, while its
+  mixed-source and next-three-PR observations remain outstanding.
+
+Feature flag/configuration: none.
+Staging/preview: none.
+Pilot: none.
+Production activation: none.
+
+Merge requires a fresh independent `APPROVED` review followed by explicit CTO
+authorization. The implementing agent must not merge.
+
+## 15. Rollback
+
+Rollback is a normal revert of this documentation-only approval pull request.
+The revert must restore the prior `PROPOSED` decision and tracker state while
+preserving unrelated later work.
+
+No database, data, API, authorization, source-account, distribution,
+deployment, release or production-state rollback is required.
+
+The CI observation comment is immutable historical evidence and must not be
+rewritten as though the observation did not occur.
+
+## 16. Stop conditions
+
+Stop and report `BLOCKED` if:
+
+- `develop` differs from
+  `bafd4cbf752f9d6153036fc7f47115220fed3fbd` before branching;
+- the working tree is not clean before branching;
+- the task branch already exists locally or remotely;
+- the approved architecture conflicts with merged repository evidence;
+- another repository file must change to maintain consistency;
+- implementation requires runtime, migration, API, workflow, issue, deployment,
+  release, production or secret access;
+- the actual pull-request number is unavailable for approval records;
+- an exact-head required context is missing, pending or not merge-safe;
+- a heavy Rust, migration or Docker step executes for this documentation-only
+  pull request;
+- the branch ceases to be a documentation-only diff;
+- independent review or explicit CTO merge authorization is unavailable.
+
+## 17. Independent review and merge authorization
+
+A fresh non-implementing reviewer must inspect:
+
+- this approved specification;
+- exact base and final head;
+- ordered commit sequence and specification-first history;
+- complete cumulative diff and allowlist compliance;
+- all ADR, matrix, control and programme changes;
+- matrix identity and every approved invariant;
+- local validation evidence;
+- exact-head GitHub Actions run and job-step evidence;
+- the CI-DOCS-01 top-level evidence comment;
+- remaining blockers and the absence of implementation/readiness claims;
+- absence of runtime, migration, workflow, issue, deployment, release and
+  production changes;
+- unresolved review threads.
+
+The reviewer must return exactly one verdict: `APPROVED`, `CHANGES REQUIRED` or
+`BLOCKED`. Approval is permitted only when no unresolved P0 or P1 finding
+remains.
+
+The implementing agent may not approve or merge this work. Do not merge without
+explicit CTO authorization after independent approval.
+
+## 18. Approval
+
+Approved for implementation by: Javi, CTO
+
+Decision date: 2026-07-28
+
+Notes: This approval authorizes only the bounded documentation and CI-observation
+task defined above.

--- a/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+++ b/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
@@ -175,6 +175,54 @@ CI, a new immutable observation comment, fresh independent exact-head review and
 explicit CTO authorization before merge. The existing three commits and
 historical CI observation comment must not be amended, rewritten or replaced.
 
+### 3.2 Post-ready active-entry-point correction
+
+Automated post-ready review of PR
+[#772](https://github.com/thoth-pub/thoth/pull/772) at exact head
+`1124262dd28e0b51f33259be1b70e1396e3bdb1c` returned one P1 finding:
+
+```text
+P1 - Reconcile the stale active ADR indexes
+```
+
+The normative decision and tracker records were correct, but these three active
+repository entry points still described ADR-0001 as `PROPOSED` or as an
+outstanding approval blocker:
+
+```text
+docs/engineering/README.md
+docs/metrics/README.md
+docs/publisher-services/README.md
+```
+
+These are active contradictions rather than historical review evidence. Active
+entry points must agree with the normative decision and tracker records while
+preserving the real remaining Publisher Services, Metrics, Diesel and
+repository-readiness blockers.
+
+Javi, CTO, approved a narrow allowlist amendment on 2026-07-28. The correction
+may modify exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+docs/engineering/README.md
+docs/metrics/README.md
+docs/publisher-services/README.md
+```
+
+Before repository changes, PR #772 must return to draft. The correction requires
+one new bounded commit, `docs: reconcile ADR-0001 programme entry points`, fresh
+exact-head CI, a new immutable observation comment, a reply to and resolution
+of the P1 only after exact-head evidence is terminal, fresh independent
+exact-head review and fresh explicit CTO authorization before merge.
+
+Creating the correction commit invalidates the prior independent approval for
+head `1124262dd28e0b51f33259be1b70e1396e3bdb1c` and the CTO merge authorization
+bound to that head. Those records remain immutable historical evidence and must
+not be rewritten or erased. No existing commit may be amended, squashed,
+rebased, reset, force-pushed or otherwise rewritten.
+
 ## 4. Explicit scope
 
 The task must:
@@ -213,6 +261,11 @@ The task must:
 11. Observe the final exact-head GitHub Actions jobs and post one top-level PR
     evidence comment with immutable CI evidence.
 12. Keep the pull request draft and hand it off for fresh independent review.
+13. Reconcile the three active README entry points so ADR-0001 is shown as
+    approved by Javi, CTO, on 2026-07-28 through PR #772, pending merge of the
+    approval record, without claiming implementation or merge.
+14. Preserve every genuine programme blocker and prove that active entry points
+    agree with the normative decision and tracker records.
 
 ## 5. Approved file allowlist
 
@@ -226,15 +279,22 @@ docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
 docs/engineering/decisions/package-capability-matrix.md
 docs/engineering/decisions/decision-register.md
 docs/engineering/repository-map/control-gaps.md
+docs/engineering/README.md
 docs/publisher-services/decisions.md
 docs/publisher-services/task-status.md
+docs/publisher-services/README.md
 docs/metrics/decisions.md
 docs/metrics/task-status.md
+docs/metrics/README.md
 ```
 
 The actual changed-file set may be a subset of this allowlist. If another
 repository file requires modification, stop and report the exact stale reference
 as follow-up work rather than expanding scope.
+
+The post-ready active-entry-point correction is restricted to the exact five
+files listed in Section 3.2. It must not modify any other file in the cumulative
+allowlist.
 
 ## 6. Non-goals
 
@@ -381,6 +441,12 @@ implementation readiness and retain all remaining blockers specified in Section
 - [ ] `BE-01` remains `BLOCKED` pending its own approved bounded specification.
 - [ ] `MET-CTRL-01` remains `CHANGES REQUIRED`.
 - [ ] Metrics WP1 and later work packages remain `BLOCKED`.
+- [ ] No active README describes ADR-0001 as proposed or lists its approval as
+  an outstanding blocker.
+- [ ] All three active README entry points record the approver, date, approval
+  PR and pending-merge status consistently.
+- [ ] All three active README entry points preserve genuine remaining
+  programme, task-specification, Diesel and repository-readiness blockers.
 - [ ] No document claims implementation is ready, started or complete.
 - [ ] The changelog records approval without describing runtime functionality as
   implemented.
@@ -407,6 +473,7 @@ Verify:
 
 - every changed path is under `docs/**` or exactly `CHANGELOG.md`;
 - the changed-file set is a subset of Section 5;
+- the post-ready correction changes exactly the five files in Section 3.2;
 - no runtime or workflow file changed;
 - every active ADR-0001 status in the approved scope is consistent;
 - matrices are identical in the ADR, appendix and programme summaries;
@@ -426,6 +493,27 @@ Verify:
 - internal links and paths resolve;
 - canonical repository and programme terminology is used;
 - no active document claims implementation readiness.
+
+Search all active documentation for stale ADR-0001 state:
+
+```bash
+rg -n \
+  'ADR-0001.*PROPOSED|ADR-0001 remains proposed|ADR-0001.*blocking|blocked.*ADR-0001' \
+  docs \
+  --glob '*.md'
+```
+
+Classify every result as an active entry point/current control record,
+historical task/report/review evidence, or ambiguous. Active contradictions must
+be corrected; historical evidence must be preserved; ambiguous results are a
+stop condition.
+
+Run `.github/scripts/classify_ci_changes.py` over the exact cumulative path set
+and require:
+
+```json
+{"docs_only": "true", "run_build": "false", "run_docker": "false", "run_migrations": "false"}
+```
 
 Rust, database, migration, GraphQL and authorization tests are not applicable
 because the approved task is documentation-only and changes none of those
@@ -531,6 +619,15 @@ docs: clarify package distribution and downgrade semantics
 
 Do not amend, squash, rebase or rewrite any of the existing three commits.
 
+Post-ready remediation adds exactly one further bounded commit:
+
+```text
+docs: reconcile ADR-0001 programme entry points
+```
+
+That commit must contain exactly the five files listed in Section 3.2. Do not
+amend, squash, rebase, reset, force-push or rewrite any existing commit.
+
 ## 14. Rollout
 
 Initial state after merge:
@@ -580,6 +677,8 @@ Stop and report `BLOCKED` if:
 - a heavy Rust, migration or Docker step executes for this documentation-only
   pull request;
 - the branch ceases to be a documentation-only diff;
+- another active entry point or current control record requires correction
+  outside the five-file post-ready amendment;
 - independent review or explicit CTO merge authorization is unavailable.
 
 ## 17. Independent review and merge authorization

--- a/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+++ b/docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
@@ -223,6 +223,54 @@ bound to that head. Those records remain immutable historical evidence and must
 not be rewritten or erased. No existing commit may be amended, squashed,
 rebased, reset, force-pushed or otherwise rewritten.
 
+### 3.3 Second post-ready rollout-gate correction
+
+A second automated post-ready review of PR
+[#772](https://github.com/thoth-pub/thoth/pull/772) at exact head
+`56c4f873c27fa83e6358c1f207cd718cb3dde679` returned one unresolved P1:
+
+```text
+P1 - Reconcile the ADR-0001 Publisher Services rollout gate
+```
+
+Stage 0 in the active Publisher Services rollout control correctly required
+`ADR-0001 approved`, but its `Outstanding evidence` list still contained the
+stale current blocker:
+
+```text
+docs/publisher-services/rollout-plan.md
+- ADR-0001 approval;
+```
+
+Javi, CTO, approved a narrow three-file amendment on 2026-07-28. The correction
+may modify exactly:
+
+```text
+docs/engineering/ai-delivery/tasks/ADR-0001-APPROVAL.md
+docs/engineering/ai-delivery/implementation-reports/ADR-0001-APPROVAL-implementation-report.md
+docs/publisher-services/rollout-plan.md
+```
+
+Before repository changes, PR #772 must return to draft. The rollout plan must
+preserve ADR-0001 approval as a Stage 0 requirement, move the approval record to
+achieved evidence, remove only the stale approval blocker, preserve every
+genuine Publisher Services blocker and make no readiness or implementation
+claim.
+
+Because this is the second post-ready stale-reference finding, the correction
+also requires exhaustive classification of every ADR-0001 reference in active
+documentation, excluding only historical task and implementation-report
+evidence. Any additional active contradiction outside the three-file amendment
+is a stop condition.
+
+Creating this correction invalidates the exact-head independent approval and CTO
+authorization for `56c4f873c27fa83e6358c1f207cd718cb3dde679`. Fresh exact-head
+CI, a new immutable CI-DOCS-01 observation comment, a reply to and resolution of
+the P1 only after CI is terminal, fresh independent review, fresh CTO
+authorization and a new automated post-ready review are required. Existing
+commits, reviews, authorizations and CI comments remain immutable historical
+evidence.
+
 ## 4. Explicit scope
 
 The task must:
@@ -266,6 +314,14 @@ The task must:
     approval record, without claiming implementation or merge.
 14. Preserve every genuine programme blocker and prove that active entry points
     agree with the normative decision and tracker records.
+15. Reconcile the active Publisher Services Stage 0 rollout gate by recording
+    ADR-0001 approval under achieved evidence and removing it only from
+    outstanding evidence.
+16. Exhaustively list and classify every active-document ADR-0001 reference,
+    with no uncorrected or ambiguous current status remaining.
+17. Preserve Publisher Services ADR-01, inventory, repository/branch-readiness,
+    bounded-task-specification, independent-review-assignment and
+    control-consistency blockers without marking any stage or task ready.
 
 ## 5. Approved file allowlist
 
@@ -283,6 +339,7 @@ docs/engineering/README.md
 docs/publisher-services/decisions.md
 docs/publisher-services/task-status.md
 docs/publisher-services/README.md
+docs/publisher-services/rollout-plan.md
 docs/metrics/decisions.md
 docs/metrics/task-status.md
 docs/metrics/README.md
@@ -294,6 +351,10 @@ as follow-up work rather than expanding scope.
 
 The post-ready active-entry-point correction is restricted to the exact five
 files listed in Section 3.2. It must not modify any other file in the cumulative
+allowlist.
+
+The second post-ready rollout-gate correction is restricted to the exact three
+files listed in Section 3.3. It must not modify any other file in the cumulative
 allowlist.
 
 ## 6. Non-goals
@@ -447,6 +508,16 @@ implementation readiness and retain all remaining blockers specified in Section
   PR and pending-merge status consistently.
 - [ ] All three active README entry points preserve genuine remaining
   programme, task-specification, Diesel and repository-readiness blockers.
+- [ ] The Publisher Services Stage 0 required controls still include ADR-0001
+  approval, and achieved evidence records Javi, CTO, 2026-07-28 and PR #772.
+- [ ] ADR-0001 approval is absent from Stage 0 outstanding evidence while
+  ADR-01, final inventory, repository/branch readiness, bounded task
+  specifications, independent review assignments and control consistency remain
+  outstanding.
+- [ ] Every active-document ADR-0001 reference is classified and no active
+  document describes approval as proposed, outstanding, awaiting or blocking.
+- [ ] No stage, `BE-01`, `OAI-01` or programme is marked ready, complete,
+  activated or rolled out.
 - [ ] No document claims implementation is ready, started or complete.
 - [ ] The changelog records approval without describing runtime functionality as
   implemented.
@@ -474,6 +545,8 @@ Verify:
 - every changed path is under `docs/**` or exactly `CHANGELOG.md`;
 - the changed-file set is a subset of Section 5;
 - the post-ready correction changes exactly the five files in Section 3.2;
+- the second post-ready correction changes exactly the three files in Section
+  3.3;
 - no runtime or workflow file changed;
 - every active ADR-0001 status in the approved scope is consistent;
 - matrices are identical in the ADR, appendix and programme summaries;
@@ -503,10 +576,34 @@ rg -n \
   --glob '*.md'
 ```
 
-Classify every result as an active entry point/current control record,
-historical task/report/review evidence, or ambiguous. Active contradictions must
-be corrected; historical evidence must be preserved; ambiguous results are a
-stop condition.
+For the second post-ready correction, list every ADR-0001 reference in active
+documentation while excluding historical task and implementation-report
+evidence:
+
+```bash
+rg -n 'ADR-0001' docs \
+  --glob '*.md' \
+  --glob '!docs/engineering/ai-delivery/tasks/**' \
+  --glob '!docs/engineering/ai-delivery/implementation-reports/**'
+```
+
+Also run:
+
+```bash
+rg -n \
+  'ADR-0001.*(PROPOSED|proposed|outstanding|awaiting|pending approval|block)|((outstanding|awaiting|pending approval|block).*)ADR-0001' \
+  docs \
+  --glob '*.md'
+```
+
+Classify every result as an active normative decision, current control/status
+record, reference-only document, historical task/report/review evidence or
+ambiguous. Active contradictions must be corrected; historical evidence must be
+preserved; ambiguous results are a stop condition. No active document may
+describe ADR-0001 as proposed, list approval as outstanding, treat obtaining
+approval as a current blocker or claim the approved runtime behaviour is
+implemented. References to approval as an already satisfied requirement and
+statements that other dependencies still block implementation are permitted.
 
 Run `.github/scripts/classify_ci_changes.py` over the exact cumulative path set
 and require:
@@ -628,6 +725,15 @@ docs: reconcile ADR-0001 programme entry points
 That commit must contain exactly the five files listed in Section 3.2. Do not
 amend, squash, rebase, reset, force-push or rewrite any existing commit.
 
+Second post-ready remediation adds exactly one further bounded commit:
+
+```text
+docs: reconcile ADR-0001 rollout gate
+```
+
+That commit must contain exactly the three files listed in Section 3.3. Do not
+amend, squash, rebase, reset, force-push or rewrite any existing commit.
+
 ## 14. Rollout
 
 Initial state after merge:
@@ -678,7 +784,7 @@ Stop and report `BLOCKED` if:
   pull request;
 - the branch ceases to be a documentation-only diff;
 - another active entry point or current control record requires correction
-  outside the five-file post-ready amendment;
+  outside the three-file second post-ready amendment;
 - independent review or explicit CTO merge authorization is unavailable.
 
 ## 17. Independent review and merge authorization
@@ -694,6 +800,9 @@ A fresh non-implementing reviewer must inspect:
 - local validation evidence;
 - exact-head GitHub Actions run and job-step evidence;
 - the CI-DOCS-01 top-level evidence comment;
+- exhaustive active-document ADR-0001 search results and classification;
+- the corrected Publisher Services Stage 0 achieved/outstanding evidence and
+  preservation of all genuine rollout blockers;
 - remaining blockers and the absence of implementation/readiness claims;
 - absence of runtime, migration, workflow, issue, deployment, release and
   production changes;

--- a/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+++ b/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
@@ -1,8 +1,11 @@
 # ADR-0001 - Publisher Package Capability Model
 
-Status: PROPOSED
+Status: APPROVED
 Date: 2026-07-24
 Decision owner: CTO
+Approved by: Javi, CTO
+Approval date: 2026-07-28
+Approval PR: [#772](https://github.com/thoth-pub/thoth/pull/772)
 Programmes affected: Publisher Services, Thoth Metrics, OAI-PMH
 Repositories affected: `thoth`, `thoth-app`, `thoth-sphinx`, `metrics-dashboard`, `metrics-widget`
 Supersedes: None
@@ -156,11 +159,18 @@ Every package and capability pair must be covered by tests.
 
 Feature code calls `has_capability`. It must not compare package names directly except inside the mapping implementation or its tests.
 
-The normative proposed matrix is:
+The normative approved matrix is:
 
 ```text
 docs/engineering/decisions/package-capability-matrix.md
 ```
+
+| Package | OAI_PMH | METRICS_COLLECT | METRICS_IMPORT | METRICS_DASHBOARD | METRICS_WIDGET | METRICS_OPERAS_EXPORT |
+|---|---:|---:|---:|---:|---:|---:|
+| OASIS | No | No | No | No | No | No |
+| OBELISK | Yes | Yes | No | No | No | No |
+| SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
+| PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
 
 ### 4.3 Capability set
 
@@ -219,6 +229,19 @@ Actual operation may additionally require:
 - schedules;
 - rollout approval.
 
+A package capability never fabricates operational configuration or metric data.
+In particular:
+
+- OASIS has no managed collection capability because Thoth does not distribute
+  OASIS files and therefore has no managed usage-data source for those
+  publishers;
+- OBELISK background collection is private and may run only when a valid source
+  account, credentials and source-specific operational configuration exist;
+- missing OBELISK source configuration, source outages, retries, reconciliation
+  and collection failures must not block distribution, metadata, package changes
+  or other unrelated publisher services;
+- missing or unavailable metric data must not be treated as zero.
+
 ### 4.7 Upgrade and downgrade
 
 The upgrade and downgrade semantics in `package-capability-matrix.md` are part of this decision.
@@ -227,7 +250,14 @@ In particular:
 
 - retained canonical metrics may become visible when serving capability is gained;
 - a package upgrade does not automatically bulk-export historical metrics to OPERAS;
-- a downgrade does not delete canonical metrics;
+- historical OPERAS export requires a separately scoped, reviewed and explicitly
+  activated backfill;
+- a downgrade to OBELISK stops publisher import, dashboard, widget and OPERAS
+  export behaviour, while validly configured private background collection may
+  continue;
+- a downgrade to OASIS stops Thoth-managed collection as well as publisher
+  import, dashboard, widget and OPERAS export behaviour;
+- neither downgrade deletes retained canonical metrics;
 - package changes never modify distribution-platform assignments.
 
 ## 5. Consequences
@@ -250,9 +280,11 @@ In particular:
 
 ### Risks
 
-- The proposed matrix may not match final commercial packaging.
-- `METRICS_COLLECT` for all packages has storage and operational cost.
-- Treating PYRAMID as cumulative with SPHINX must be confirmed.
+- OBELISK private collection has storage and operational cost even though the
+  package has no metrics serving, import or export capability.
+- Missing source configuration or source outages could accidentally couple
+  collection to unrelated operations unless the non-blocking invariant is
+  enforced.
 - In-flight work could cross a downgrade unless entitlement is rechecked.
 
 ## 6. Invariants created by this decision
@@ -265,6 +297,10 @@ In particular:
 6. Historical OPERAS export is an explicit operation, not an upgrade side effect.
 7. Publisher users cannot mutate their package.
 8. Capability mappings are identical across environments running the same version.
+9. OASIS has no managed metrics collection.
+10. OBELISK collection remains private, configured and non-blocking for
+    unrelated operations.
+11. Missing or unavailable metric data is not fabricated or treated as zero.
 
 ## 7. Implementation impact
 
@@ -332,8 +368,8 @@ Rollback:
 ## 10. Approval
 
 Approval required from: CTO
-Approved by:
-Approval date:
-Notes:
-
-The CTO must complete the checklist in `package-capability-matrix.md` before changing this ADR to `APPROVED`.
+Approved by: Javi, CTO
+Approval date: 2026-07-28
+Approval PR: [#772](https://github.com/thoth-pub/thoth/pull/772)
+Notes: Approved with the final matrix and operational decisions recorded above.
+This approval does not state that implementation has started or completed.

--- a/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
+++ b/docs/engineering/decisions/ADR-0001-publisher-package-capability-model.md
@@ -232,15 +232,27 @@ Actual operation may additionally require:
 A package capability never fabricates operational configuration or metric data.
 In particular:
 
-- OASIS has no managed collection capability because Thoth does not distribute
-  OASIS files and therefore has no managed usage-data source for those
-  publishers;
+- OASIS has no `METRICS_COLLECT` capability as an independent package
+  entitlement; under current operations Thoth has no managed OASIS usage-data
+  source because it does not operationally distribute OASIS files;
 - OBELISK background collection is private and may run only when a valid source
   account, credentials and source-specific operational configuration exist;
 - missing OBELISK source configuration, source outages, retries, reconciliation
   and collection failures must not block distribution, metadata, package changes
   or other unrelated publisher services;
 - missing or unavailable metric data must not be treated as zero.
+
+The current absence of a managed OASIS metrics source does not create a
+package-to-platform rule. This ADR does not disable or remove OASIS
+distribution-platform assignments, prevent a superuser from configuring
+platforms, define dissemination eligibility, create a distribution capability or
+change distribution-job behaviour. Any permanent rule that OASIS publishers
+cannot be distributed requires a separately approved Publisher Services
+decision through ADR-01 or another cross-programme ADR.
+
+Metrics collection must not infer entitlement from the presence of a
+distribution-platform assignment or remote location. It must check the package's
+`METRICS_COLLECT` capability directly.
 
 ### 4.7 Upgrade and downgrade
 
@@ -252,13 +264,19 @@ In particular:
 - a package upgrade does not automatically bulk-export historical metrics to OPERAS;
 - historical OPERAS export requires a separately scoped, reviewed and explicitly
   activated backfill;
-- a downgrade to OBELISK stops publisher import, dashboard, widget and OPERAS
-  export behaviour, while validly configured private background collection may
-  continue;
-- a downgrade to OASIS stops Thoth-managed collection as well as publisher
-  import, dashboard, widget and OPERAS export behaviour;
-- neither downgrade deletes retained canonical metrics;
-- package changes never modify distribution-platform assignments.
+- every package change is evaluated using the resulting package's capabilities;
+- `PYRAMID -> SPHINX` removes no initial capability: collection, import,
+  dashboard, widget, OAI-PMH and eligible OPERAS export remain permitted subject
+  to their normal configuration, authorization and rollout requirements;
+- `SPHINX` or `PYRAMID -> OBELISK` retains OAI-PMH and validly configured private
+  collection, while publisher import, dashboard, widget and OPERAS export are
+  denied because the resulting package lacks those capabilities;
+- any package `-> OASIS` denies all six initial capabilities and stops
+  Thoth-managed collection;
+- every downgrade retains canonical metrics and leaves distribution-platform
+  assignments unchanged;
+- in-flight work rechecks the relevant capability at its final write, serving or
+  delivery boundary and fails closed if the resulting package lacks it.
 
 ## 5. Consequences
 
@@ -285,22 +303,29 @@ In particular:
 - Missing source configuration or source outages could accidentally couple
   collection to unrelated operations unless the non-blocking invariant is
   enforced.
-- In-flight work could cross a downgrade unless entitlement is rechecked.
+- In-flight work could cross a package change unless the relevant capability is
+  rechecked at its final boundary.
 
 ## 6. Invariants created by this decision
 
 1. Package capability checks are centralized in Thoth.
 2. Feature code does not hardcode package-name combinations.
-3. Package changes do not change distribution assignments.
+3. Package changes do not change distribution assignments, distribution-job
+   eligibility or dissemination behaviour.
 4. Capabilities do not bypass authorization or feature-specific configuration.
 5. Canonical metrics are not deleted on downgrade.
 6. Historical OPERAS export is an explicit operation, not an upgrade side effect.
 7. Publisher users cannot mutate their package.
 8. Capability mappings are identical across environments running the same version.
-9. OASIS has no managed metrics collection.
+9. OASIS has no `METRICS_COLLECT` entitlement. The current absence of a managed
+   OASIS source does not define a permanent distribution rule.
 10. OBELISK collection remains private, configured and non-blocking for
     unrelated operations.
 11. Missing or unavailable metric data is not fabricated or treated as zero.
+12. Metrics collection does not infer entitlement from distribution assignments
+    or remote locations.
+13. Package changes are evaluated using the resulting package's capabilities,
+    and in-flight work rechecks the relevant capability at its final boundary.
 
 ## 7. Implementation impact
 
@@ -342,8 +367,17 @@ Required evidence:
 - exhaustive package/capability unit test;
 - migration tests for existing and new publishers;
 - authorization tests;
-- downgrade and upgrade tests;
+- `PYRAMID -> SPHINX` test proving no initial capability is removed;
+- downgrade-to-OBELISK test proving only OAI-PMH and configured private
+  collection remain permitted;
+- downgrade-to-OASIS test proving all six initial capabilities are denied and
+  Thoth-managed collection stops;
+- tests proving every downgrade retains canonical history;
 - tests proving distribution assignments are unchanged;
+- tests proving in-flight work rechecks the relevant capability at its final
+  boundary;
+- tests proving metrics collection does not infer entitlement from distribution
+  assignments or remote locations;
 - tests proving metrics and OAI call capability methods;
 - test proving no automatic historical export is created;
 - GraphQL compatibility review.

--- a/docs/engineering/decisions/decision-register.md
+++ b/docs/engineering/decisions/decision-register.md
@@ -2,11 +2,11 @@
 
 Status: ACTIVE
 Owner: CTO
-Last updated: 2026-07-27
+Last updated: 2026-07-28
 
 | ADR | Decision | Status | Programmes | Approval blocker |
 |---|---|---|---|---|
-| `ADR-0001` | Publisher package capability model | PROPOSED | Publisher Services, Thoth Metrics, OAI-PMH | CTO approval of ownership, matrix and upgrade/export semantics |
+| `ADR-0001` | Publisher package capability model | APPROVED | Publisher Services, Thoth Metrics, OAI-PMH | Satisfied - CTO approved the final package matrix, OASIS/OBELISK collection distinction and upgrade/downgrade/export semantics on 2026-07-28 through PR [#772](https://github.com/thoth-pub/thoth/pull/772) |
 | `ADR-0002` | Distribution and metrics platform domain boundaries | APPROVED | Publisher Services, Thoth Metrics | Satisfied - CTO approved strict type separation and no initial cross-domain mapping on 2026-07-27 through PR [#769](https://github.com/thoth-pub/thoth/pull/769) |
 
 ## Merge and implementation rules
@@ -23,7 +23,7 @@ No implementation task may rely on them until:
 
 ## Approval sequence
 
-Approve `ADR-0001` before:
+Merge the independently approved `ADR-0001` approval PR before:
 
 - Publisher Services `BE-01`;
 - metrics entitlement implementation;

--- a/docs/engineering/decisions/package-capability-matrix.md
+++ b/docs/engineering/decisions/package-capability-matrix.md
@@ -1,8 +1,11 @@
 # Package Capability Matrix
 
-Status: PROPOSED
-Normative owner after approval: `ADR-0001`
+Status: APPROVED
+Normative owner: `ADR-0001`
 Decision owner: CTO
+Approved by: Javi, CTO
+Approval date: 2026-07-28
+Approval PR: [#772](https://github.com/thoth-pub/thoth/pull/772)
 
 ## 1. Package order
 
@@ -32,38 +35,48 @@ This matrix does not make package selection imply distribution-platform assignme
 
 Capability codes are stable API identifiers. Display labels are separate.
 
-## 3. Recommended initial mapping
+## 3. Approved initial mapping
 
 | Package | OAI_PMH | METRICS_COLLECT | METRICS_IMPORT | METRICS_DASHBOARD | METRICS_WIDGET | METRICS_OPERAS_EXPORT |
 |---|---:|---:|---:|---:|---:|---:|
-| OASIS | No | Yes | No | No | No | No |
+| OASIS | No | No | No | No | No | No |
 | OBELISK | Yes | Yes | No | No | No | No |
 | SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
 | PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
 
 ## 4. Rationale
 
-### Collection for every package
+### OASIS has no managed collection
 
-`METRICS_COLLECT` is an internal collection permission, not a promise that metrics are served or exported.
+Thoth does not distribute OASIS files and therefore has no managed usage-data
+source for OASIS publishers. OASIS has no `METRICS_COLLECT` capability, and the
+system must not fabricate data or treat missing data as zero.
+
+### Private, non-blocking OBELISK collection
+
+OBELISK permits private background collection but does not permit publisher
+import, dashboard serving, widget serving or OPERAS export.
 
 Collection still requires all of:
 
 - an enabled metric source account;
+- valid source credentials;
 - an enabled platform/measure mapping;
 - direct collection configured for that mapping;
 - an enabled operational schedule;
 - successful source-specific validation.
 
-Giving every package `METRICS_COLLECT` allows Thoth to retain history without exposing a paid service before entitlement.
-
-If this operational cost is not acceptable, the CTO may remove it from OASIS and/or OBELISK before approval.
+OBELISK collection is operationally non-blocking. Missing configuration, source
+outages, retries, reconciliation and collection failures must not block
+distribution, metadata, package changes or other unrelated publisher services.
+Non-blocking does not mean unconfigured collection.
 
 ### SPHINX and PYRAMID metrics access
 
-The recommendation treats PYRAMID as including the metrics capabilities of SPHINX.
-
-If PYRAMID is intended to be a separate non-cumulative product rather than the highest package, its row must be amended before approval.
+SPHINX has every initial metrics capability. PYRAMID includes all SPHINX metrics
+capabilities. Both packages permit collection, publisher import, dashboard and
+widget serving, and OPERAS export when the additional configuration,
+authorization and rollout requirements are satisfied.
 
 ### OAI-PMH
 
@@ -93,7 +106,7 @@ A package capability alone must never:
 
 ## 6. Upgrade behaviour
 
-Recommended behaviour:
+Approved behaviour:
 
 - changing to SPHINX or PYRAMID enables dashboard and widget access to retained canonical history;
 - existing retained history is not rewritten;
@@ -114,10 +127,11 @@ Historical OPERAS export requires a separate, bounded, reviewed administrative b
 
 ## 7. Downgrade behaviour
 
-Recommended behaviour:
+Approved behaviour:
 
 - canonical metric history is retained;
-- collection may continue while `METRICS_COLLECT` remains present;
+- on downgrade to OBELISK, validly configured private collection may continue;
+- on downgrade to OASIS, Thoth-managed collection stops;
 - new publisher imports are denied;
 - dashboard and widget service responses are denied;
 - no new OPERAS export work is created or delivered;
@@ -148,10 +162,17 @@ It must also test:
 
 The CTO must explicitly confirm:
 
-- [ ] OASIS has `METRICS_COLLECT`.
-- [ ] OBELISK has `METRICS_COLLECT` but no metrics serving/import/export.
-- [ ] SPHINX has all metrics capabilities.
-- [ ] PYRAMID includes all SPHINX metrics capabilities.
-- [ ] Retained history becomes visible after upgrade.
-- [ ] Historical OPERAS export requires an explicit backfill.
-- [ ] Downgrade retains canonical data and does not change distribution assignments.
+- [x] OASIS has no `METRICS_COLLECT` capability because Thoth has no managed
+  OASIS usage-data source.
+- [x] OBELISK has `METRICS_COLLECT` but no metrics serving/import/export.
+- [x] OBELISK collection is configured, private and non-blocking for unrelated
+  operations.
+- [x] SPHINX has all metrics capabilities.
+- [x] PYRAMID includes all SPHINX metrics capabilities.
+- [x] Retained history becomes visible after upgrade.
+- [x] Historical OPERAS export requires an explicit backfill.
+- [x] Downgrade retains canonical data and does not change distribution assignments.
+
+Approved by: Javi, CTO
+
+Approval date: 2026-07-28

--- a/docs/engineering/decisions/package-capability-matrix.md
+++ b/docs/engineering/decisions/package-capability-matrix.md
@@ -46,11 +46,19 @@ Capability codes are stable API identifiers. Display labels are separate.
 
 ## 4. Rationale
 
-### OASIS has no managed collection
+### OASIS entitlement and current operational context
 
-Thoth does not distribute OASIS files and therefore has no managed usage-data
-source for OASIS publishers. OASIS has no `METRICS_COLLECT` capability, and the
-system must not fabricate data or treat missing data as zero.
+OASIS has no `METRICS_COLLECT` capability as an independent package-entitlement
+decision. Under current operations Thoth has no managed OASIS usage-data source
+because it does not operationally distribute OASIS files. The system must not
+fabricate data or treat missing data as zero.
+
+That operational context does not create a package-to-platform rule. ADR-0001
+does not disable or remove OASIS distribution-platform assignments, prevent a
+superuser from configuring platforms, define dissemination eligibility, create a
+distribution capability or change distribution-job behaviour. Any permanent
+rule that OASIS publishers cannot be distributed requires a separately approved
+Publisher Services decision through ADR-01 or another cross-programme ADR.
 
 ### Private, non-blocking OBELISK collection
 
@@ -104,6 +112,10 @@ A package capability alone must never:
 - bypass publisher-platform upload approval;
 - bypass work-level licence or lifecycle checks.
 
+Metrics collection must not infer entitlement from a distribution-platform
+assignment or remote location. It must check `METRICS_COLLECT` on the current
+package.
+
 ## 6. Upgrade behaviour
 
 Approved behaviour:
@@ -129,16 +141,22 @@ Historical OPERAS export requires a separate, bounded, reviewed administrative b
 
 Approved behaviour:
 
-- canonical metric history is retained;
-- on downgrade to OBELISK, validly configured private collection may continue;
-- on downgrade to OASIS, Thoth-managed collection stops;
-- new publisher imports are denied;
-- dashboard and widget service responses are denied;
-- no new OPERAS export work is created or delivered;
-- distribution assignments remain unchanged;
-- no canonical records are deleted.
+Every package change is evaluated using the resulting package's capabilities:
 
-In-flight work must re-check entitlement at the final write/delivery boundary and fail closed.
+- `PYRAMID -> SPHINX` removes no initial capability. Collection, publisher
+  import, dashboard, widget, OAI-PMH and eligible OPERAS export remain permitted
+  subject to their normal configuration, authorization and rollout
+  requirements.
+- `SPHINX` or `PYRAMID -> OBELISK` retains OAI-PMH and validly configured private
+  collection. Publisher import, dashboard, widget and OPERAS export are denied
+  because OBELISK lacks those capabilities.
+- any package `-> OASIS` denies all six initial capabilities and stops
+  Thoth-managed collection.
+
+Every downgrade retains canonical metric history and leaves
+distribution-platform assignments unchanged. In-flight work must re-check the
+relevant capability at its final write, serving or delivery boundary and fail
+closed if the resulting package lacks it.
 
 ## 8. Implementation tests
 
@@ -156,14 +174,22 @@ It must also test:
 - OAI eligibility uses `OAI_PMH` plus licence/lifecycle checks;
 - retained metrics remain inaccessible without dashboard/widget capability;
 - upgrade does not enqueue uncontrolled historical OPERAS exports;
-- downgrade stops new protected serving/export without deleting data.
+- `PYRAMID -> SPHINX` removes no initial capability;
+- downgrade to OBELISK retains OAI-PMH and configured private collection while
+  denying import, dashboard, widget and OPERAS export;
+- downgrade to OASIS denies all six initial capabilities and stops managed
+  collection;
+- every downgrade retains canonical history and distribution assignments;
+- in-flight work rechecks the relevant capability at its final boundary;
+- metrics collection does not infer entitlement from distribution assignments
+  or remote locations.
 
 ## 9. Approval checklist
 
 The CTO must explicitly confirm:
 
-- [x] OASIS has no `METRICS_COLLECT` capability because Thoth has no managed
-  OASIS usage-data source.
+- [x] OASIS has no `METRICS_COLLECT` entitlement; the absence of a managed OASIS
+  source is current operational context and not a package-to-platform rule.
 - [x] OBELISK has `METRICS_COLLECT` but no metrics serving/import/export.
 - [x] OBELISK collection is configured, private and non-blocking for unrelated
   operations.
@@ -172,6 +198,9 @@ The CTO must explicitly confirm:
 - [x] Retained history becomes visible after upgrade.
 - [x] Historical OPERAS export requires an explicit backfill.
 - [x] Downgrade retains canonical data and does not change distribution assignments.
+- [x] `PYRAMID -> SPHINX` removes no initial capability.
+- [x] Package changes use resulting capabilities and recheck in-flight work at
+  the final boundary.
 
 Approved by: Javi, CTO
 

--- a/docs/engineering/repository-map/control-gaps.md
+++ b/docs/engineering/repository-map/control-gaps.md
@@ -35,14 +35,17 @@ Use verified actual branches until normalization or explicit exceptions complete
 
 App, Sphinx, dashboard, widget and cc-license remain outstanding. Dissemination has incomplete controls.
 
-### CG-06 - Shared ADR-0001 remains proposed
+### CG-06 - Shared ADR approvals (RESOLVED 2026-07-28)
 
 ADR-0002 was approved by the CTO on 2026-07-27 and recorded as `APPROVED` through
 approval PR [#769](https://github.com/thoth-pub/thoth/pull/769); its independent
-review and merge close this part of the gate. ADR-0001 remains the unresolved
-shared-ADR gate and requires explicit CTO approval and independent review before
-its dependent implementation. Approving ADR-0002 removes one dependency and does
-not make any implementation task ready.
+review and merge close this part of the gate. ADR-0001 was approved by the CTO on
+2026-07-28 with the final OASIS/OBELISK collection distinction and recorded
+through approval PR [#772](https://github.com/thoth-pub/thoth/pull/772).
+Dependent implementation still requires PR #772 to merge after fresh independent
+review, plus each task's own approved bounded specification and remaining
+programme controls. Resolving this shared-ADR gap does not make any implementation
+task ready.
 
 ### CG-07 - Publisher Services platform ADR open
 

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -105,6 +105,12 @@ BLOCKED FOR IMPLEMENTATION
 
 Achieved:
 
+- `ADR-0001` publisher package capabilities is `APPROVED` (Javi, CTO,
+  2026-07-28, approval PR
+  [#772](https://github.com/thoth-pub/thoth/pull/772)); the independently
+  reviewed approval record is pending merge. It establishes the
+  package-capability model without starting metrics collection, entitlement
+  enforcement, serving, imports or exports.
 - `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
   PR [#769](https://github.com/thoth-pub/thoth/pull/769)) and is no longer a
   blocking control. `MetricPlatform` remains separate from `DistributionPlatform`
@@ -118,15 +124,15 @@ Blocking controls:
    `bac598e32abbd0d7e69ff467c82945ee00df02ba`, closing P0-01. The Metrics
    programme control task `MET-CTRL-01` nevertheless remains `CHANGES REQUIRED`
    and is not yet closed.
-2. `ADR-0001` is `PROPOSED`.
-3. `thoth-sphinx` is placeholder-only and has not been bootstrapped.
-4. Thoth Diesel generation procedure is unresolved.
-5. Branch topology differs in Sphinx and client repositories.
-6. Service-role codes require approval before WP5.
-7. Representative source fixtures and COUNTER mappings are missing for source-specific work.
-8. Guaranteed OPERAS inbound discovery is unavailable.
+2. `thoth-sphinx` is placeholder-only and has not been bootstrapped.
+3. Thoth Diesel generation procedure is unresolved.
+4. Branch topology differs in Sphinx and client repositories.
+5. Service-role codes require approval before WP5.
+6. Representative source fixtures and COUNTER mappings are missing for source-specific work.
+7. Guaranteed OPERAS inbound discovery is unavailable.
 
 Discovery, benchmarking, fixture collection and task specification may continue.
+ADR-0001 approval does not mark WP1 or any later work package ready.
 
 ## 7. Files
 

--- a/docs/metrics/decisions.md
+++ b/docs/metrics/decisions.md
@@ -1,7 +1,7 @@
 # Thoth Metrics Decision Summary
 
 Status: ACTIVE SUMMARY
-Last updated: 2026-07-24
+Last updated: 2026-07-28
 Owner: CTO
 
 The approved technical design and approved ADRs remain authoritative.
@@ -49,7 +49,37 @@ Outbound uses durable Thoth claims. Sphinx delivers idempotently. Direct mapping
 
 ## 2. Shared decisions
 
-`ADR-0001` remains `PROPOSED`. It is required for entitlements, serving, imports, export and collection policy.
+`ADR-0001` is `APPROVED` (Javi, CTO, 2026-07-28, approval PR
+[#772](https://github.com/thoth-pub/thoth/pull/772)). It establishes the
+code-owned exhaustive package-capability model for later entitlement, serving,
+import, export and collection tasks:
+
+| Package | OAI_PMH | METRICS_COLLECT | METRICS_IMPORT | METRICS_DASHBOARD | METRICS_WIDGET | METRICS_OPERAS_EXPORT |
+|---|---:|---:|---:|---:|---:|---:|
+| OASIS | No | No | No | No | No | No |
+| OBELISK | Yes | Yes | No | No | No | No |
+| SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
+| PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
+
+OASIS collection is excluded because Thoth does not distribute OASIS files and
+has no managed usage-data source for those publishers. OBELISK collection is
+private: there is no publisher import, dashboard serving, widget serving or
+OPERAS export. It requires a valid source account, credentials and
+source-specific configuration, and missing configuration, source outages,
+retries, reconciliation or collection failure must not block unrelated
+distribution, metadata, package-change or publisher-service operations. Missing
+data is not zero.
+
+Retained canonical history becomes available after an upgrade only when the new
+package grants the relevant serving capability. Historical OPERAS export
+requires a separately scoped, reviewed and explicitly activated backfill.
+Downgrades retain canonical history and stop newly prohibited behaviour;
+validly configured private collection may continue after downgrade to OBELISK,
+while managed collection stops after downgrade to OASIS. Package changes never
+modify distribution-platform assignments.
+
+This approval settles the shared matrix but does not start implementation or
+make any Metrics work package ready.
 
 `ADR-0002` is `APPROVED` (CTO, 2026-07-27, approval PR [#769](https://github.com/thoth-pub/thoth/pull/769)) as written, and is required for metric platform implementation. `MetricPlatform` remains a separate domain type from `DistributionPlatform`, with no name-based conversion and no initial cross-domain mapping.
 
@@ -95,3 +125,6 @@ Select report types and metric mappings only after representative reports are su
 8. Sphinx runs are restartable.
 9. Every row receives an explicit classification.
 10. Every source mapping is versioned and deterministic.
+11. OBELISK collection failures and missing configuration do not block unrelated
+    operations.
+12. Missing or unavailable metric data is never fabricated or treated as zero.

--- a/docs/metrics/decisions.md
+++ b/docs/metrics/decisions.md
@@ -61,11 +61,20 @@ import, export and collection tasks:
 | SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
 | PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
 
-OASIS collection is excluded because Thoth does not distribute OASIS files and
-has no managed usage-data source for those publishers. OBELISK collection is
-private: there is no publisher import, dashboard serving, widget serving or
-OPERAS export. It requires a valid source account, credentials and
-source-specific configuration, and missing configuration, source outages,
+OASIS has no `METRICS_COLLECT` entitlement. Under current operations Thoth has no
+managed OASIS usage-data source because it does not operationally distribute
+OASIS files. That context does not create a package-to-platform rule: ADR-0001
+does not disable or remove OASIS distribution assignments, prevent superuser
+platform configuration, define dissemination eligibility, create a distribution
+capability or change distribution-job behaviour. Any permanent OASIS
+distribution prohibition requires a separately approved Publisher Services
+decision through ADR-01 or another cross-programme ADR.
+
+Metrics collection must check `METRICS_COLLECT` on the current package and must
+not infer entitlement from a distribution assignment or remote location.
+OBELISK collection is private: there is no publisher import, dashboard serving,
+widget serving or OPERAS export. It requires a valid source account, credentials
+and source-specific configuration, and missing configuration, source outages,
 retries, reconciliation or collection failure must not block unrelated
 distribution, metadata, package-change or publisher-service operations. Missing
 data is not zero.
@@ -73,10 +82,19 @@ data is not zero.
 Retained canonical history becomes available after an upgrade only when the new
 package grants the relevant serving capability. Historical OPERAS export
 requires a separately scoped, reviewed and explicitly activated backfill.
-Downgrades retain canonical history and stop newly prohibited behaviour;
-validly configured private collection may continue after downgrade to OBELISK,
-while managed collection stops after downgrade to OASIS. Package changes never
-modify distribution-platform assignments.
+Every package change uses the resulting package's capabilities:
+
+- `PYRAMID -> SPHINX` removes no initial capability; collection, import,
+  dashboard, widget, OAI-PMH and eligible OPERAS export remain subject to normal
+  configuration, authorization and rollout requirements;
+- `SPHINX` or `PYRAMID -> OBELISK` retains OAI-PMH and validly configured private
+  collection while denying publisher import, dashboard, widget and OPERAS
+  export;
+- any package `-> OASIS` denies all six initial capabilities and stops
+  Thoth-managed collection;
+- every downgrade retains canonical history, leaves distribution-platform
+  assignments unchanged and rechecks the relevant capability at the final
+  boundary.
 
 This approval settles the shared matrix but does not start implementation or
 make any Metrics work package ready.

--- a/docs/metrics/task-status.md
+++ b/docs/metrics/task-status.md
@@ -4,7 +4,7 @@ Status: ACTIVE TRACKER
 Programme owner: CTO
 Master issue: [#766](https://github.com/thoth-pub/thoth/issues/766)
 Approved design: [private Google Doc](https://docs.google.com/document/d/11AeQFGpm0kUZajBM5PrAqsttmzJlpUrt89tGYyVM8c0/edit), Drive revision `6`
-Last updated: 2026-07-27
+Last updated: 2026-07-28
 
 ## 1. Control rule
 
@@ -15,7 +15,7 @@ A work package is not one implementation task. Each must be decomposed into boun
 | Task | Repository | Risk | Status | Base / target | Dependencies | Issue |
 |---|---|---:|---|---|---|---|
 | MET-CTRL-01 Programme controls | `thoth` | LOW | CHANGES REQUIRED | PR #764 merged into `develop` as `5b406e4ef9b5c192cc38eb8a97a41bbd0fc3bc06` | Shared foundation closed (P0-01 closeout PR #767 independently `APPROVED` and merged as `bac598e32abbd0d7e69ff467c82945ee00df02ba`); MET-CTRL-01's own `CHANGES REQUIRED` remediation outstanding | [#766](https://github.com/thoth-pub/thoth/issues/766) |
-| ADR-0001 Package capability model | `thoth` | MEDIUM | PROPOSED | `develop` - proposal introduced by merged PR #764 | CTO decision | #766 |
+| ADR-0001 Package capability model | `thoth` | MEDIUM | APPROVED | `develop` - proposal introduced by merged PR #764 | CTO approved 2026-07-28; approval PR [#772](https://github.com/thoth-pub/thoth/pull/772) | #766 |
 | ADR-0002 Platform boundaries | `thoth` | MEDIUM | APPROVED | `develop` - proposal introduced by merged PR #764 | CTO approved 2026-07-27; approval PR [#769](https://github.com/thoth-pub/thoth/pull/769) | #766 |
 | SPHINX-BOOT-01 Repository bootstrap | `thoth-sphinx` | MEDIUM | BLOCKED | current `develop`; target `develop` after BR-SPHINX-01 verification | MET-CTRL-01; BR-SPHINX-01; approved bootstrap spec | #766 |
 | THOTH-DB-CTRL-01 Diesel generation procedure | `thoth` | MEDIUM | BLOCKED | `develop` -> `develop` | verified procedure | #766 |
@@ -27,11 +27,11 @@ A work package is not one implementation task. Each must be decomposed into boun
 
 | WP | Scope | Repositories | Risk | Status | Blocking dependencies | Issue |
 |---|---|---|---:|---|---|---|
-| WP1 | Domain and database foundation | `thoth` | HIGH | BLOCKED | MET-CTRL-01; ADR-0001; Diesel control | #766 |
+| WP1 | Domain and database foundation | `thoth` | HIGH | BLOCKED | MET-CTRL-01; Diesel control; approved bounded slice specification | #766 |
 | WP2 | Canonical ingestion | `thoth` | CRITICAL | BLOCKED | WP1 | #766 |
-| WP3 | Upload API and publisher UI | `thoth`, app | HIGH | BLOCKED | WP1/WP2; ADR-0001; BR-APP-01 | #766 |
+| WP3 | Upload API and publisher UI | `thoth`, app | HIGH | BLOCKED | WP1/WP2; BR-APP-01; approved bounded slice specifications | #766 |
 | WP4 | Rollups and GraphQL | `thoth` | HIGH | BLOCKED | WP1/WP2; benchmark dataset | #766 |
-| WP5 | Service auth and entitlements | `thoth`, clients | CRITICAL | BLOCKED | ADR-0001; role decision; WP4 | #766 |
+| WP5 | Service auth and entitlements | `thoth`, clients | CRITICAL | BLOCKED | role decision; WP4; approved bounded slice specifications | #766 |
 | WP6 | Sphinx core | `thoth-sphinx` | HIGH | BLOCKED | bootstrap; pinned API contract | #766 |
 | WP7 | CloudFront driver | `thoth-sphinx` | HIGH | BLOCKED | WP6; fixtures; methodology confirmation | #766 |
 | WP8 | Additional drivers and COUNTER | Sphinx/app | HIGH | BLOCKED | WP6; source fixtures; COUNTER decision | #766 |
@@ -39,6 +39,12 @@ A work package is not one implementation task. Each must be decomposed into boun
 | WP10 | Dashboard and widget clients | clients/Thoth | HIGH | BLOCKED | WP4/WP5; client CI/tests | #766 |
 | WP11 | Deployment, monitoring, migration | multiple | CRITICAL | BLOCKED | WP1-WP10 | #766 |
 | MET-E2E-01 | Integrated acceptance/cutover | multiple | CRITICAL | BLOCKED | all production slices | #766 |
+
+ADR-0001 approval removes one shared architectural dependency only. WP1 and
+every later work package remain blocked by their listed programme-control,
+Diesel, repository-readiness, design, fixture, contract and bounded-specification
+dependencies. `MET-CTRL-01` remains `CHANGES REQUIRED`; no Metrics
+implementation package is ready.
 
 ## 4. Branch strategy
 
@@ -59,10 +65,14 @@ verified base.
    `APPROVED` and merged as `bac598e32abbd0d7e69ff467c82945ee00df02ba`, closing
    P0-01, and the repository closeout record is reconciled. `MET-CTRL-01`
    remains `CHANGES REQUIRED` pending its own remediation.
-2. `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
+2. `ADR-0001` package capabilities is `APPROVED` (Javi, CTO, 2026-07-28,
+   approval PR [#772](https://github.com/thoth-pub/thoth/pull/772)); this removes
+   one shared architecture dependency and does not make WP1 or any later work
+   package ready.
+3. `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
    PR [#769](https://github.com/thoth-pub/thoth/pull/769)); this removes one
    shared-ADR dependency and does not make any work package ready.
-3. Approve or amend `ADR-0001`.
 4. Scope SPHINX-BOOT-01.
 5. Resolve THOTH-DB-CTRL-01.
-6. Prepare the first bounded WP1 slice only after those gates.
+6. Remediate `MET-CTRL-01`.
+7. Prepare and approve the first bounded WP1 slice only after those gates.

--- a/docs/publisher-services/README.md
+++ b/docs/publisher-services/README.md
@@ -73,6 +73,12 @@ BLOCKED FOR IMPLEMENTATION
 
 Achieved:
 
+- `ADR-0001` publisher package capabilities is `APPROVED` (Javi, CTO,
+  2026-07-28, approval PR
+  [#772](https://github.com/thoth-pub/thoth/pull/772)); the independently
+  reviewed approval record is pending merge. Approval preserves package and
+  distribution-platform independence and does not implement package storage,
+  capability enforcement or distribution behaviour.
 - `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
   PR [#769](https://github.com/thoth-pub/thoth/pull/769)). This removes one
   shared-ADR dependency and does not, by itself, make ADR-01, BE-02 or any other
@@ -89,15 +95,18 @@ Reasons still blocking:
    engineering-control foundation only; it does not approve an ADR, approve the
    final inventory, satisfy branch readiness, or make any implementation task
    ready. The remaining reasons below keep the programme blocked.
-2. `ADR-0001` package capability model is `PROPOSED`.
-3. Publisher Services `ADR-01` has not finalized or approved the
-   distribution-platform enum.
+2. Publisher Services `ADR-01` has not finalized or approved the
+   distribution-platform enum or final distribution-platform inventory.
+3. Task-specific approved specifications remain required, including for
+   `BE-01`.
 4. Branch-readiness tasks are required before work in repositories whose
    current topology differs from policy.
 
 Discovery, review and documentation may continue. P0-01 closure and ADR-0002
 approval do not authorize production implementation, which must not start until
 its applicable architecture, specification and branch-readiness gates pass.
+ADR-0001 approval does not authorize `BE-01`, `OAI-01` or any production
+implementation.
 
 ## 6. Files
 

--- a/docs/publisher-services/decisions.md
+++ b/docs/publisher-services/decisions.md
@@ -1,7 +1,7 @@
 # Publisher Services Decision Summary
 
 Status: ACTIVE SUMMARY
-Last updated: 2026-07-24
+Last updated: 2026-07-28
 Owner: CTO
 
 This file summarizes decisions. The approved technical design and approved ADRs remain authoritative.
@@ -71,22 +71,39 @@ This programme initially implements desired state and durable publisher back-cat
 
 ### ADR-0001 - Package capability model
 
-Status: `PROPOSED` - awaiting its separate CTO decision on ownership, the
-capability matrix and upgrade/export semantics.
+Status: `APPROVED` (Javi, CTO, 2026-07-28, approval PR
+[#772](https://github.com/thoth-pub/thoth/pull/772)).
 
-Proposes:
+Approved architecture:
 
 - code-owned exhaustive capability mappings;
-- metrics collection permitted independently of serving/export;
+- Thoth ownership and stable GraphQL capability codes;
+- no database capability rows or bespoke publisher overrides;
+- entitlement remains separate from source accounts, credentials and other
+  operational configuration;
 - retained metrics visible after an entitled upgrade;
 - no automatic historical OPERAS bulk export after upgrade;
+- downgrades retain canonical metrics and stop newly prohibited behaviour;
 - package changes never alter distribution assignments.
 
-Implementation dependency:
+The approved package matrix is:
 
-- `BE-01`
-- metrics entitlement tasks
-- `OAI-01`
+| Package | OAI_PMH | METRICS_COLLECT | METRICS_IMPORT | METRICS_DASHBOARD | METRICS_WIDGET | METRICS_OPERAS_EXPORT |
+|---|---:|---:|---:|---:|---:|---:|
+| OASIS | No | No | No | No | No | No |
+| OBELISK | Yes | Yes | No | No | No | No |
+| SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
+| PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
+
+Thoth has no managed OASIS collection source because it does not distribute
+OASIS files. OBELISK collection is private, requires valid source credentials
+and source-specific configuration, and must not block distribution, metadata,
+package changes or unrelated publisher services when configuration is missing or
+a source fails.
+
+Approval settles the shared architecture but does not start or complete `BE-01`,
+metrics entitlement work or `OAI-01`. Each remains subject to its own approved
+bounded specification and other tracker dependencies.
 
 ### ADR-0002 - Platform domain boundaries
 

--- a/docs/publisher-services/decisions.md
+++ b/docs/publisher-services/decisions.md
@@ -83,7 +83,8 @@ Approved architecture:
   operational configuration;
 - retained metrics visible after an entitled upgrade;
 - no automatic historical OPERAS bulk export after upgrade;
-- downgrades retain canonical metrics and stop newly prohibited behaviour;
+- package changes use the resulting package's capabilities, and downgrades
+  retain canonical metrics;
 - package changes never alter distribution assignments.
 
 The approved package matrix is:
@@ -95,11 +96,32 @@ The approved package matrix is:
 | SPHINX | Yes | Yes | Yes | Yes | Yes | Yes |
 | PYRAMID | Yes | Yes | Yes | Yes | Yes | Yes |
 
-Thoth has no managed OASIS collection source because it does not distribute
-OASIS files. OBELISK collection is private, requires valid source credentials
-and source-specific configuration, and must not block distribution, metadata,
-package changes or unrelated publisher services when configuration is missing or
-a source fails.
+OASIS is not entitled to Thoth-managed metrics collection. Under current
+operations Thoth has no managed OASIS usage-data source because it does not
+operationally distribute OASIS files. This metrics-entitlement decision does not
+disable or remove OASIS distribution-platform assignments, prevent superuser
+platform configuration, define dissemination eligibility, create a distribution
+capability or change distribution-job behaviour. Any permanent OASIS
+distribution prohibition requires a separately approved decision through ADR-01
+or another cross-programme ADR.
+
+Metrics collection must not infer entitlement from a distribution assignment or
+remote location. OBELISK collection is private, requires valid source
+credentials and source-specific configuration, and must not block distribution,
+metadata, package changes or unrelated publisher services when configuration is
+missing or a source fails.
+
+Package changes use the resulting package's capabilities:
+
+- `PYRAMID -> SPHINX` removes no initial capability;
+- `SPHINX` or `PYRAMID -> OBELISK` retains OAI-PMH and configured private
+  collection while denying publisher import, dashboard, widget and OPERAS
+  export;
+- any package `-> OASIS` denies all six initial capabilities and stops
+  Thoth-managed collection;
+- every downgrade retains canonical metric history, leaves distribution
+  assignments unchanged and rechecks the relevant capability at the final
+  boundary.
 
 Approval settles the shared architecture but does not start or complete `BE-01`,
 metrics entitlement work or `OAI-01`. Each remains subject to its own approved

--- a/docs/publisher-services/rollout-plan.md
+++ b/docs/publisher-services/rollout-plan.md
@@ -40,11 +40,14 @@ Achieved evidence:
   repository closeout; issue #765 remains open;
 - `ADR-0002` platform domain boundaries approved by the CTO on 2026-07-27
   (approval PR [#769](https://github.com/thoth-pub/thoth/pull/769)); this removes
-  one shared-ADR dependency and does not unlock implementation.
+  one shared-ADR dependency and does not unlock implementation;
+- `ADR-0001` publisher package capabilities approved by Javi, CTO, on
+  2026-07-28 through approval PR
+  [#772](https://github.com/thoth-pub/thoth/pull/772); this removes the shared
+  decision dependency and does not unlock Publisher Services implementation.
 
 Outstanding evidence:
 
-- ADR-0001 approval;
 - Publisher Services ADR-01 specification and final platform-inventory
   approval;
 - applicable repository/branch-readiness decisions;

--- a/docs/publisher-services/task-status.md
+++ b/docs/publisher-services/task-status.md
@@ -4,7 +4,7 @@ Status: ACTIVE TRACKER
 Programme owner: CTO
 Master issue: [#765](https://github.com/thoth-pub/thoth/issues/765)
 Approved design: [private Google Doc](https://docs.google.com/document/d/1kr2Ft0Y4pxgcXGyFAKs_wfFx4I0jlxEvaceswE5Dus8/edit), Drive revision `3`
-Last updated: 2026-07-27
+Last updated: 2026-07-28
 
 ## 1. Control rule
 
@@ -22,7 +22,7 @@ No task moves to `READY` without an approved specification, architecture depende
 | ADR-01 Platform inventory/final architecture | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | missing approved bounded ADR-01 specification; final distribution-platform inventory decision | #765 | TBD | NOT STARTED |
 | LIC-01 Expand `cc-license` | `cc-license` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; BR-LIC-01 or CTO exception; approved spec | #765 | TBD | NOT STARTED |
 | LIC-02 Enforce supported licences | `thoth` | HIGH | BLOCKED | `develop` / `develop` | LIC-01 release; production licence audit plan | #765 | TBD | NOT STARTED |
-| BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | P0-01; ADR-0001 approval | #765 | TBD | NOT STARTED |
+| BE-01 Publisher package model | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | its own approved bounded specification | #765 | TBD | NOT STARTED |
 | BE-02 Distribution platform model | `thoth` | HIGH | BLOCKED | `develop` / `develop` | ADR-01 | #765 | TBD | NOT STARTED |
 | BE-03 Protected service configuration | `thoth` | HIGH | BLOCKED | `develop` / `develop` | BE-01; BE-02 | #765 | TBD | NOT STARTED |
 | BE-04 Durable distribution jobs | `thoth` | HIGH | BLOCKED | `develop` / `develop` | BE-02; BE-03 | #765 | TBD | NOT STARTED |
@@ -33,7 +33,7 @@ No task moves to `READY` without an approved specification, architecture depende
 | DIS-01 API discovery/comparison | `thoth-dissemination` | HIGH | BLOCKED | `develop` / `develop` | BE-02; MIG-01; BR-DIS-01 or exception | #765 | TBD | NOT STARTED |
 | DIS-02 Back-catalogue worker | `thoth-dissemination` | CRITICAL | BLOCKED | `develop` / `develop` | BE-04; DIS-01 clean comparison; production controls | #765 | TBD | NOT STARTED |
 | EXP-01 OCLC KBART index | `thoth` | MEDIUM | BLOCKED | `develop` / `develop` | BE-02; ADR-01 OCLC decision | #765 | TBD | NOT STARTED |
-| OAI-01 Package/licence gating | `thoth` | HIGH | BLOCKED | fresh task branch; target decided after divergence review | BE-01; LIC-02; ADR-0001; resolve design/target-policy branch conflict | #765 | TBD | NOT STARTED |
+| OAI-01 Package/licence gating | `thoth` | HIGH | BLOCKED | fresh task branch; target decided after divergence review | BE-01; LIC-02; resolve design/target-policy branch conflict; its own approved bounded specification | #765 | TBD | NOT STARTED |
 | OPS-01 Monitoring/runbooks/cleanup | multiple | HIGH | BLOCKED | repository-local task branches | implemented components; runtime ownership | #765 | TBD | NOT STARTED |
 | E2E-01 Full workflow verification | multiple | HIGH | BLOCKED | controlled acceptance run | all activated components; pilot; rollback | #765 | TBD | NOT STARTED |
 
@@ -51,13 +51,18 @@ Each branch starts from the repository's verified development branch and targets
 
 ## 4. Next actions
 
-1. `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
+1. `ADR-0001` package capabilities is `APPROVED` (Javi, CTO, 2026-07-28,
+   approval PR [#772](https://github.com/thoth-pub/thoth/pull/772)); this settles
+   the shared matrix but does not make `BE-01`, `OAI-01` or any implementation
+   task ready;
+2. `ADR-0002` platform domain boundaries is `APPROVED` (CTO, 2026-07-27, approval
    PR [#769](https://github.com/thoth-pub/thoth/pull/769)); this removes one
-   shared-ADR dependency and does not approve architecture or unlock
+   shared-ADR dependency and does not approve ADR-01 or unlock
    implementation;
-2. approve or amend `ADR-0001` (immediate decision);
-3. prepare and approve the bounded ADR-01 specification before architecture
+3. prepare and approve the bounded `BE-01` specification before package-model
    implementation starts;
-4. finalize and approve the distribution-platform inventory through ADR-01;
-5. record repository-specific branch normalization or exceptions before
+4. prepare and approve the bounded ADR-01 specification before architecture
+   implementation starts;
+5. finalize and approve the distribution-platform inventory through ADR-01;
+6. record repository-specific branch normalization or exceptions before
    affected tasks.


### PR DESCRIPTION
## Summary

- approve ADR-0001 and the final publisher package capability matrix
- reconcile bounded Publisher Services, Metrics, and engineering-control records
- perform the first controlled CI-DOCS-01 documentation-only observation

## Scope

Documentation and control records only. No runtime, migration, API, workflow, issue, deployment, release, or production change.

## Review state

Draft. Fresh independent review and explicit CTO merge authorization are required. The implementing agent must not approve or merge.