### PR TITLE
Release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [[1.6.2]](https://github.com/thoth-pub/thoth/releases/tag/v1.6.2) - 2026-08-10
 ### Fixed
-  - [794](https://github.com/thoth-pub/thoth/pull/794) - Declare the `xlink` namespace on the Crossref DOI deposit root element (`CROSSREF_NS`), so deposits whose JATS abstract markup contains `<jats:ext-link xlink:href="...">` are no longer rejected by Crossref with "The prefix "xlink" for attribute "xlink:href" ... is not bound"
+  - [794](https://github.com/thoth-pub/thoth/pull/794) - Declare the `xlink` namespace on the Crossref DOI deposit root element (`CROSSREF_NS`), so the DOI deposit XML binds the `xlink` prefix required by JATS abstract links using `xlink:href`, and deposits whose abstract markup contains `<jats:ext-link xlink:href="...">` are no longer rejected by Crossref with "The prefix "xlink" for attribute "xlink:href" ... is not bound"
 
 ## [[1.6.1]](https://github.com/thoth-pub/thoth/releases/tag/v1.6.1) - 2026-07-23
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "thoth"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-api"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "actix-web",
  "aws-config",
@@ -5062,7 +5062,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-api-server"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-client"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "chrono",
  "graphql_client",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-errors"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "actix-web",
  "chrono",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-export-server"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -15,10 +15,10 @@ maintenance = { status = "actively-developed" }
 members = ["thoth-api", "thoth-api-server", "thoth-client", "thoth-errors", "thoth-export-server"]
 
 [dependencies]
-thoth-api = { version = "=1.6.1", path = "thoth-api", features = ["backend"] }
-thoth-api-server = { version = "=1.6.1", path = "thoth-api-server" }
-thoth-errors = { version = "=1.6.1", path = "thoth-errors" }
-thoth-export-server = { version = "=1.6.1", path = "thoth-export-server" }
+thoth-api = { version = "=1.6.2", path = "thoth-api", features = ["backend"] }
+thoth-api-server = { version = "=1.6.2", path = "thoth-api-server" }
+thoth-errors = { version = "=1.6.2", path = "thoth-errors" }
+thoth-export-server = { version = "=1.6.2", path = "thoth-export-server" }
 base64 = "0.22.1"
 clap = { version = "4.5.32", features = ["cargo", "env"] }
 dialoguer = { version = "0.11.0", features = ["password"] }

--- a/thoth-api-server/Cargo.toml
+++ b/thoth-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-api-server"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/thoth-pub/thoth"
 readme = "README.md"
 
 [dependencies]
-thoth-api = { version = "=1.6.1", path = "../thoth-api", features = ["backend"] }
-thoth-errors = { version = "=1.6.1", path = "../thoth-errors" }
+thoth-api = { version = "=1.6.2", path = "../thoth-api", features = ["backend"] }
+thoth-errors = { version = "=1.6.2", path = "../thoth-errors" }
 actix-web = "4.14.0"
 actix-cors = "0.7.1"
 actix-http = "3.13.1"

--- a/thoth-api/Cargo.toml
+++ b/thoth-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-api"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ backend = [
 ]
 
 [dependencies]
-thoth-errors = { version = "=1.6.1", path = "../thoth-errors" }
+thoth-errors = { version = "=1.6.2", path = "../thoth-errors" }
 actix-web = { version = "4.14.0", optional = true }
 isbn = "0.6.0"
 chrono = { version = "0.4.45", features = ["serde"] }

--- a/thoth-client/Cargo.toml
+++ b/thoth-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-client"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -10,8 +10,8 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-thoth-api = {version = "=1.6.1", path = "../thoth-api" }
-thoth-errors = {version = "=1.6.1", path = "../thoth-errors" }
+thoth-api = {version = "=1.6.2", path = "../thoth-api" }
+thoth-errors = {version = "=1.6.2", path = "../thoth-errors" }
 graphql_client = "0.14.0"
 chrono = { version = "0.4.45", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
@@ -22,4 +22,4 @@ serde_json = "1.0.150"
 uuid = { version = "1.23.4", features = ["serde"] }
 
 [build-dependencies]
-thoth-api = { version = "=1.6.1", path = "../thoth-api", features = ["backend"] }
+thoth-api = { version = "=1.6.2", path = "../thoth-api", features = ["backend"] }

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-errors"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/thoth-export-server/Cargo.toml
+++ b/thoth-export-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-export-server"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -10,9 +10,9 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-thoth-api = { version = "=1.6.1", path = "../thoth-api", features = ["backend"] }
-thoth-errors = { version = "=1.6.1", path = "../thoth-errors" }
-thoth-client = { version = "=1.6.1", path = "../thoth-client" }
+thoth-api = { version = "=1.6.2", path = "../thoth-api", features = ["backend"] }
+thoth-errors = { version = "=1.6.2", path = "../thoth-errors" }
+thoth-client = { version = "=1.6.2", path = "../thoth-client" }
 actix-web = "4.14.0"
 actix-cors = "0.7.1"
 cc_license = "0.1.0"


### PR DESCRIPTION
Release v1.6.2 — patch release carrying the Crossref `xlink` namespace hotfix ([#794](https://github.com/thoth-pub/thoth/pull/794)).

Contains only:

- **Version bump** `1.6.1` → `1.6.2` across all six workspace crates and their `=` pins (`bump patch`, i.e. `cargo workspaces version patch --no-git-commit --exact`, forced across all crates to preserve the repo's lockstep versioning);
- **Finalized changelog** for `1.6.2`, dated 2026-08-10, with the Crossref entry moved out of `[Unreleased]` (which remains in place for future changes).

No functional code changes beyond what is already on `master` via #794.

### Release base

Cut from `master`, **not** `develop`, so the unreleased major work currently on `develop` is not part of this release. `git merge-base --is-ancestor origin/develop HEAD` confirms no `develop` commits are reachable from this branch.

### Checks

```
cargo test -p thoth-export-server doideposit_crossref   # 8 passed
cargo test -p thoth-export-server                       # 144 passed (+2 doc-tests)
cargo test --workspace                                  # 1026 passed, 0 failed, 8 ignored
cargo fmt --all -- --check                              # clean
cargo clippy --all --all-targets --all-features -- -D warnings   # clean
```

After merge, `v1.6.2` will be tagged on `master` and `master` merged back into `develop` to forward-port the hotfix. The GitHub release will be created manually from the tag.
