### PR TITLE
REL-1.8.0-PREP-01: Prepare Thoth v1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [[1.8.0]](https://github.com/thoth-pub/thoth/releases/tag/v1.8.0) - 2026-08-29
 ### Added
   - `API-IMPORT-ORCID-BATCH-01`: additive `contributorsByOrcids(orcids: [Orcid!]!): [Contributor!]!` query resolving a bounded set of ORCIDs to contributors with a single set-based exact-equality lookup, allowing bulk-import clients to avoid one request per ORCID (issue [851](https://github.com/thoth-pub/thoth/issues/851), parent [850](https://github.com/thoth-pub/thoth/issues/850)). Values must be supplied in Thoth's stored representation (`https://orcid.org/XXXX-XXXX-XXXX-XXXX`); matching is exact, so partial identifiers never match, unknown ORCIDs are omitted, and each matching contributor is returned at most once. At most 1000 ORCIDs per request: a larger list returns a clear field error without truncating or querying the database, and an empty list returns `[]` without querying it either. `contributors(filter:)`, `contributor(id:)`, contributor writes, ORCID uniqueness, history and authorization are unchanged.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "thoth"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-api"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "actix-web",
  "aws-config",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-api-server"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-client"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "chrono",
  "graphql_client",
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-errors"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "actix-web",
  "chrono",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "thoth-export-server"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -15,10 +15,10 @@ maintenance = { status = "actively-developed" }
 members = ["thoth-api", "thoth-api-server", "thoth-client", "thoth-errors", "thoth-export-server"]
 
 [dependencies]
-thoth-api = { version = "=1.7.0", path = "thoth-api", features = ["backend"] }
-thoth-api-server = { version = "=1.7.0", path = "thoth-api-server" }
-thoth-errors = { version = "=1.7.0", path = "thoth-errors" }
-thoth-export-server = { version = "=1.7.0", path = "thoth-export-server" }
+thoth-api = { version = "=1.8.0", path = "thoth-api", features = ["backend"] }
+thoth-api-server = { version = "=1.8.0", path = "thoth-api-server" }
+thoth-errors = { version = "=1.8.0", path = "thoth-errors" }
+thoth-export-server = { version = "=1.8.0", path = "thoth-export-server" }
 base64 = "0.22.1"
 clap = { version = "4.5.32", features = ["cargo", "env"] }
 dialoguer = { version = "0.11.0", features = ["password"] }

--- a/thoth-api-server/Cargo.toml
+++ b/thoth-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-api-server"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/thoth-pub/thoth"
 readme = "README.md"
 
 [dependencies]
-thoth-api = { version = "=1.7.0", path = "../thoth-api", features = ["backend"] }
-thoth-errors = { version = "=1.7.0", path = "../thoth-errors" }
+thoth-api = { version = "=1.8.0", path = "../thoth-api", features = ["backend"] }
+thoth-errors = { version = "=1.8.0", path = "../thoth-errors" }
 actix-web = "4.14.0"
 actix-cors = "0.7.1"
 actix-http = "3.13.1"

--- a/thoth-api/Cargo.toml
+++ b/thoth-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-api"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ backend = [
 ]
 
 [dependencies]
-thoth-errors = { version = "=1.7.0", path = "../thoth-errors" }
+thoth-errors = { version = "=1.8.0", path = "../thoth-errors" }
 actix-web = { version = "4.14.0", optional = true }
 isbn = "0.6.0"
 chrono = { version = "0.4.45", features = ["serde"] }

--- a/thoth-client/Cargo.toml
+++ b/thoth-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-client"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -10,8 +10,8 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-thoth-api = {version = "=1.7.0", path = "../thoth-api" }
-thoth-errors = {version = "=1.7.0", path = "../thoth-errors" }
+thoth-api = {version = "=1.8.0", path = "../thoth-api" }
+thoth-errors = {version = "=1.8.0", path = "../thoth-errors" }
 graphql_client = "0.14.0"
 chrono = { version = "0.4.45", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
@@ -22,4 +22,4 @@ serde_json = "1.0.150"
 uuid = { version = "1.23.4", features = ["serde"] }
 
 [build-dependencies]
-thoth-api = { version = "=1.7.0", path = "../thoth-api", features = ["backend"] }
+thoth-api = { version = "=1.8.0", path = "../thoth-api", features = ["backend"] }

--- a/thoth-errors/Cargo.toml
+++ b/thoth-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-errors"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/thoth-export-server/Cargo.toml
+++ b/thoth-export-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thoth-export-server"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Javier Arias <javi@thoth.pub>", "Ross Higman <ross@thoth.pub>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -10,9 +10,9 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-thoth-api = { version = "=1.7.0", path = "../thoth-api", features = ["backend"] }
-thoth-errors = { version = "=1.7.0", path = "../thoth-errors" }
-thoth-client = { version = "=1.7.0", path = "../thoth-client" }
+thoth-api = { version = "=1.8.0", path = "../thoth-api", features = ["backend"] }
+thoth-errors = { version = "=1.8.0", path = "../thoth-errors" }
+thoth-client = { version = "=1.8.0", path = "../thoth-client" }
 actix-web = "4.14.0"
 actix-cors = "0.7.1"
 cc_license = "0.1.0"


### PR DESCRIPTION
## Task identity

- Task ID: `REL-1.8.0-PREP-01`
- Owning issue: #864 (parent coordination #850; released feature #851 / PR #860; CI prerequisite #861 / PR #862)
- Risk: MEDIUM
- Exact authorized base: `master @ ce478426328559549327e87db9b58f76f624b94c`
- Branch: `release/v1.8.0` -> `master`
- Final head: `56c3be8c1916635804721b66a3825a5d28c789a6`
- Release version: `v1.8.0` (minor: the release line adds the additive public GraphQL field `contributorsByOrcids`)

Draft until independent exact-head review and separate merge authorization.

## Changes

Two bounded commits:

1. `34b55d034677bf95a6146badd202542b26430043` - `Update changelog for v1.8.0`
2. `56c3be8c1916635804721b66a3825a5d28c789a6` - `Bump v1.8.0`

### Changelog cut

Pure two-line insertion in `CHANGELOG.md`: `## [Unreleased]` is left empty and a new
`## [[1.8.0]](https://github.com/thoth-pub/thoth/releases/tag/v1.8.0) - 2026-08-29` heading is added
above the existing `### Added` / `### Fixed` sections. The two approved entries
(`API-IMPORT-ORCID-BATCH-01`, `CTRL-CI-CLIPPY-MASTER-01`) and all historical sections are byte-for-byte unchanged.

### Version bump

All six Thoth workspace packages `1.7.0` -> `1.8.0` (`thoth`, `thoth-api`, `thoth-api-server`,
`thoth-client`, `thoth-errors`, `thoth-export-server`), and every exact internal workspace pin
`=1.7.0` -> `=1.8.0`. `Cargo.lock` changes only the six corresponding `[[package]] version` lines.
No third-party dependency version moved; no dependency resolution changed.

## Write scope

Exactly the eight authorized existing paths, no new files:

```
CHANGELOG.md
Cargo.lock
Cargo.toml
thoth-api-server/Cargo.toml
thoth-api/Cargo.toml
thoth-client/Cargo.toml
thoth-errors/Cargo.toml
thoth-export-server/Cargo.toml
```

## Validation

- `git diff --name-only <base>...HEAD` - exactly the eight paths above.
- `git diff --check <base>...HEAD` - clean.
- `cargo metadata --no-deps --format-version 1` - all six workspace packages report `1.8.0`; no `1.7.0` remains in any manifest or in `Cargo.lock`.
- `cargo fmt --all -- --check` - clean.
- `cargo check --locked -p thoth-api -p thoth-api-server -p thoth-client -p thoth-errors` - clean (lockfile accepted under `--locked`).
- `cargo clippy --locked -p thoth-api -p thoth-api-server -p thoth-client -p thoth-errors --all-targets --all-features -- -D warnings` - clean.
- `cargo test --locked -p thoth-api -p thoth-api-server -p thoth-client -p thoth-errors` - 1228 passed, 0 failed (8 doc-tests ignored).

Environment limitation (not a source problem): `thoth-export-server` and the root `thoth` package cannot
be built in this local git worktree. `thoth-export-server/build.rs` (unchanged by this PR) calls `dotenv()`,
which resolves the main checkout's `.env` further up the tree, then unconditionally reads the
worktree-relative `../.env`, which does not exist, and panics. The failure is version-independent and
reproduces regardless of this change; creating a local `.env` was deliberately not done, as it is
untracked scaffolding outside the authorized write budget. Full-workspace `cargo check`/`test`/`clippy`
coverage for those two packages is therefore delegated to PR CI.

## Impact

No migration, GraphQL/API behaviour, runtime, authorization, workflow, toolchain, infrastructure or
deployment effect. Release identity/version metadata only.

Automatic PR CI and the normal automatic GHCR `staging-pr-*` publication are expected side effects of
opening this PR.

## Explicitly not performed / not authorized

Merge; ready-for-review transition; tag creation; GitHub Release creation or publication; production
image publication; deployment or production activation; manual CI dispatch/rerun/cancel; force-push;
branch deletion; `master -> develop` reconciliation; any Metrics source mutation.

The Metrics `v1.8.0 -> v1.9.0` migration-suffix reconciliation is tracked separately under #766 and is
untouched here.

Refs #864
Refs #850
Refs #851
Refs #861
Refs #766
